### PR TITLE
Add 'include_comment' field

### DIFF
--- a/edsl/questions/derived/QuestionLinearScale.py
+++ b/edsl/questions/derived/QuestionLinearScale.py
@@ -22,6 +22,7 @@ class QuestionLinearScale(QuestionMultipleChoice):
         option_labels: Optional[dict[int, str]] = None,
         answering_instructions: Optional[str] = None,
         question_presentation: Optional[str] = None,
+        include_comment: Optional[bool] = True,
     ):
         """Instantiate a new QuestionLinearScale.
 
@@ -36,6 +37,7 @@ class QuestionLinearScale(QuestionMultipleChoice):
             question_text=question_text,
             question_options=question_options,
             use_code=False,  # question linear scale will have it's own code
+            include_comment=include_comment,
         )
         self.question_options = question_options
         self.option_labels = (

--- a/edsl/questions/derived/QuestionTopK.py
+++ b/edsl/questions/derived/QuestionTopK.py
@@ -20,6 +20,7 @@ class QuestionTopK(QuestionCheckBox):
         max_selections: int,
         question_presentation: Optional[str] = None,
         answering_instructions: Optional[str] = None,
+        include_comment: Optional[bool] = True,
     ):
         """Initialize the question.
 
@@ -37,6 +38,7 @@ class QuestionTopK(QuestionCheckBox):
             max_selections=max_selections,
             question_presentation=question_presentation,
             answering_instructions=answering_instructions,
+            include_comment=include_comment,
         )
         if min_selections != max_selections:
             raise QuestionCreationValidationError(

--- a/edsl/questions/derived/QuestionYesNo.py
+++ b/edsl/questions/derived/QuestionYesNo.py
@@ -19,6 +19,7 @@ class QuestionYesNo(QuestionMultipleChoice):
         question_options: list[str] = ["No", "Yes"],
         answering_instructions: Optional[str] = None,
         question_presentation: Optional[str] = None,
+        include_comment: Optional[bool] = True,
     ):
         """Instantiate a new QuestionYesNo.
 
@@ -33,6 +34,7 @@ class QuestionYesNo(QuestionMultipleChoice):
             use_code=False,
             answering_instructions=answering_instructions,
             question_presentation=question_presentation,
+            include_comment=include_comment,
         )
         self.question_options = question_options
 


### PR DESCRIPTION
I don't know if we want the include_comment to be passed to the example parameter - did I do it with other questions? 

https://www.expectedparrot.com/content/4cc9e610-899c-410c-bb88-fd58d6cb9f64

Regardless, many of these were missing the parameter