### PR TITLE
make cost negative when cache is used

### DIFF
--- a/edsl/jobs/runners/JobsRunnerAsyncio.py
+++ b/edsl/jobs/runners/JobsRunnerAsyncio.py
@@ -186,7 +186,10 @@ class JobsRunnerAsyncio:
             raw_model_results_dictionary[
                 question_name + "_raw_model_response"
             ] = result.raw_model_response
-            raw_model_results_dictionary[question_name + "_cost"] = result.cost
+            if result.cache_used:
+                raw_model_results_dictionary[question_name + "_cost"] = -result.cost
+            else:
+                raw_model_results_dictionary[question_name + "_cost"] = result.cost
             one_use_buys = (
                 "NA"
                 if isinstance(result.cost, str)


### PR DESCRIPTION
@johnjosephhorton @onmyraedar @apostolosfilippas This is a solution without modifying the Results schema to reflect in cost if the cache was used during result creation. Any ideas on how to handle it (set it to 0 or keep it like a negative value)?

Also regarding tests: We have tests where we check if **result_first_run == result_second_run_from_cache** -> we should add a custom compare for this.