### PR TITLE
Fix failing test

### DIFF
--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -1,6 +1,12 @@
 import datetime
-import time
 import hashlib
+
+# TODO: deal better with types
+# passing in
+#    parameters = "{'temperature': 0.5}"
+# vs
+#    parameters = '{"temperature": 0.5}'
+# yields different hashes
 
 
 class CacheEntry:
@@ -35,7 +41,7 @@ class CacheEntry:
         self, *, model, parameters, system_prompt, user_prompt, iteration
     ) -> str:
         """
-        Generate a key for the cache entry.
+        Generates a key for the cache entry.
 
         >>> CacheEntry.gen_key(model = "gpt-3.5-turbo", parameters = "{'temperature': 0.5}", system_prompt = "The quick brown fox jumps over the lazy dog.", user_prompt = "What does the fox say?", iteration = 1)
         '55ce2e13d38aa7fb6ec848053285edb4'
@@ -46,7 +52,7 @@ class CacheEntry:
     @property
     def key(self) -> str:
         """
-        Return the key for the cache entry.
+        Returns the key for the cache entry.
 
         >>> CacheEntry.example().key
         '55ce2e13d38aa7fb6ec848053285edb4'
@@ -54,48 +60,10 @@ class CacheEntry:
         d = {k: value for k, value in self.__dict__.items() if k in self.key_fields}
         return self.gen_key(**d)
 
-    def __eq__(self, other_entry: "CacheEntry") -> bool:
-        """Check if two cache entries are equal.
-
-        :param other_entry: The other cache entry to compare to.
-
-        >>> CacheEntry.example() == CacheEntry.example()
-        True
-        """
-        for field in self.all_fields:
-            if getattr(self, field) != getattr(other_entry, field):
-                return False
-        return True
-
-    @classmethod
-    def example_dict(cls) -> dict:
-        """Return an example dictionary of cache entries."""
-        entity = cls.example()
-        key = entity.key
-        return {key: entity}
-
-    @classmethod
-    def fetch_input_example(cls) -> dict:
-        """
-        Create an example input for a 'fetch' operation.
-        """
-        input = cls.example().to_dict()
-        _ = input.pop("timestamp")
-        _ = input.pop("output")
-        return input
-
-    @classmethod
-    def store_input_example(cls) -> dict:
-        """
-        Create an example input for a 'store' operation.
-        """
-        input = cls.example().to_dict()
-        _ = input.pop("timestamp")
-        input["response"] = input.pop("output")
-        return input
-
     def to_dict(self) -> dict:
-        """Return a dictionary representation of the cache entry."""
+        """
+        Returns a dictionary representation of a CacheEntry.
+        """
         return {
             "model": self.model,
             "parameters": self.parameters,
@@ -106,16 +74,34 @@ class CacheEntry:
             "timestamp": self.timestamp,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict) -> "CacheEntry":
+        """
+        Initializes a CacheEntry object from its dictionary representation.
+        """
+        return cls(**data)
+
+    def __eq__(self, other: "CacheEntry") -> bool:
+        """
+        Checks if two CacheEntry objects are equal.
+        - Includes timestamp in the comparison.
+        """
+        for field in self.all_fields:
+            if getattr(self, field) != getattr(other, field):
+                return False
+        return True
+
     def __repr__(self) -> str:
+        """
+        Returns a string representation of a CacheEntry.
+        """
         return f"CacheEntry(model={self.model}, parameters={self.parameters}, system_prompt={self.system_prompt}, user_prompt={self.user_prompt}, output={self.output}, iteration={self.iteration}, timestamp={self.timestamp})"
 
     @classmethod
-    def from_dict(cls, data: dict) -> "CacheEntry":
-        """Create a cache entry from a dictionary representation."""
-        return cls(**data)
-
-    @classmethod
     def example(cls) -> "CacheEntry":
+        """
+        Returns a CacheEntry example.
+        """
         return CacheEntry(
             model="gpt-3.5-turbo",
             parameters={"temperature": 0.5},
@@ -126,24 +112,60 @@ class CacheEntry:
             timestamp=int(datetime.datetime.now(datetime.timezone.utc).timestamp()),
         )
 
+    @classmethod
+    def example_dict(cls) -> dict:
+        """
+        Returns an example dictionary with a single CacheEntry.
+        - This will be useful one level up, in the Cache class.
+        """
+        cache_entry = cls.example()
+        return {cache_entry.key: cache_entry}
+
+    @classmethod
+    def fetch_input_example(cls) -> dict:
+        """
+        Creates an example input for a 'fetch' operation.
+        - This will be useful one level up, in the Cache class.
+        """
+        input = cls.example().to_dict()
+        _ = input.pop("timestamp")
+        _ = input.pop("output")
+        return input
+
+    @classmethod
+    def store_input_example(cls) -> dict:
+        """
+        Creates an example input for a 'store' operation.
+        - This will be useful one level up, in the Cache class.
+        """
+        input = cls.example().to_dict()
+        _ = input.pop("timestamp")
+        input["response"] = input.pop("output")
+        return input
+
 
 def main():
     from edsl.data.CacheEntry import CacheEntry
 
     # an example of how a cache entry looks
-    CacheEntry.example()
+    cache_entry = CacheEntry.example()
     # the key gives the hash of the cache entry
-    CacheEntry.example().key
+    cache_entry.key
     # kind of a forward method, that will be used by Cache
-    CacheEntry.example().example_dict()
+    cache_entry.example_dict()
     # to dict / from dict
-    CacheEntry.example().to_dict()
-    CacheEntry.from_dict(CacheEntry.example().to_dict())
-
+    cache_entry.to_dict()
+    CacheEntry.from_dict(cache_entry.to_dict())
+    # TODO: this will be false because equality includes timestamp
+    CacheEntry.from_dict(cache_entry.to_dict()) == CacheEntry.example()
     # equality through checking one by one
     CacheEntry.example() == CacheEntry.example()
     # but could also check the hash
-    CacheEntry.example().key == CacheEntry.example().key
+    cache_entry.key == CacheEntry.example().key
+
+    # not sure what these are useful for yet
+    cache_entry.fetch_input_example()
+    cache_entry.store_input_example()
 
 
 if __name__ == "__main__":

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -9,6 +9,8 @@ from typing import Optional
 #    parameters = '{"temperature": 0.5}'
 # yields different hashes
 
+# TODO: equality includes timestamps. Is that what we want?
+
 
 class CacheEntry:
     """Class to represent a cache entry."""
@@ -165,6 +167,7 @@ def main():
     cache_entry.key == CacheEntry.example().key
 
     # not sure what these are useful for yet
+    cache_entry.example_dict()
     cache_entry.fetch_input_example()
     cache_entry.store_input_example()
 

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -89,6 +89,8 @@ class CacheEntry:
         Checks if two CacheEntry objects are equal.
         - Includes timestamp in the comparison.
         """
+        if not isinstance(other, CacheEntry):
+            return False
         for field in self.all_fields:
             if getattr(self, field) != getattr(other, field):
                 return False

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -20,11 +20,11 @@ class CacheEntry:
         output: str,
         timestamp: int = None,
     ):
-        self.model = str(model)
-        self.parameters = str(parameters)
-        self.system_prompt = str(system_prompt)
-        self.user_prompt = str(user_prompt)
-        self.output = str(output)
+        self.model = model
+        self.parameters = parameters
+        self.system_prompt = system_prompt
+        self.user_prompt = user_prompt
+        self.output = output
         self.iteration = iteration or 0
         self.timestamp = timestamp or int(
             datetime.datetime.now(datetime.timezone.utc).timestamp()

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -67,7 +67,7 @@ class CacheEntry:
         - Treats single and double quotes as the same. TODO: add more robustness.
         """
         long_key = f"{model}{parameters}{system_prompt}{user_prompt}{iteration}"
-        long_key = long_key.replace('"', "'")
+long_key = f'{model}{json.dumps(parameters, sort_keys=True)}{system_prompt}{user_prompt}{iteration}'
         return hashlib.md5(long_key.encode()).hexdigest()
 
     @property

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+from typing import Optional
 
 # TODO: deal better with types
 # passing in
@@ -22,9 +23,9 @@ class CacheEntry:
         parameters: str,
         system_prompt: str,
         user_prompt: str,
-        iteration: int = None,
         output: str,
-        timestamp: int = None,
+        iteration: Optional[int] = None,
+        timestamp: Optional[int] = None,
     ):
         self.model = model
         self.parameters = parameters

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -1,24 +1,62 @@
+import datetime
 import time
 import hashlib
+
 
 class CacheEntry:
     """Class to represent a cache entry."""
 
-    key_fields = ['model', 'parameters', 'system_prompt', 'user_prompt', 'iteration']
-    all_fields = key_fields + ['timestamp', 'output']
+    key_fields = ["model", "parameters", "system_prompt", "user_prompt", "iteration"]
+    all_fields = key_fields + ["timestamp", "output"]
 
-    def __init__(self, *, model, parameters, system_prompt, user_prompt, output, iteration = None, timestamp = None):
-        self.model = model
-        self.parameters = parameters
-        self.system_prompt = system_prompt
-        self.user_prompt = user_prompt
-        self.output = output
-        self.iteration = iteration or 0 
-        self.timestamp = timestamp or int(time.time())
+    def __init__(
+        self,
+        *,
+        model: str,
+        parameters: str,
+        system_prompt: str,
+        user_prompt: str,
+        iteration: int = None,
+        output: str,
+        timestamp: int = None,
+    ):
+        self.model = str(model)
+        self.parameters = str(parameters)
+        self.system_prompt = str(system_prompt)
+        self.user_prompt = str(user_prompt)
+        self.output = str(output)
+        self.iteration = iteration or 0
+        self.timestamp = timestamp or int(
+            datetime.datetime.now(datetime.timezone.utc).timestamp()
+        )
 
-    def __eq__(self, other_entry: 'CacheEntry') -> bool:
+    @classmethod
+    def gen_key(
+        self, *, model, parameters, system_prompt, user_prompt, iteration
+    ) -> str:
+        """
+        Generate a key for the cache entry.
+
+        >>> CacheEntry.gen_key(model = "gpt-3.5-turbo", parameters = "{'temperature': 0.5}", system_prompt = "The quick brown fox jumps over the lazy dog.", user_prompt = "What does the fox say?", iteration = 1)
+        '55ce2e13d38aa7fb6ec848053285edb4'
+        """
+        long_key = f"{model}{parameters}{system_prompt}{user_prompt}{iteration}"
+        return hashlib.md5(long_key.encode()).hexdigest()
+
+    @property
+    def key(self) -> str:
+        """
+        Return the key for the cache entry.
+
+        >>> CacheEntry.example().key
+        '55ce2e13d38aa7fb6ec848053285edb4'
+        """
+        d = {k: value for k, value in self.__dict__.items() if k in self.key_fields}
+        return self.gen_key(**d)
+
+    def __eq__(self, other_entry: "CacheEntry") -> bool:
         """Check if two cache entries are equal.
-        
+
         :param other_entry: The other cache entry to compare to.
 
         >>> CacheEntry.example() == CacheEntry.example()
@@ -41,74 +79,74 @@ class CacheEntry:
         """
         Create an example input for a 'fetch' operation.
         """
-        input =cls.example().to_dict()
-        _ = input.pop('timestamp')
-        _ = input.pop('output')
+        input = cls.example().to_dict()
+        _ = input.pop("timestamp")
+        _ = input.pop("output")
         return input
 
-    @classmethod    
+    @classmethod
     def store_input_example(cls) -> dict:
         """
         Create an example input for a 'store' operation.
         """
         input = cls.example().to_dict()
         _ = input.pop("timestamp")
-        input['response'] = input.pop('output')
+        input["response"] = input.pop("output")
         return input
-
-    @classmethod
-    def gen_key(self, *, model, parameters, system_prompt, user_prompt, iteration) -> str:
-        """Generate a key for the cache entry.
-        
-        >>> CacheEntry.gen_key(model = "gpt-3.5-turbo", parameters = "{'temperature': 0.5}", system_prompt = "The quick brown fox jumps over the lazy dog.", user_prompt = "What does the fox say?", iteration = 1)
-        '55ce2e13d38aa7fb6ec848053285edb4'
-        """
-
-        long_key = f"{model}{parameters}{system_prompt}{user_prompt}{iteration}"
-        return hashlib.md5(long_key.encode()).hexdigest()
-
-    @property
-    def key(self):
-        """Return the key for the cache entry.
-        
-        >>> CacheEntry.example().key
-        '55ce2e13d38aa7fb6ec848053285edb4'
-        """
-        d = {k:value for k, value in self.__dict__.items() if k in self.key_fields}
-        return self.gen_key(**d)
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of the cache entry."""
         return {
-            'model': self.model,
-            'parameters': self.parameters,
-            'system_prompt': self.system_prompt,
-            'user_prompt': self.user_prompt,
-            'output': self.output,
-            'iteration': self.iteration,
-            'timestamp': self.timestamp
+            "model": self.model,
+            "parameters": self.parameters,
+            "system_prompt": self.system_prompt,
+            "user_prompt": self.user_prompt,
+            "output": self.output,
+            "iteration": self.iteration,
+            "timestamp": self.timestamp,
         }
-    
-    def __repr__(self):
+
+    def __repr__(self) -> str:
         return f"CacheEntry(model={self.model}, parameters={self.parameters}, system_prompt={self.system_prompt}, user_prompt={self.user_prompt}, output={self.output}, iteration={self.iteration}, timestamp={self.timestamp})"
-    
+
     @classmethod
-    def from_dict(cls, data: dict):
+    def from_dict(cls, data: dict) -> "CacheEntry":
         """Create a cache entry from a dictionary representation."""
         return cls(**data)
-    
+
     @classmethod
-    def example(cls):
+    def example(cls) -> "CacheEntry":
         return CacheEntry(
             model="gpt-3.5-turbo",
-            parameters="{'temperature': 0.5}",
+            parameters={"temperature": 0.5},
             system_prompt="The quick brown fox jumps over the lazy dog.",
             user_prompt="What does the fox say?",
             output="The fox says 'hello'",
             iteration=1,
-            timestamp=int(time.time())
+            timestamp=int(datetime.datetime.now(datetime.timezone.utc).timestamp()),
         )
+
+
+def main():
+    from edsl.data.CacheEntry import CacheEntry
+
+    # an example of how a cache entry looks
+    CacheEntry.example()
+    # the key gives the hash of the cache entry
+    CacheEntry.example().key
+    # kind of a forward method, that will be used by Cache
+    CacheEntry.example().example_dict()
+    # to dict / from dict
+    CacheEntry.example().to_dict()
+    CacheEntry.from_dict(CacheEntry.example().to_dict())
+
+    # equality through checking one by one
+    CacheEntry.example() == CacheEntry.example()
+    # but could also check the hash
+    CacheEntry.example().key == CacheEntry.example().key
+
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/edsl/data/CacheEntry.py
+++ b/edsl/data/CacheEntry.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import json
 import datetime
 import hashlib
 from typing import Optional
@@ -66,8 +67,8 @@ class CacheEntry:
         Generates a key for the cache entry.
         - Treats single and double quotes as the same. TODO: add more robustness.
         """
-        long_key = f"{model}{parameters}{system_prompt}{user_prompt}{iteration}"
-long_key = f'{model}{json.dumps(parameters, sort_keys=True)}{system_prompt}{user_prompt}{iteration}'
+        #long_key = f"{model}{parameters}{system_prompt}{user_prompt}{iteration}"
+        long_key = f'{model}{json.dumps(parameters, sort_keys=True)}{system_prompt}{user_prompt}{iteration}'
         return hashlib.md5(long_key.encode()).hexdigest()
 
     @property

--- a/edsl/data/SQLiteDict.py
+++ b/edsl/data/SQLiteDict.py
@@ -20,7 +20,9 @@ class SQLiteDict:
         try:
             self.conn = sqlite3.connect(self.db_path)
         except sqlite3.OperationalError:
+            print(f"Tried to connect to the database at {self.db_path}.")
             raise Exception("Unable to connect to the database.")
+        
 
         self.cursor = self.conn.cursor()
         self.cursor.execute("CREATE TABLE IF NOT EXISTS data (key TEXT PRIMARY KEY, value TEXT)")

--- a/edsl/data/__init__.py
+++ b/edsl/data/__init__.py
@@ -1,0 +1,1 @@
+from edsl.data.CacheEntry import CacheEntry

--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -208,6 +208,11 @@ class Jobs(Base):
 
         if cache is None:
             from edsl.data.SQLiteDict import SQLiteDict
+
+            import os 
+            if not os.path.exists(".edsl_cache"):
+                os.makedirs(".edsl_cache")
+
             cache = Cache(data = SQLiteDict())
         
             #import shutil

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -400,7 +400,7 @@ class LanguageModel(
             cache.store(
                 user_prompt=user_prompt,
                 model=str(self.model),
-                parameters=str(self.parameters),
+                parameters=self.parameters,
                 system_prompt=system_prompt,
                 response=response,
                 iteration=iteration,

--- a/tests/data/test_CacheEntry.py
+++ b/tests/data/test_CacheEntry.py
@@ -1,67 +1,82 @@
-from edsl.data.CacheEntry import CacheEntry
-import time
-import pytest
+from edsl.data import CacheEntry
 
-def test_eq():
+
+def test_CacheEntry_equality():
+    # timestamp doesn't matter for equality
     entry1 = CacheEntry.example()
     entry2 = CacheEntry.example()
     assert entry1 == entry2
+    entry2.timestamp = entry2.timestamp + 1
+    assert entry1 == entry2
+    # can also compare keys
+    assert entry1.key == entry2.key
+    # from_dict -> to_dict yields an equal object
+    assert entry1 == CacheEntry.from_dict(entry1.to_dict())
+    # and repr is evalable
+    assert eval(repr(entry1)) == entry1
 
-    entry2.timestamp = int(time.time()) + 1
-    assert entry1 != entry2
 
-def test_example_dict():
+def test_CacheEntry_example_dict():
     example_dict = CacheEntry.example_dict()
     assert len(example_dict) == 1
     key = list(example_dict.keys())[0]
     assert key == CacheEntry.example().key
 
-def test_fetch_input_example():
+
+def test_CacheEntry_fetch_input_example():
     fetch_input = CacheEntry.fetch_input_example()
-    assert 'timestamp' not in fetch_input
-    assert 'output' not in fetch_input
+    assert "timestamp" not in fetch_input
+    assert "output" not in fetch_input
     assert all(field in fetch_input for field in CacheEntry.key_fields)
+
 
 def test_store_input_example():
     store_input = CacheEntry.store_input_example()
-    assert 'timestamp' not in store_input
-    assert 'response' in store_input
-    assert 'output' not in store_input
-    assert all(field in store_input for field in CacheEntry.key_fields + ['response'])
+    assert "timestamp" not in store_input
+    assert "response" in store_input
+    assert "output" not in store_input
+    assert all(field in store_input for field in CacheEntry.key_fields + ["response"])
 
-def test_gen_key():
+
+def test_CacheEntry_gen_key():
     key = CacheEntry.gen_key(
         model="gpt-3.5-turbo",
         parameters="{'temperature': 0.5}",
         system_prompt="The quick brown fox jumps over the lazy dog.",
         user_prompt="What does the fox say?",
-        iteration=1
+        iteration=1,
     )
-    assert key == '55ce2e13d38aa7fb6ec848053285edb4'
+    assert key == "55ce2e13d38aa7fb6ec848053285edb4"
 
-def test_key_property():
+
+def test_CacheEntry_key_property():
     entry = CacheEntry.example()
-    assert entry.key == '55ce2e13d38aa7fb6ec848053285edb4'
+    assert entry.key == "55ce2e13d38aa7fb6ec848053285edb4"
 
-def test_to_dict():
+
+def test_CacheEntry_to_dict():
     entry = CacheEntry.example()
     entry_dict = entry.to_dict()
     assert all(field in entry_dict for field in CacheEntry.all_fields)
-    assert entry_dict['model'] == entry.model
-    assert entry_dict['parameters'] == entry.parameters
-    assert entry_dict['system_prompt'] == entry.system_prompt
-    assert entry_dict['user_prompt'] == entry.user_prompt
-    assert entry_dict['output'] == entry.output
-    assert entry_dict['iteration'] == entry.iteration
-    assert entry_dict['timestamp'] == entry.timestamp
+    assert entry_dict["model"] == entry.model
+    assert entry_dict["parameters"] == entry.parameters
+    assert entry_dict["system_prompt"] == entry.system_prompt
+    assert entry_dict["user_prompt"] == entry.user_prompt
+    assert entry_dict["output"] == entry.output
+    assert entry_dict["iteration"] == entry.iteration
+    assert entry_dict["timestamp"] == entry.timestamp
 
-def test_from_dict():
+
+def test_CacheEntry_from_dict():
     entry_dict = CacheEntry.example().to_dict()
     entry = CacheEntry.from_dict(entry_dict)
     assert isinstance(entry, CacheEntry)
-    assert all(getattr(entry, field) == entry_dict[field] for field in CacheEntry.all_fields)
+    assert all(
+        getattr(entry, field) == entry_dict[field] for field in CacheEntry.all_fields
+    )
 
-def test_repr():
+
+def test_CacheEntry_repr():
     entry = CacheEntry.example()
-    expected_repr = f"CacheEntry(model={entry.model}, parameters={entry.parameters}, system_prompt={entry.system_prompt}, user_prompt={entry.user_prompt}, output={entry.output}, iteration={entry.iteration}, timestamp={entry.timestamp})"
+    expected_repr = f"CacheEntry(model={repr(entry.model)}, parameters={entry.parameters}, system_prompt={repr(entry.system_prompt)}, user_prompt={repr(entry.user_prompt)}, output={repr(entry.output)}, iteration={entry.iteration}, timestamp={entry.timestamp})"
     assert repr(entry) == expected_repr

--- a/tests/data/test_CacheEntry.py
+++ b/tests/data/test_CacheEntry.py
@@ -46,12 +46,12 @@ def test_CacheEntry_gen_key():
         user_prompt="What does the fox say?",
         iteration=1,
     )
-    assert key == "55ce2e13d38aa7fb6ec848053285edb4"
+    assert key == '5ee60636048b05b4f7b6995a0cf9b78e'
 
 
 def test_CacheEntry_key_property():
     entry = CacheEntry.example()
-    assert entry.key == "55ce2e13d38aa7fb6ec848053285edb4"
+    assert entry.key == '5513286eb6967abc0511211f0402587d'
 
 
 def test_CacheEntry_to_dict():

--- a/tests/language_models/test_LanguageModel.py
+++ b/tests/language_models/test_LanguageModel.py
@@ -126,7 +126,7 @@ class TestLanguageModel(unittest.TestCase):
         expected_response = {
 #            "id": 1,
             "model": "fake model",
-            "parameters": "{'temperature': 0.5}",
+            "parameters": {'temperature': 0.5},
             "system_prompt": "You are a helpful agent",
             "user_prompt": "Hello world",
             "output": '{"message": "{\\"answer\\": \\"Hello world\\"}"}',


### PR DESCRIPTION
There were a few issues: 

1. We needed to add to Jobs.py code to create the ".edsl_cache.db"
2. The "store" command for cache entry was converting parameters to string (which was stopping job running)
3. Job running fails "show up" in this interview test failure because jobs that are failing for any reason (such as above) cause this test to fail- it's a bit complex and hard to explain. We probably need to re-factor this to show these early exceptions as these are now hard to debug. 

@ellipsis - can you summarize code changes?  

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit b36628eeb94399ea67238e34910966077eb941a4.  | 
|--------|--------|

### Summary:
This PR addresses several issues, makes improvements to the `Cache` and `CacheEntry` classes, updates corresponding test files, and modifies the `CacheEntry` class to correctly handle parameters in the cache entry key generation.

**Key points**:
- Improved the `Cache` and `CacheEntry` classes by adding type hints, improving docstrings, refactoring some methods.
- Fixed issues with the 'Jobs.py' code and the 'store' command for cache entry.
- Addressed job running failures.
- Updated `test_CacheEntry.py` and `test_LanguageModel.py` to reflect changes in the main codebase.
- Modified `gen_key` method in `CacheEntry` class to convert `parameters` to a JSON string before generating the key.
- Updated expected keys in `test_CacheEntry_gen_key` and `test_CacheEntry_key_property` tests to reflect the change in key generation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
