### PR TITLE
Adding matrix Question type

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -22,6 +22,7 @@ from edsl.questions import (
     QuestionRank,
     QuestionTopK,
     QuestionYesNo,
+    QuestionMatrix
 )
 from edsl.scenarios.Scenario import Scenario
 from edsl.scenarios.ScenarioList import ScenarioList

--- a/edsl/enums.py
+++ b/edsl/enums.py
@@ -28,6 +28,7 @@ class QuestionType(EnumWithChecks):
     TOP_K = "top_k"
     LIKERT_FIVE = "likert_five"
     LINEAR_SCALE = "linear_scale"
+    MATRIX = "matrix"
 
 
 # https://huggingface.co/meta-llama/Llama-2-70b-chat-hf

--- a/edsl/prompts/Prompt.py
+++ b/edsl/prompts/Prompt.py
@@ -302,6 +302,7 @@ from edsl.prompts.library.question_numerical import *
 from edsl.prompts.library.question_rank import *
 from edsl.prompts.library.question_extract import *
 from edsl.prompts.library.question_list import *
+from edsl.prompts.library.question_matrix import *
 
 
 if __name__ == "__main__":

--- a/edsl/prompts/library/question_matrix.py
+++ b/edsl/prompts/library/question_matrix.py
@@ -4,7 +4,7 @@ from edsl.prompts.QuestionInstructionsBase import QuestionInstuctionsBase
 
 
 class Matrix(QuestionInstuctionsBase):
-    """Checkbox question type."""
+    """Matrix question type."""
 
     question_type = "matrix"
     model = "gpt-4-1106-preview"
@@ -19,8 +19,9 @@ class Matrix(QuestionInstuctionsBase):
         {% for option in question_options %}
         {{ loop.index0 }}: {{option}}
         {% endfor %}
-        Return a valid JSON formatted like this, selecting only the number of the option:
-        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
+        Your response should be ONLY be a valid JSON in the following format:
+        {"answer": [<list of comma-separated integer options>], "comment": "<put explanation here>"}
+        The list must contain exactly the same number of answers as items.
         """
     )
 

--- a/edsl/prompts/library/question_matrix.py
+++ b/edsl/prompts/library/question_matrix.py
@@ -1,0 +1,26 @@
+"""Checkbox question type."""
+import textwrap
+from edsl.prompts.QuestionInstructionsBase import QuestionInstuctionsBase
+
+
+class Matrix(QuestionInstuctionsBase):
+    """Checkbox question type."""
+
+    question_type = "matrix"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The items are:
+        {% for option in question_items %}
+        - {{option}}
+        {% endfor %}
+        For each of theses items choose one of the following options:
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}
+        Return a valid JSON formatted like this, selecting only the number of the option:
+        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
+        """
+    )
+

--- a/edsl/prompts/registry.py
+++ b/edsl/prompts/registry.py
@@ -98,6 +98,7 @@ class RegisterPromptsMeta(ABCMeta):
 
         key = cls._create_prompt_class_key(dct, component_type)
         cls.data = key
+
         RegisterPromptsMeta._prompts_by_component_type[component_type].append(cls)
 
     @classmethod

--- a/edsl/questions/AnswerValidatorMixin.py
+++ b/edsl/questions/AnswerValidatorMixin.py
@@ -166,6 +166,33 @@ class AnswerValidatorMixin:
                 f"Answer codes, {answer_codes}, has more than {self.max_selections} options selected."
             )
 
+    def _validate_answer_matrix(self, answer: dict[str, Union[str, int]]) -> None:
+        """Validate QuestionCheckbox-specific answer.
+
+        Check that answer["answer"]:
+        - has elements that are strings, bytes-like objects or real numbers evaluating to integers
+        - has elements that are in the range of the number of options
+        - has at least `min_selections` elements, if provided
+        - has at most `max_selections` elements, if provided
+        """
+        answer_codes = answer["answer"]
+        try:
+            answer_codes = [int(k) for k in answer["answer"]]
+        except:
+            raise QuestionAnswerValidationError(
+                f"Answer codes must be a list of strings, bytes-like objects or real numbers (got {answer['answer']})."
+            )
+        acceptable_values = list(range(len(self.question_options)))
+        for answer_code in answer_codes:
+            if answer_code not in acceptable_values:
+                raise QuestionAnswerValidationError(
+                    f"Answer code {answer_code} has elements not in {acceptable_values}."
+                )
+        if len(answer_codes) < len(self.question_items):
+            raise QuestionAnswerValidationError(
+                f"Answer {answer_codes} has fewer answers than items ({len(self.question_items)})."
+            )
+
     def _validate_answer_extract(self, answer: dict[str, Any]) -> None:
         """Validate QuestionExtract-specific answer.
 

--- a/edsl/questions/QuestionMatrix.py
+++ b/edsl/questions/QuestionMatrix.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+import random
+from typing import Any, Optional, Union
+
+from jinja2 import Template
+
+from edsl.questions.QuestionBase import QuestionBase
+from edsl.questions.descriptors import (
+    IntegerDescriptor,
+    QuestionOptionsDescriptor,
+)
+from edsl.scenarios import Scenario
+from edsl.utilities import random_string
+
+
+class QuestionMatrix(QuestionBase):
+    """This question prompts the agent to select options from a list."""
+
+    question_type = "matrix"
+    purpose = "When you have a a matrix of options per items"
+    question_options: list[str] = QuestionOptionsDescriptor()
+    question_items: list[str] = QuestionOptionsDescriptor()
+
+    def __init__(
+        self,
+        question_name: str,
+        question_text: str,
+        question_options: list[str],
+        question_items: list[str],
+    ):
+        self.question_name = question_name
+        self.question_text = question_text
+        self.question_options = question_options
+        self.question_items = question_items
+
+    ################
+    # Answer methods
+    ################
+    def _validate_answer(self, answer: Any) -> dict[str, Union[int, str]]:
+        """Validate the answer."""
+        self._validate_answer_template_basic(answer)
+        self._validate_answer_key_value(answer, "answer", list)
+        self._validate_answer_matrix(answer)
+        return answer
+
+    def _translate_answer_code_to_answer(self, answer_codes, scenario: Scenario = None):
+        """
+        Translate the answer code to the actual answer.
+
+        For example, for question options ["a", "b", "c"],the answer codes are 0, 1, and 2.
+        The LLM will respond with [0,1] and this code will translate it to ["a","b"].
+        """
+        scenario = scenario or Scenario()
+        translated_options = [
+            Template(option).render(scenario) for option in self.question_options
+        ]
+        translated_codes = []
+        for answer_code in answer_codes:
+            translated_codes.append(translated_options[int(answer_code)])
+        return translated_codes
+
+    def _simulate_answer(self, human_readable=True) -> dict[str, Union[int, str]]:
+        """Simulate a valid answer for debugging purposes."""
+        if human_readable:
+            # Select a random number of options from self.question_options
+            selected_options = random.sample(self.question_options, num_selections)
+            answer = {
+                "answer": selected_options,
+                "comment": random_string(),
+            }
+        else:
+            # Select a random number of indices from the range of self.question_options
+            selected_indices = random.sample(
+                range(len(self.question_options)), num_selections
+            )
+            answer = {
+                "answer": selected_indices,
+                "comment": random_string(),
+            }
+        return answer
+
+    ################
+    # Helpful methods
+    ################
+    @classmethod
+    def example(cls) -> QuestionCheckBox:
+        """Return an example checkbox question."""
+        return cls(
+            question_name="never_eat",
+            question_text="What is your opinion on these countries?",
+            question_items=[
+                "Dislike",
+                "Neutral",
+                "Like",
+            ],
+            question_options=[
+                "France",
+                "Spain",
+                "Itally",
+            ]
+        )
+
+
+def main():
+    """Create an example QuestionCheckBox and test its methods."""
+    from edsl.questions.QuestionCheckBox import QuestionCheckBox
+
+    q = QuestionMatrix.example()
+    q.question_text
+    q.question_options
+    q.question_items
+    q.question_name
+    # validate an answer
+    q._validate_answer({"answer": [1, 1, 1], "comment": "I'm neutral for these countries"})
+    # translate answer code
+    q._translate_answer_code_to_answer([1, 1, 1])
+    # simulate answer
+    q._simulate_answer()
+    q._simulate_answer(human_readable=False)
+    q._validate_answer(q._simulate_answer(human_readable=False))
+    # serialization (inherits from Question)
+    q.to_dict()
+    assert q.from_dict(q.to_dict()) == q
+
+    import doctest
+
+    doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/edsl/questions/QuestionMatrix.py
+++ b/edsl/questions/QuestionMatrix.py
@@ -14,7 +14,7 @@ from edsl.utilities import random_string
 
 
 class QuestionMatrix(QuestionBase):
-    """This question prompts the agent to select options from a list."""
+    """This question prompts the agent to select options from a set of items."""
 
     question_type = "matrix"
     purpose = "When you have a a matrix of options per items"
@@ -102,8 +102,8 @@ class QuestionMatrix(QuestionBase):
 
 
 def main():
-    """Create an example QuestionCheckBox and test its methods."""
-    from edsl.questions.QuestionCheckBox import QuestionCheckBox
+    """Create an example QuestionMatrix and test its methods."""
+    from edsl.questions.QuestionMatrix import QuestionMatrix
 
     q = QuestionMatrix.example()
     q.question_text

--- a/edsl/questions/__init__.py
+++ b/edsl/questions/__init__.py
@@ -15,6 +15,7 @@ from edsl.questions.QuestionList import QuestionList
 from edsl.questions.QuestionMultipleChoice import QuestionMultipleChoice
 from edsl.questions.QuestionNumerical import QuestionNumerical
 from edsl.questions.QuestionRank import QuestionRank
+from edsl.questions.QuestionMatrix import QuestionMatrix
 
 # Questions derived from core questions
 from edsl.questions.derived.QuestionLikertFive import QuestionLikertFive


### PR DESCRIPTION
This merge request adds the matrix question type. This allows the agents to answer questions of the type: 

![image](https://github.com/expectedparrot/edsl/assets/132118/43655933-b0a5-4ed6-9076-b03d059954b0)

The interface for this question can be observed in the example located [here](https://github.com/nurv/edsl/blob/5f9b4593f34da59ca834e1199a51d6055f3250c2/edsl/questions/QuestionMatrix.py#L89-L101)