### PR TITLE
Fix error created when python code is generated with question_text that has text on multiple lines

### DIFF
--- a/edsl/surveys/SurveyExportMixin.py
+++ b/edsl/surveys/SurveyExportMixin.py
@@ -41,6 +41,9 @@ class SurveyExportMixin:
         header_lines.append("from edsl import Question")
         lines = ["\n".join(header_lines)]
         for question in self._questions:
+            question.question_text = question["question_text"].replace("\n", " ")
+            # remove dublicate spaces
+            question.question_text = " ".join(question.question_text.split())
             lines.append(f"{question.question_name} = " + repr(question))
         lines.append(
             f"{survey_var_name} = Survey(questions = [{', '.join(self.question_names)}])"


### PR DESCRIPTION
@rbyh  This is a fix for the below error.
<img width="926" alt="330165454-9fae77ac-b7df-4472-8b34-4c3cefb21ba3" src="https://github.com/expectedparrot/edsl/assets/96014354/113cd645-3f25-4e0d-86b0-87ddae86946d">
