### PR TITLE
Transforming ISC into a registry to support other providers

### DIFF
--- a/edsl/inference_services/InferenceServicesCollection.py
+++ b/edsl/inference_services/InferenceServicesCollection.py
@@ -20,11 +20,14 @@ class InferenceServicesCollection():
             model[2] = i
             model = tuple(model)
         return sorted_models
-    
+
+    def register(self, service):
+        self.services.append(service)
+
     def create_model_factory(self, model_name:str, service_name = None, index = None):
         for service in self.services:
             if model_name in service.available():
                 if service_name is None or service_name == service._inference_service_:
                     return service.create_model(model_name)
-            
+
         raise Exception(f"Model {model_name} not found in any of the services")

--- a/edsl/inference_services/registry.py
+++ b/edsl/inference_services/registry.py
@@ -5,7 +5,7 @@ from edsl.inference_services.AnthropicService import AnthropicService
 from edsl.inference_services.DeepInfraService import DeepInfraService
 from edsl.inference_services.GoogleService import GoogleService
 
-collection = InferenceServicesCollection([
+default = InferenceServicesCollection([
     OpenAIService,
     AnthropicService,
     DeepInfraService,

--- a/edsl/language_models/registry.py
+++ b/edsl/language_models/registry.py
@@ -3,7 +3,7 @@ import textwrap
 
 def get_model_class(model_name, registry=None):
     from edsl.inference_services.registry import default
-    registry = registry or collection
+    registry = registry or default
     factory = registry.create_model_factory(model_name)
     return factory
 
@@ -31,14 +31,14 @@ class Model(metaclass=Meta):
         if model_name is None:
             model_name = cls.default_model
         from edsl.inference_services.registry import default
-        registry = registry or collection
+        registry = registry or default
         factory = registry.create_model_factory(model_name)
         return factory(*args, **kwargs)
 
     @classmethod
     def available(cls, search_term = None, name_only = False, registry=None):
         from edsl.inference_services.registry import default
-        registry = registry or collection
+        registry = registry or default
         full_list = registry.available()
         if search_term is None:
             if name_only:

--- a/edsl/language_models/registry.py
+++ b/edsl/language_models/registry.py
@@ -1,10 +1,11 @@
 import textwrap
 
 
-def get_model_class(model_name):
-    from edsl.inference_services.services_collection import collection
-    factory = collection.create_model_factory(model_name)
-    return factory      
+def get_model_class(model_name, registry=None):
+    from edsl.inference_services.registry import default
+    registry = registry or collection
+    factory = registry.create_model_factory(model_name)
+    return factory
 
 class Meta(type):
     def __repr__(cls):
@@ -25,24 +26,20 @@ class Model(metaclass=Meta):
 
     default_model = "gpt-4-1106-preview"
 
-    def __new__(cls, model_name=None, *args, **kwargs):
+    def __new__(cls, model_name=None, registry=None, *args, **kwargs):
         # Map index to the respective subclass
         if model_name is None:
             model_name = cls.default_model
-        from edsl.inference_services.services_collection import collection
-        factory = collection.create_model_factory(model_name)
+        from edsl.inference_services.registry import default
+        registry = registry or collection
+        factory = registry.create_model_factory(model_name)
         return factory(*args, **kwargs)
-    
-    @classmethod
-    def from_index(cls, index, *args, **kwargs):
-        from edsl.inference_services.services_collection import collection
-        model_name = collection.available()[index][0]
-        return cls(model_name, *args, **kwargs)
 
     @classmethod
-    def available(cls, search_term = None, name_only = False):
-        from edsl.inference_services.services_collection import collection
-        full_list = collection.available()
+    def available(cls, search_term = None, name_only = False, registry=None):
+        from edsl.inference_services.registry import default
+        registry = registry or collection
+        full_list = registry.available()
         if search_term is None:
             if name_only:
                 return [m[0] for m in full_list]

--- a/tests/jobs/test_Jobs.py
+++ b/tests/jobs/test_Jobs.py
@@ -114,8 +114,9 @@ def test_jobs_by_models():
         question_name="how_feeling",
     )
     survey = Survey(name="Test Survey", questions=[q])
-    model1 = Model.from_index(0)
-    model2 = Model.from_index(1)
+    from edsl.inference_services.registry import default
+    model1 = Model(default.available()[0][0])
+    model2 = Model(default.available()[1][0])
     # by without existing models
     job = survey.by(model1)
     assert job.models == [model1]


### PR DESCRIPTION
This merge request changes the functionality of `InferenceServicesCollection` and transforming it into a registry for infrastructure providers. It also introduces functionality to support adding new services and pass the registry to the model when creating