### PR TITLE
Cache and coop updates

### DIFF
--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod, ABCMeta
 import gzip
 import io
 import json
+from typing import Union
 from uuid import UUID
 from IPython.display import display
 from rich.console import Console
@@ -47,7 +48,7 @@ class PersistenceMixin:
         return c.create(self, public, verbose=True)
 
     @classmethod
-    def pull(cls, id_or_url: str | UUID):
+    def pull(cls, id_or_url: Union[str, UUID]):
         """Pull the object from coop."""
         from edsl.coop import Coop
 

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod, ABCMeta
 import gzip
 import io
 import json
+from uuid import UUID
 from IPython.display import display
 from rich.console import Console
 from edsl.utilities import is_notebook
@@ -46,16 +47,16 @@ class PersistenceMixin:
         return c.create(self, public, verbose=True)
 
     @classmethod
-    def pull(cls, id_or_url: str):
+    def pull(cls, id_or_url: str | UUID):
         """Pull the object from coop."""
         from edsl.coop import Coop
 
         c = Coop()
-        if c.url in id_or_url:
-            id = id_or_url.split("/")[-1]
+        if isinstance(id_or_url, str) and c.url in id_or_url:
+            return c.get(url=id_or_url)
         else:
-            id = id_or_url
-        return c._get_base(cls, id)
+            _, object_type = c._resolve_edsl_object(cls)
+            return c.get(object_type, id_or_url)
 
     @classmethod
     def search(cls, query):

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -38,20 +38,27 @@ class RichPrintingMixin:
 class PersistenceMixin:
     """Mixin for saving and loading objects to and from files."""
 
-    def push(self, public=False):
+    def push(self, public=True):
         """Post the object to coop."""
         from edsl.coop import Coop
 
         c = Coop()
-        _ = c.create(self, public)
-        print(_)
+        details = c.create(self, public)
+        object_uuid = details["uuid"]
+        coop_url = c.url + "/explore/questions/" +  f"{object_uuid}"
+        print(f"Object pushed to coop - available at {coop_url}")
+        return details
 
     @classmethod
-    def pull(cls, id):
+    def pull(cls, id_or_url: str):
         """Pull the object from coop."""
         from edsl.coop import Coop
 
         c = Coop()
+        if c.url in id_or_url:
+            id = id_or_url.split("/")[-1]
+        else:
+            id = id_or_url
         return c._get_base(cls, id)
 
     @classmethod

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -42,10 +42,23 @@ class PersistenceMixin:
         """Post the object to coop."""
         from edsl.coop import Coop
 
+        # TODO: Do something smarter here so this doesn't break if we add a new question
+        # or a coopable object.  
+        directory_lookup = {
+            'QuestionMultipleChoice': 'questions',
+            'QuestionFreeText': 'questions',
+            'QuestionYesNo': 'questions',
+            'QuestionBudget': 'questions',
+            'Survey': 'surveys',
+            'Results': 'results', 
+            'Agent': 'agents',
+        }
+        directory = directory_lookup.get(self.__class__.__name__, 'misc')
+
         c = Coop()
         details = c.create(self, public)
         object_uuid = details["uuid"]
-        coop_url = c.url + "/explore/questions/" +  f"{object_uuid}"
+        coop_url = c.url + "/explore/"  + directory +  f"/{object_uuid}"
         print(f"Object pushed to coop - available at {coop_url}")
         return details
 

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -42,25 +42,8 @@ class PersistenceMixin:
         """Post the object to coop."""
         from edsl.coop import Coop
 
-        # TODO: Do something smarter here so this doesn't break if we add a new question
-        # or a coopable object.  
-        directory_lookup = {
-            'QuestionMultipleChoice': 'questions',
-            'QuestionFreeText': 'questions',
-            'QuestionYesNo': 'questions',
-            'QuestionBudget': 'questions',
-            'Survey': 'surveys',
-            'Results': 'results', 
-            'Agent': 'agents',
-        }
-        directory = directory_lookup.get(self.__class__.__name__, 'misc')
-
         c = Coop()
-        details = c.create(self, public)
-        object_uuid = details["uuid"]
-        coop_url = c.url + "/explore/"  + directory +  f"/{object_uuid}"
-        print(f"Object pushed to coop - available at {coop_url}")
-        return details
+        return c.create(self, public, verbose=True)
 
     @classmethod
     def pull(cls, id_or_url: str):

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -179,20 +179,27 @@ class Coop:
             },
         )
         self._resolve_server_response(response)
-        return response.json()
+        response_json = response.json()
+        url = f"{self.url}/explore/{uri}/{response_json['uuid']}"
+        response_json["url"] = url
+        return response_json
 
     def create(
         self,
         object: Union[Type[QuestionBase], Survey, Agent, AgentList, Results],
-        public: bool = False,
-    ):
+        public: bool = True,
+        verbose: bool = False,
+    ) -> dict:
         """
         Create an EDSL object in the Coop server.
 
         :param object: the EDSL object to be sent.
-        :param public: whether the object should be public (defaults to False)
+        :param public: whether the object should be public (defaults to True)
         """
-        return self._create(object, public)
+        response = self._create(object, public)
+        if verbose:
+            print(f"Object pushed to Coop - available at {response['url']}")
+        return response
 
     # ----------
     # B. GET

--- a/edsl/data/Cache.py
+++ b/edsl/data/Cache.py
@@ -46,7 +46,7 @@ class Cache(Base):
 
         """
         self.data = data or {}
-        self.data_at_init = data or {}
+        #self.data_at_init = data or {}
         self.fetched_data = {}
         self.remote = remote
         self.immediate_write = immediate_write
@@ -72,9 +72,7 @@ class Cache(Base):
     
     def new_entries_cache(self) -> Cache:
         """Return a new Cache object with the new entries."""
-        new_entries = {k: v for k, v in self.data.items() if k not in self.data_at_init}
-        new_entries.update(self.fetched_data)
-        return Cache(data=new_entries)
+        return Cache(data={**self.new_entries, **self.fetched_data})
 
     def _perform_checks(self):
         """Perform checks on the cache."""
@@ -208,6 +206,18 @@ class Cache(Base):
         Construct a Cache from a SQLite database.
         """
         return cls(data=SQLiteDict(db_path))
+    
+    @classmethod
+    def from_local_cache(cls) -> Cache:
+        """
+        Construct a Cache from a local cache file.
+        """
+        from edsl.config import CONFIG
+        CACHE_PATH = CONFIG.get("EDSL_DATABASE_PATH")
+        path = CACHE_PATH.replace("sqlite:///", "")
+        db_path = os.path.join(os.path.dirname(path), "data.db")
+        return cls.from_sqlite_db(db_path=db_path)
+
 
     @classmethod
     def from_jsonl(cls, jsonlfile: str, db_path: str = None) -> Cache:

--- a/edsl/data/Cache.py
+++ b/edsl/data/Cache.py
@@ -15,8 +15,9 @@ from edsl.data.SQLiteDict import SQLiteDict
 #       -- if two keys are the same but the values are different?
 # TODO: In the read methods, if the file already exists, make sure it is valid.
 
+from edsl.Base import Base
 
-class Cache:
+class Cache(Base):
     """
     A class that represents a cache of responses from a language model.
 
@@ -53,6 +54,14 @@ class Cache:
         self.new_entries_to_write_later = {}
         self.coop = None
         self._perform_checks()
+
+    def rich_print(sefl):
+        pass
+        #raise NotImplementedError("This method is not implemented yet.")
+
+    def code(sefl):
+        pass
+        #raise NotImplementedError("This method is not implemented yet.")
 
     def keys(self):
         return list(self.data.keys())
@@ -281,8 +290,8 @@ class Cache:
     @classmethod
     def from_dict(cls, data) -> Cache:
         """Construct a Cache from a dictionary."""
-        data = {k: CacheEntry.from_dict(v) for k, v in data}
-        return cls(data=data)
+        newdata = {k: CacheEntry.from_dict(v) for k, v in data.items()}
+        return cls(data=newdata)
 
     def __len__(self):
         """Return the number of CacheEntry objects in the Cache."""

--- a/edsl/data/SQLiteDict.py
+++ b/edsl/data/SQLiteDict.py
@@ -156,6 +156,17 @@ class SQLiteDict:
             for instance in db.query(Data).all():
                 yield (instance.key, CacheEntry.from_dict(json.loads(instance.value)))
 
+    def to_dict(self):
+        """
+        Returns the cache as a dictionary.
+
+        >>> d = SQLiteDict.example()
+        >>> d["foo"] = CacheEntry.example()
+        >>> d.to_dict() == {"foo": CacheEntry.example()}
+        True
+        """
+        return dict(self.items())
+
     def __delitem__(self, key: str) -> None:
         """
         Deletes the value for a given key.

--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -253,6 +253,7 @@ class Jobs(Base):
             sidecar_model=sidecar_model,
             batch_mode=batch_mode,
         )
+        results.cache = cache.new_entries_cache()
 
         return results
 

--- a/edsl/questions/question_registry.py
+++ b/edsl/questions/question_registry.py
@@ -52,12 +52,19 @@ class Question(metaclass=Meta):
         return instance
 
     @classmethod
-    def pull(cls, id: int) -> "QuestionBase":
+    def pull(cls, id_or_url: str):
         """Pull the object from coop."""
         from edsl.coop import Coop
 
         c = Coop()
-        return c.get("question", id)
+        if c.url in id_or_url:
+            id = id_or_url.split("/")[-1]
+        else:
+            id = id_or_url
+        from edsl.questions.QuestionBase import QuestionBase
+        return c._get_base(QuestionBase, id)
+
+   
 
     @classmethod
     def available(cls, show_class_names: bool = False) -> Union[list, dict]:

--- a/edsl/results/Results.py
+++ b/edsl/results/Results.py
@@ -27,6 +27,7 @@ from edsl.results.Result import Result
 from edsl.results.ResultsExportMixin import ResultsExportMixin
 from edsl.scenarios import Scenario
 from edsl.surveys import Survey
+from edsl.data.Cache import Cache
 from edsl.utilities import (
     is_gzipped,
     is_valid_variable_name,
@@ -48,38 +49,11 @@ from edsl.results.ResultsDBMixin import ResultsDBMixin
 class Mixins(ResultsExportMixin, ResultsDBMixin):
     pass
 
-
-# These are only made available if the user has installed
-# our package from pip with the [report] option
-# try:
-#     from edsl.report.RegressionMixin import RegressionMixin
-
-#     Mixins = type("Mixins", (RegressionMixin, Mixins), {})
-# except (ImportError, ModuleNotFoundError):
-#     pass
-
-# try:
-#     from edsl.results.ResultsFetchMixin import ResultsFetchMixin
-
-#     Mixins = type("Mixins", (ResultsFetchMixin, Mixins), {})
-# except (ImportError, ModuleNotFoundError):
-#     pass
-
-# try:
-#     from edsl.report.ResultsOutputMixin import ResultsOutputMixin
-
-#     Mixins = type("Mixins", (ResultsOutputMixin, Mixins), {})
-# except (ImportError, ModuleNotFoundError):
-#     pass
-
-
 from edsl.Base import Base
 from edsl.results.ResultsFetchMixin import ResultsFetchMixin
 
-
 class Mixins(ResultsExportMixin, ResultsDBMixin, ResultsFetchMixin):
     pass
-
 
 class Results(UserList, Mixins, Base):
     """
@@ -105,6 +79,7 @@ class Results(UserList, Mixins, Base):
         survey: Optional[Survey] = None,
         data: Optional[list[Result]] = None,
         created_columns: Optional[list[str]] = None,
+        cache: Optional[Cache] = None,
         job_uuid: Optional[str] = None,
         total_results: Optional[int] = None,
     ):
@@ -121,6 +96,7 @@ class Results(UserList, Mixins, Base):
         self.created_columns = created_columns or []
         self._job_uuid = job_uuid
         self._total_results = total_results
+        self.cache = cache or Cache()
 
         if hasattr(self, "_add_output_functions"):
             self._add_output_functions()
@@ -188,6 +164,7 @@ class Results(UserList, Mixins, Base):
             "data": [result.to_dict() for result in self.data],
             "survey": self.survey.to_dict(),
             "created_columns": self.created_columns,
+            "cache": Cache() if not hasattr(self, "cache") else self.cache.to_dict(),
         }
 
     @classmethod
@@ -208,6 +185,7 @@ class Results(UserList, Mixins, Base):
             survey=Survey.from_dict(data["survey"]),
             data=[Result.from_dict(r) for r in data["data"]],
             created_columns=data.get("created_columns", None),
+            cache = Cache.from_dict(data.get("cache")) if "cache" in data else Cache()
         )
         return results
 

--- a/tests/base/test_Base.py
+++ b/tests/base/test_Base.py
@@ -26,6 +26,7 @@ class TestBaseModels:
                 "ScenarioList",
                 "AgentList",
                 "Jobs",
+                "Cache"
             ]
 
         methods = [

--- a/tests/coop/test_coop_client.py
+++ b/tests/coop/test_coop_client.py
@@ -41,9 +41,12 @@ def test_coop_client_questions():
     for question, public in question_examples:
         response = coop.create(question, public=public)
         assert response.get("type") == "question", "Expected type 'question'"
+        # get by object type and uuid
         assert (
             coop.get(object_type="question", uuid=response.get("uuid")) == question
         ), "Question retrieval mismatch"
+        # get by url
+        assert coop.get(url=response.get("url")) == question
         responses.append(response)
     # ..check length
     assert len(coop.questions) == 3
@@ -71,10 +74,12 @@ def test_coop_client_questions():
     for i, response in enumerate(responses):
         question, public = question_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert (
                 coop_anon.get(object_type="question", uuid=response.get("uuid"))
                 == question
             )
+            assert coop_anon.get(url=response.get("url")) == question
         else:
             with pytest.raises(Exception):
                 x = coop_anon.get(object_type="question", uuid=response.get("uuid"))
@@ -111,7 +116,10 @@ def test_coop_client_surveys():
     for survey, public in survey_examples:
         response = coop.create(survey, public=public)
         assert response.get("type") == "survey", "Expected type 'survey'"
+        # get by object type and uuid
         assert coop.get(object_type="survey", uuid=response.get("uuid")) == survey
+        # get by url
+        assert coop.get(url=response.get("url")) == survey
         responses.append(response)
     # ..can't create an empty survey
     with pytest.raises(Exception):
@@ -124,7 +132,9 @@ def test_coop_client_surveys():
     for i, response in enumerate(responses):
         survey, public = survey_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert coop2.get(object_type="survey", uuid=response.get("uuid")) == survey
+            assert coop2.get(url=response.get("url")) == survey
         else:
             with pytest.raises(Exception):
                 coop2.get(object_type="survey", uuid=response.get("uuid"))
@@ -140,9 +150,11 @@ def test_coop_client_surveys():
     for i, response in enumerate(responses):
         survey, public = survey_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert (
                 coop_anon.get(object_type="survey", uuid=response.get("uuid")) == survey
             )
+            assert coop_anon.get(url=response.get("url")) == survey
         else:
             with pytest.raises(Exception):
                 x = coop_anon.get(object_type="survey", uuid=response.get("uuid"))
@@ -178,7 +190,10 @@ def test_coop_client_agents():
     for agent, public in agent_examples:
         response = coop.create(agent, public=public)
         assert response.get("type") == "agent", "Expected type 'agent'"
+        # get by object type and uuid
         assert coop.get(object_type="agent", uuid=response.get("uuid")) == agent
+        # get by url
+        assert coop.get(url=response.get("url")) == agent
         responses.append(response)
     # ..check length
     assert len(coop.agents) == 3
@@ -188,7 +203,9 @@ def test_coop_client_agents():
     for i, response in enumerate(responses):
         agent, public = agent_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert coop2.get(object_type="agent", uuid=response.get("uuid")) == agent
+            assert coop2.get(url=response.get("url")) == agent
         else:
             with pytest.raises(Exception):
                 coop2.get(object_type="agent", uuid=response.get("uuid"))
@@ -204,9 +221,11 @@ def test_coop_client_agents():
     for i, response in enumerate(responses):
         agent, public = agent_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert (
                 coop_anon.get(object_type="agent", uuid=response.get("uuid")) == agent
             )
+            assert coop_anon.get(url=response.get("url")) == agent
         else:
             with pytest.raises(Exception):
                 x = coop_anon.get(object_type="agent", uuid=response.get("uuid"))
@@ -242,7 +261,10 @@ def test_coop_client_results():
     for results, public in results_examples:
         response = coop.create(results, public=public)
         assert response.get("type") == "results", "Expected type 'results'"
+        # get by object type and uuid
         assert coop.get(object_type="results", uuid=response.get("uuid")) == results
+        # get by url
+        assert coop.get(url=response.get("url")) == results
         responses.append(response)
     # ..check length
     assert len(coop.results) == 3
@@ -252,9 +274,11 @@ def test_coop_client_results():
     for i, response in enumerate(responses):
         results, public = results_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert (
                 coop2.get(object_type="results", uuid=response.get("uuid")) == results
             )
+            assert coop2.get(url=response.get("url")) == results
         else:
             with pytest.raises(Exception):
                 coop2.get(object_type="results", uuid=response.get("uuid"))
@@ -270,10 +294,12 @@ def test_coop_client_results():
     for i, response in enumerate(responses):
         results, public = results_examples[i]
         if public:
+            # should be able to get both by object type and uuid or by url
             assert (
                 coop_anon.get(object_type="results", uuid=response.get("uuid"))
                 == results
             )
+            assert coop_anon.get(url=response.get("url")) == results
         else:
             with pytest.raises(Exception):
                 x = coop_anon.get(object_type="results", uuid=response.get("uuid"))

--- a/tests/data/test_Cache.py
+++ b/tests/data/test_Cache.py
@@ -29,6 +29,12 @@ def test_fetch_nonexistent_entry():
         iteration=1,
     ) == None
 
+def test_new_entries(cache_empty):
+    cache = cache_empty
+    input = CacheEntry.store_input_example()
+    cache.store(**input)
+    len(cache.new_entries_cache()) == 1
+
 def test_fetch_existing_entry(cache_example):
     cache = cache_example
     assert cache.fetch(**cache.fetch_input_example()) == "The fox says 'hello'"


### PR DESCRIPTION
This PR: 

- Let's you call coop objects by uuid or by URL 
- Makes `Cache` object a child of Base.py. This will make it 'coopable' more easily 
- It gives results a 'cache' object that has the cache entries generated or called upon for that result
- Those cache entries are serialized 

NOTE: @zer0dss This will break the existing Results deserialization from previous version of edsl, such as those currently on coop. Not sure what's our best approach to handle... 