### PR TITLE
Task history deserialization with exceptions

### DIFF
--- a/edsl/agents/InvigilatorBase.py
+++ b/edsl/agents/InvigilatorBase.py
@@ -115,7 +115,11 @@ class InvigilatorBase(ABC):
         iteration = data["iteration"]
         additional_prompt_data = data["additional_prompt_data"]
         cache = Cache.from_dict(data["cache"])
-        sidecar_model = LanguageModel.from_dict(data["sidecar_model"])
+
+        if data["sidecar_model"] is None:
+            sidecar_model = None
+        else:
+            sidecar_model = LanguageModel.from_dict(data["sidecar_model"])
 
         return cls(
             agent=agent,

--- a/edsl/jobs/interviews/Interview.py
+++ b/edsl/jobs/interviews/Interview.py
@@ -178,7 +178,7 @@ class Interview:
         if include_exceptions:
             d["exceptions"] = self.exceptions.to_dict()
         return d
-    
+
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "Interview":
         """Return an Interview instance from a dictionary."""
@@ -187,13 +187,23 @@ class Interview:
         scenario = Scenario.from_dict(d["scenario"])
         model = LanguageModel.from_dict(d["model"])
         iteration = d["iteration"]
-        return cls(agent=agent, survey=survey, scenario=scenario, model=model, iteration=iteration)
+        interview = cls(
+            agent=agent,
+            survey=survey,
+            scenario=scenario,
+            model=model,
+            iteration=iteration,
+        )
+        if "exceptions" in d:
+            exceptions = InterviewExceptionCollection.from_dict(d["exceptions"])
+            interview.exceptions = exceptions
+        return interview
 
     def __hash__(self) -> int:
         from edsl.utilities.utilities import dict_hash
 
         return dict_hash(self._to_dict(include_exceptions=False))
-    
+
     def __eq__(self, other: "Interview") -> bool:
         """
         >>> from edsl.jobs.interviews.Interview import Interview; i = Interview.example(); d = i._to_dict(); i2 = Interview.from_dict(d); i == i2

--- a/edsl/jobs/interviews/InterviewExceptionEntry.py
+++ b/edsl/jobs/interviews/InterviewExceptionEntry.py
@@ -132,18 +132,25 @@ class InterviewExceptionEntry:
         )
         console.print(tb)
         return html_output.getvalue()
-    
+
     @staticmethod
     def serialize_exception(exception: Exception) -> dict:
         return {
             "type": type(exception).__name__,
             "message": str(exception),
-            "traceback": "".join(traceback.format_exception(type(exception), exception, exception.__traceback__)),
+            "traceback": "".join(
+                traceback.format_exception(
+                    type(exception), exception, exception.__traceback__
+                )
+            ),
         }
-    
+
     @staticmethod
     def deserialize_exception(data: dict) -> Exception:
-        exception_class = globals()[data["type"]]
+        try:
+            exception_class = globals()[data["type"]]
+        except KeyError:
+            exception_class = Exception
         return exception_class(data["message"])
 
     def to_dict(self) -> dict:
@@ -158,7 +165,7 @@ class InterviewExceptionEntry:
             "traceback": self.traceback,
             "invigilator": self.invigilator.to_dict(),
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> "InterviewExceptionEntry":
         """Create an InterviewExceptionEntry from a dictionary."""


### PR DESCRIPTION
To generate error reports on Coop, we need to include exceptions when deserializing task history.