### PR TITLE
fix: remove deleted report module from projects list

### DIFF
--- a/scripts/visualize_structure.py
+++ b/scripts/visualize_structure.py
@@ -14,7 +14,6 @@ projects = [
     ("utilities", "edsl/utilities"),
     ("coop", "edsl/coop"),
     ("prompts", "edsl/prompts"),
-    ("report", "edsl/report"),
     ("questions", "edsl/questions"),
     ("data_transfer_models", "edsl/data_transfer_models"),
     ("enums", "edsl/enums"),


### PR DESCRIPTION
The report module was removed in #304, causing the script to fail.