### PR TITLE
Jinja warning and convert

### DIFF
--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -460,6 +460,12 @@ class Jobs(Base):
                 if warn:
                     warnings.warn(message)
 
+        if self.scenarios.has_jinja_braces:
+            warnings.warn(
+                "The scenarios have Jinja braces ({{ and }}). Converting to '<<' and '>>'. If you want a different conversion, use the convert_jinja_braces method first to modify the scenario."
+            )
+            self.scenarios = self.scenarios.convert_jinja_braces()
+
     @property
     def skip_retry(self):
         if not hasattr(self, "_skip_retry"):

--- a/edsl/jobs/runners/JobsRunnerAsyncio.py
+++ b/edsl/jobs/runners/JobsRunnerAsyncio.py
@@ -174,7 +174,7 @@ class JobsRunnerAsyncio(JobsRunnerStatusMixin):
             for k in answer_key_names
         }
         comments_dict = {
-            "k" + "_comment": question_results[k].comment for k in answer_key_names
+            k + "_comment": question_results[k].comment for k in answer_key_names
         }
 
         # we should have a valid result for each question

--- a/edsl/scenarios/Scenario.py
+++ b/edsl/scenarios/Scenario.py
@@ -58,7 +58,7 @@ class Scenario(Base, UserDict, ScenarioImageMixin, ScenarioHtmlMixin):
         True
         """
         for key, value in self.items():
-            if "{{" in value and "}}" in value:
+            if "{{" in str(value) and "}}" in value:
                 return True
         return False
     
@@ -72,7 +72,10 @@ class Scenario(Base, UserDict, ScenarioImageMixin, ScenarioHtmlMixin):
         """
         new_scenario = Scenario()
         for key, value in self.items():
-            new_scenario[key] = value.replace("{{", replacement_left).replace("}}", replacement_right)
+            if isinstance(value, str):
+                new_scenario[key] = value.replace("{{", replacement_left).replace("}}", replacement_right)
+            else:
+                new_scenario[key] = value
         return new_scenario
 
     @has_image.setter

--- a/edsl/scenarios/Scenario.py
+++ b/edsl/scenarios/Scenario.py
@@ -48,6 +48,32 @@ class Scenario(Base, UserDict, ScenarioImageMixin, ScenarioHtmlMixin):
         if not hasattr(self, "_has_image"):
             self._has_image = False
         return self._has_image
+    
+    @property 
+    def has_jinja_braces(self) -> bool:
+        """Return whether the scenario has jinja braces. This matters for rendering.
+        
+        >>> s = Scenario({"food": "I love {{wood chips}}"})
+        >>> s.has_jinja_braces
+        True
+        """
+        for key, value in self.items():
+            if "{{" in value and "}}" in value:
+                return True
+        return False
+    
+    def convert_jinja_braces(self, replacement_left = "<<", replacement_right = ">>") -> Scenario:
+        """Convert Jinja braces to some other character.
+        
+        >>> s = Scenario({"food": "I love {{wood chips}}"})
+        >>> s.convert_jinja_braces()
+        Scenario({'food': 'I love <<wood chips>>'})
+        
+        """
+        new_scenario = Scenario()
+        for key, value in self.items():
+            new_scenario[key] = value.replace("{{", replacement_left).replace("}}", replacement_right)
+        return new_scenario
 
     @has_image.setter
     def has_image(self, value):

--- a/edsl/scenarios/ScenarioList.py
+++ b/edsl/scenarios/ScenarioList.py
@@ -39,6 +39,15 @@ class ScenarioList(Base, UserList, ScenarioListMixin):
             super().__init__([])
         self.codebook = codebook or {}
 
+    @property
+    def has_jinja_braces(self) -> bool:
+        """Check if the ScenarioList has Jinja braces."""
+        return any([scenario.has_jinja_braces for scenario in self])
+    
+    def convert_jinja_braces(self) -> ScenarioList:
+        """Convert Jinja braces to Python braces."""
+        return ScenarioList([scenario.convert_jinja_braces() for scenario in self])
+
     def give_valid_names(self) -> ScenarioList:
         """Give valid names to the scenario keys.
 


### PR DESCRIPTION
This is a proposed fix for Issue #1013 https://github.com/expectedparrot/edsl/issues/1013
```python
from edsl import ScenarioList, Scenario 
s = Scenario({'text': "What is your favorite {{ food}}"})
from edsl import QuestionFreeText
q = QuestionFreeText(question_text = "What do you think of this question: {{ text}}?", question_name = "assess")
q.by(s).run()
```
which will convert the braces to "<<" and ">>" and warn the user about the change. 