### PR TITLE
Add Sonnet 3.5 and dynamic model-adding

### DIFF
--- a/edsl/inference_services/AnthropicService.py
+++ b/edsl/inference_services/AnthropicService.py
@@ -16,6 +16,7 @@ class AnthropicService(InferenceServiceABC):
     def available(cls):
         # TODO - replace with an API call
         return [
+            "claude-3-5-sonnet-20240620",
             "claude-3-opus-20240229",
             "claude-3-sonnet-20240229",
             "claude-3-haiku-20240307",

--- a/edsl/inference_services/InferenceServicesCollection.py
+++ b/edsl/inference_services/InferenceServicesCollection.py
@@ -2,9 +2,18 @@ from edsl.inference_services.InferenceServiceABC import InferenceServiceABC
 
 
 class InferenceServicesCollection:
+
+    added_models = {}
+
     def __init__(self, services: list[InferenceServiceABC] = None):
         self.services = services or []
 
+    @classmethod
+    def add_model(cls, service_name, model_name):
+        if service_name not in cls.added_models:
+            cls.added_models[service_name] = []
+        cls.added_models[service_name].append(model_name)
+       
     def available(self):
         total_models = []
         for service in self.services:
@@ -16,6 +25,10 @@ class InferenceServicesCollection:
                 continue
             for model in service_models:
                 total_models.append([model, service._inference_service_, -1])
+            
+            for model in self.added_models.get(service._inference_service_, []):
+                total_models.append([model, service._inference_service_, -1])
+
         sorted_models = sorted(total_models)
         for i, model in enumerate(sorted_models):
             model[2] = i

--- a/edsl/language_models/registry.py
+++ b/edsl/language_models/registry.py
@@ -37,6 +37,20 @@ class Model(metaclass=Meta):
         registry = registry or default
         factory = registry.create_model_factory(model_name)
         return factory(*args, **kwargs)
+    
+    @classmethod
+    def add_model(cls, service_name, model_name):
+        from edsl.inference_services.registry import default
+
+        registry = default
+        registry.add_model(service_name, model_name)
+    
+    @classmethod
+    def services(cls, registry=None):
+        from edsl.inference_services.registry import default
+
+        registry = registry or default
+        return [r._inference_service_ for r in registry.services]
 
     @classmethod
     def available(cls, search_term=None, name_only=False, registry=None):


### PR DESCRIPTION
This also lets you add new models dynamically if we are out of date: 
@rbyh can you add to `Model` documentation? 

```
>>> from edsl import Model; Model.add_model(service_name = "anthropic", model_name = "poo")
>>> Model.available("anthropic")
[['claude-3-5-sonnet-20240620', 'anthropic', 10], ['claude-3-haiku-20240307', 'anthropic', 11], ['claude-3-opus-20240229', 'anthropic', 12], ['claude-3-sonnet-20240229', 'anthropic', 13], ['poo', 'anthropic', 61]]
>>> from edsl import Model; Model.add_model(service_name = "openai", model_name = "poo")
```
I also added a helper function that lets you see the services available: 
```
>>> Model.services()
['openai', 'anthropic', 'deep_infra', 'google']
>>> 
```