### PR TITLE
cache deep_infra service request + add exec_profile parameter to pull…

### DIFF
--- a/edsl/Base.py
+++ b/edsl/Base.py
@@ -52,12 +52,12 @@ class PersistenceMixin:
         return c.create(self, description, visibility)
 
     @classmethod
-    def pull(cls, id_or_url: Union[str, UUID]):
+    def pull(cls, id_or_url: Union[str, UUID], exec_profile=None):
         """Pull the object from coop."""
         from edsl.coop import Coop
 
         c = Coop()
-        return c._get_base(cls, id_or_url)
+        return c._get_base(cls, id_or_url, exec_profile=exec_profile)
 
     @classmethod
     def delete(cls, id_or_url: Union[str, UUID]):


### PR DESCRIPTION
The bottleneck was similar to the previous one ( a request to DeepInfra API was executed for each Result object that was linked with DeepInfra ). 

I've also added the exec_profile parameter to the pull method. If present the method will print the exec time for downloading the JSON string of the object and the exec time to create an edsl object from it.

```python
from edsl import Results

r = Results.pull('f33a08a1-52c6-432a-9c05-e898ac76a2e2',exec_profile=True)
```