### PR TITLE
Fix `reponse` typo in yes-no instructions

### DIFF
--- a/edsl/questions/templates/yes_no/answering_instructions.jinja
+++ b/edsl/questions/templates/yes_no/answering_instructions.jinja
@@ -1,6 +1,6 @@
 {# Answering Instructions #}
-Please reponse with just your answer. 
+Please respond with just your answer. 
 
 {% if include_comment %}
-After the answer, you can put a comment explaining your reponse.
+After the answer, you can put a comment explaining your response.
 {% endif %}


### PR DESCRIPTION
Fix #1121