### PR TITLE
Allow question_options to be list of lists or numbers

### DIFF
--- a/edsl/questions/QuestionBudget.py
+++ b/edsl/questions/QuestionBudget.py
@@ -13,7 +13,7 @@ class QuestionBudget(QuestionBase):
 
     question_type = "budget"
     budget_sum: int = IntegerDescriptor(none_allowed=False)
-    question_options: list[str] = QuestionOptionsDescriptor()
+    question_options: list[str] = QuestionOptionsDescriptor(q_budget=True)
 
     def __init__(
         self,

--- a/edsl/questions/QuestionMultipleChoice.py
+++ b/edsl/questions/QuestionMultipleChoice.py
@@ -15,13 +15,15 @@ class QuestionMultipleChoice(QuestionBase):
 
     question_type = "multiple_choice"
     purpose = "When options are known and limited"
-    question_options: list[str] = QuestionOptionsDescriptor()
+    question_options: Union[
+        list[str], list[list], list[float], list[int]
+    ] = QuestionOptionsDescriptor()
 
     def __init__(
         self,
         question_name: str,
         question_text: str,
-        question_options: list[str],
+        question_options: Union[list[str], list[list], list[float], list[int]],
     ):
         """Instantiate a new QuestionMultipleChoice.
 

--- a/edsl/questions/descriptors.py
+++ b/edsl/questions/descriptors.py
@@ -258,18 +258,21 @@ class QuestionOptionsDescriptor(BaseDescriptor):
             raise QuestionCreationValidationError(
                 f"Too few question options (got {value})."
             )
-        if len(value) != len(set(value)):
+        # handle the case when question_options is a list of lists (a list of list can be converted to set)
+        tmp_value = [str(x) for x in value]
+        if len(tmp_value) != len(set(tmp_value)):
             raise QuestionCreationValidationError(
                 f"Question options must be unique (got {value})."
             )
         if not self.linear_scale:
-            if not all(isinstance(x, str) for x in value):
+            if not all(isinstance(x, (str, list, int, float)) for x in value):
                 raise QuestionCreationValidationError(
                     "Question options must be strings (got {value}).)"
                 )
             if not all(
                 [
-                    len(option) >= 1 and len(option) < Settings.MAX_OPTION_LENGTH
+                    type(option) != str
+                    or (len(option) >= 1 and len(option) < Settings.MAX_OPTION_LENGTH)
                     for option in value
                 ]
             ):

--- a/tests/questions/test_QuestionMultipleChoice.py
+++ b/tests/questions/test_QuestionMultipleChoice.py
@@ -79,9 +79,6 @@ def test_QuestionMultipleChoice_construction():
     with pytest.raises(Exception):
         QuestionMultipleChoice(**invalid_question)
     # or not of type list of strings
-    invalid_question.update({"question_options": [1, 2]})
-    with pytest.raises(Exception):
-        QuestionMultipleChoice(**invalid_question)
     invalid_question.update({"question_options": ["OK", 2]})
     with pytest.raises(Exception):
         QuestionMultipleChoice(**invalid_question)


### PR DESCRIPTION
@rbyh This is the update that allows question_options to be a list of lists and also a list of numbers. As described in the issue comments #505 