### PR TITLE
Coop client improvements

### DIFF
--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -69,6 +69,14 @@ class PersistenceMixin:
         return c._delete_base(cls, id_or_url)
 
     @classmethod
+    def update(cls, id_or_url: Union[str, UUID], visibility: str):
+        """Update the object on coop."""
+        from edsl.coop import Coop
+
+        c = Coop()
+        return c._update_base(cls, id_or_url, visibility)
+
+    @classmethod
     def search(cls, query):
         """Search for objects on coop."""
         from edsl.coop import Coop

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -69,12 +69,15 @@ class PersistenceMixin:
         return c._delete_base(cls, id_or_url)
 
     @classmethod
-    def update(cls, id_or_url: Union[str, UUID], visibility: str):
-        """Update the object on coop."""
+    def patch(cls, id_or_url: Union[str, UUID], visibility: str):
+        """
+        Patch an uploaded objects attributes.
+        - Only supports changing visibility for now.
+        """
         from edsl.coop import Coop
 
         c = Coop()
-        return c._update_base(cls, id_or_url, visibility)
+        return c._patch_base(cls, id_or_url, visibility)
 
     @classmethod
     def search(cls, query):

--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -61,6 +61,14 @@ class PersistenceMixin:
         #     return c.get(object_type, id_or_url)
 
     @classmethod
+    def delete(cls, id_or_url: Union[str, UUID]):
+        """Delete the object from coop."""
+        from edsl.coop import Coop
+
+        c = Coop()
+        return c._delete_base(cls, id_or_url)
+
+    @classmethod
     def search(cls, query):
         """Search for objects on coop."""
         from edsl.coop import Coop

--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -33,6 +33,6 @@ from edsl.results.Results import Results
 from edsl.data.Cache import Cache
 from edsl.data.CacheEntry import CacheEntry
 from edsl.data.CacheHandler import set_session_cache, unset_session_cache
-from edsl.coop.coop import Coop
 from edsl.shared import shared_globals
 from edsl.jobs import Jobs
+from edsl.coop.coop import Coop

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -208,6 +208,17 @@ class Coop:
         self._resolve_server_response(response)
         return response.json()
 
+    def _delete_base(
+        self,
+        cls: EDSLObject,
+        uuid: Union[str, UUID],
+    ) -> dict:
+        """
+        Used by the Base class to offer a delete functionality.
+        """
+        object_type = ObjectRegistry.get_object_type_by_edsl_class(cls)
+        return self.delete(object_type, uuid)
+
     ################
     # Remote Cache
     ################

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -219,14 +219,15 @@ class Coop:
         object_type = ObjectRegistry.get_object_type_by_edsl_class(cls)
         return self.delete(object_type, uuid)
 
-    def update(
+    def patch(
         self,
         object_type: ObjectType,
         uuid: Union[str, UUID],
         visibility: VisibilityType,
     ) -> dict:
         """
-        Update the visibility of an object.
+        Change the attributes of an uploaded object
+        - Only supports visibility for now
         """
         response = self._send_server_request(
             uri=f"api/v0/object",
@@ -237,17 +238,17 @@ class Coop:
         self._resolve_server_response(response)
         return response.json()
 
-    def _update_base(
+    def _patch_base(
         self,
         cls: EDSLObject,
         uuid: Union[str, UUID],
         visibility: VisibilityType,
     ) -> dict:
         """
-        Used by the Base class to offer an update functionality.
+        Used by the Base class to offer a patch functionality.
         """
         object_type = ObjectRegistry.get_object_type_by_edsl_class(cls)
-        return self.update(object_type, uuid, visibility)
+        return self.patch(object_type, uuid, visibility)
 
     ################
     # Remote Cache
@@ -466,7 +467,7 @@ if __name__ == "__main__":
             coop.get(object_type=object_type, uuid=response.get("uuid"))
         # 6. Change visibility of all objects
         for item in objects:
-            coop.update(
+            coop.patch(
                 object_type=object_type, uuid=item.get("uuid"), visibility="private"
             )
         # 7. Delete all objects
@@ -476,7 +477,7 @@ if __name__ == "__main__":
 
     response = QuestionMultipleChoice.example().push()
     QuestionMultipleChoice.pull(response.get("uuid"))
-    coop.update(object_type="question", uuid=response.get("uuid"), visibility="public")
+    coop.patch(object_type="question", uuid=response.get("uuid"), visibility="public")
     coop.delete(object_type="question", uuid=response.get("uuid"))
 
     ##############

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -237,6 +237,18 @@ class Coop:
         self._resolve_server_response(response)
         return response.json()
 
+    def _update_base(
+        self,
+        cls: EDSLObject,
+        uuid: Union[str, UUID],
+        visibility: VisibilityType,
+    ) -> dict:
+        """
+        Used by the Base class to offer an update functionality.
+        """
+        object_type = ObjectRegistry.get_object_type_by_edsl_class(cls)
+        return self.update(object_type, uuid, visibility)
+
     ################
     # Remote Cache
     ################

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -431,14 +431,27 @@ if __name__ == "__main__":
     # A. Objects
     ##############
     from uuid import uuid4
-    from edsl import Agent, Cache, Jobs, QuestionMultipleChoice, Results, Survey
+    from edsl import (
+        Agent,
+        AgentList,
+        Cache,
+        Jobs,
+        QuestionMultipleChoice,
+        Results,
+        Scenario,
+        ScenarioList,
+        Survey,
+    )
 
     OBJECTS = [
         ("agent", Agent),
+        ("agent_list", AgentList),
         ("cache", Cache),
         ("job", Jobs),
         ("question", QuestionMultipleChoice),
         ("results", Results),
+        ("scenario", Scenario),
+        ("scenario_list", ScenarioList),
         ("survey", Survey),
     ]
 

--- a/edsl/coop/utils.py
+++ b/edsl/coop/utils.py
@@ -1,23 +1,28 @@
-from edsl import Agent, Cache, Results, Survey
-from edsl.jobs import Jobs
+from edsl import Agent, AgentList, Cache, Jobs, Results, Scenario, ScenarioList, Survey
 from edsl.questions import QuestionBase
 from typing import Literal, Type, Union
 
 EDSLObject = Union[
     Agent,
+    AgentList,
     Cache,
     Jobs,
     Type[QuestionBase],
     Results,
+    Scenario,
+    ScenarioList,
     Survey,
 ]
 
 ObjectType = Literal[
     "agent",
+    "agent_list",
     "cache",
     "job",
     "question",
     "results",
+    "scenario",
+    "scenario_list",
     "survey",
 ]
 
@@ -35,10 +40,13 @@ class ObjectRegistry:
 
     objects = [
         {"object_type": "agent", "edsl_class": Agent},
+        {"object_type": "agent_list", "edsl_class": AgentList},
         {"object_type": "cache", "edsl_class": Cache},
         {"object_type": "job", "edsl_class": Jobs},
         {"object_type": "question", "edsl_class": QuestionBase},
         {"object_type": "results", "edsl_class": Results},
+        {"object_type": "scenario", "edsl_class": Scenario},
+        {"object_type": "scenario_list", "edsl_class": ScenarioList},
         {"object_type": "survey", "edsl_class": Survey},
     ]
     object_type_to_edsl_class = {

--- a/edsl/questions/question_registry.py
+++ b/edsl/questions/question_registry.py
@@ -67,6 +67,20 @@ class Question(metaclass=Meta):
         return c._get_base(QuestionBase, id)
 
     @classmethod
+    def delete(cls, id_or_url: str):
+        """Delete the object from coop."""
+        from edsl.coop import Coop
+
+        c = Coop()
+        if c.url in id_or_url:
+            id = id_or_url.split("/")[-1]
+        else:
+            id = id_or_url
+        from edsl.questions.QuestionBase import QuestionBase
+
+        return c._delete_base(QuestionBase, id)
+
+    @classmethod
     def available(cls, show_class_names: bool = False) -> Union[list, dict]:
         """Return a list of available question types.
 

--- a/edsl/questions/question_registry.py
+++ b/edsl/questions/question_registry.py
@@ -81,6 +81,20 @@ class Question(metaclass=Meta):
         return c._delete_base(QuestionBase, id)
 
     @classmethod
+    def update(cls, id_or_url: str, visibility: str):
+        """Update the object on coop."""
+        from edsl.coop import Coop
+
+        c = Coop()
+        if c.url in id_or_url:
+            id = id_or_url.split("/")[-1]
+        else:
+            id = id_or_url
+        from edsl.questions.QuestionBase import QuestionBase
+
+        return c._update_base(QuestionBase, id, visibility)
+
+    @classmethod
     def available(cls, show_class_names: bool = False) -> Union[list, dict]:
         """Return a list of available question types.
 

--- a/edsl/scenarios/Scenario.py
+++ b/edsl/scenarios/Scenario.py
@@ -97,7 +97,7 @@ class Scenario(Base, UserDict, ScenarioImageMixin, ScenarioHtmlMixin):
         >>> s.to_dict()
         {'food': 'wood chips', 'edsl_version': '...', 'edsl_class_name': 'Scenario'}
         """
-        return self.data
+        return self.data.copy()
 
     def print(self):
         from rich import print_json

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -29,7 +29,6 @@ def coop_object_api_workflows(object_type, object_examples):
     responses = []
     for object, visibility in object_examples:
         response = coop.create(object, visibility=visibility)
-        print(response)
         assert (
             coop.get(object_type=object_type, uuid=response.get("uuid")) == object
         ), f"Expected object to be the same as the one created. "
@@ -91,7 +90,7 @@ def test_coop_client_agent_lists():
 
 
 @pytest.mark.coop
-def test_coop_client_cache():
+def test_coop_client_caches():
     cache_examples = [
         (Cache.example(), "public"),
         (Cache.example(), "private"),

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -45,7 +45,21 @@ def coop_object_api_workflows(object_type, object_examples):
             with pytest.raises(Exception):
                 coop2.get(object_type=object_type, uuid=response.get("uuid"))
 
-    # 4. Cleanup
+    # 4. Test changing visibility
+    for i, response in enumerate(responses):
+        object, visibility = object_examples[i]
+        if visibility == "private":
+            change_to_visibility = "public"
+        else:
+            change_to_visibility = "private"
+        response = coop.update(
+            object_type=object_type,
+            uuid=response.get("uuid"),
+            visibility=change_to_visibility,
+        )
+        assert response.get("status") == "success"
+
+    # 5. Cleanup
     for object in coop.get_all(object_type):
         response = coop.delete(object_type, object.get("uuid"))
         assert response.get("status") == "success"

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -1,6 +1,7 @@
 import pytest
 from edsl import (
     Agent,
+    AgentList,
     Cache,
     Coop,
     Jobs,
@@ -8,6 +9,8 @@ from edsl import (
     QuestionFreeText,
     QuestionMultipleChoice,
     Results,
+    Scenario,
+    ScenarioList,
     Survey,
 )
 
@@ -52,7 +55,7 @@ def coop_object_api_workflows(object_type, object_examples):
             change_to_visibility = "public"
         else:
             change_to_visibility = "private"
-        response = coop.update(
+        response = coop.patch(
             object_type=object_type,
             uuid=response.get("uuid"),
             visibility=change_to_visibility,
@@ -74,6 +77,17 @@ def test_coop_client_agents():
         (Agent.example(), "unlisted"),
     ]
     coop_object_api_workflows("agent", agent_examples)
+
+
+@pytest.mark.coop
+def test_coop_client_agent_lists():
+    agent_list_examples = [
+        (AgentList.example(), "public"),
+        (AgentList.example(), "private"),
+        (AgentList.example(), "public"),
+        (AgentList.example(), "unlisted"),
+    ]
+    coop_object_api_workflows("agent_list", agent_list_examples)
 
 
 @pytest.mark.coop
@@ -118,6 +132,28 @@ def test_coop_client_results():
         (Results.example(), "unlisted"),
     ]
     coop_object_api_workflows("results", results_examples)
+
+
+@pytest.mark.coop
+def test_coop_client_scenarios():
+    scenario_examples = [
+        (Scenario.example(), "public"),
+        (Scenario.example(), "private"),
+        (Scenario.example(), "public"),
+        (Scenario.example(), "unlisted"),
+    ]
+    coop_object_api_workflows("scenario", scenario_examples)
+
+
+@pytest.mark.coop
+def test_coop_client_scenario_lists():
+    scenario_list_examples = [
+        (ScenarioList.example(), "public"),
+        (ScenarioList.example(), "private"),
+        (ScenarioList.example(), "public"),
+        (ScenarioList.example(), "unlisted"),
+    ]
+    coop_object_api_workflows("scenario_list", scenario_list_examples)
 
 
 @pytest.mark.coop


### PR DESCRIPTION
- Delete a coop object directly from the object (w/o using client)
- Update (only visibility for now) a coop object, both from client and directly from the object
- agentlists, scenarios, scenariolists are now coopable