### PR TITLE
Add usd suffix to job cost estimates

### DIFF
--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -193,7 +193,7 @@ class Jobs(Base):
                     inference_service=invigilator.model._inference_service_,
                     model=invigilator.model.model,
                 )
-                costs.append(prompt_cost["cost"])
+                costs.append(prompt_cost["cost_usd"])
 
         d = Dataset(
             [

--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -254,9 +254,8 @@ class Jobs(Base):
             warnings.warn(
                 "Price data could not be retrieved. Using default estimates for input and output token prices. Input: $0.15 / 1M tokens; Output: $0.60 / 1M tokens"
             )
-
-            output_price_per_token = 0.00000015  # $0.15 / 1M tokens
-            input_price_per_token = 0.00000060  # $0.60 / 1M tokens
+            input_price_per_token = 0.00000015  # $0.15 / 1M tokens
+            output_price_per_token = 0.00000060  # $0.60 / 1M tokens
 
         # Compute the number of characters (double if the question involves piping)
         user_prompt_chars = len(str(user_prompt)) * get_piping_multiplier(

--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -241,10 +241,25 @@ class Jobs(Base):
 
         try:
             relevant_prices = price_lookup[key]
-            output_price_per_token = 1 / float(
-                relevant_prices["output"]["one_usd_buys"]
+
+            service_input_token_price = float(
+                relevant_prices["input"]["service_stated_token_price"]
             )
-            input_price_per_token = 1 / float(relevant_prices["input"]["one_usd_buys"])
+            service_input_token_qty = float(
+                relevant_prices["input"]["service_stated_token_qty"]
+            )
+            input_price_per_token = service_input_token_price / service_input_token_qty
+
+            service_output_token_price = float(
+                relevant_prices["output"]["service_stated_token_price"]
+            )
+            service_output_token_qty = float(
+                relevant_prices["output"]["service_stated_token_qty"]
+            )
+            output_price_per_token = (
+                service_output_token_price / service_output_token_qty
+            )
+
         except KeyError:
             # A KeyError is likely to occur if we cannot retrieve prices (the price_lookup dict is empty)
             # Use a sensible default

--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -279,7 +279,7 @@ class Jobs(Base):
         return {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
-            "cost": cost,
+            "cost_usd": cost,
         }
 
     def estimate_job_cost_from_external_prices(
@@ -326,7 +326,7 @@ class Jobs(Base):
                         "system_prompt": system_prompt,
                         "estimated_input_tokens": prompt_cost["input_tokens"],
                         "estimated_output_tokens": prompt_cost["output_tokens"],
-                        "estimated_cost": prompt_cost["cost"],
+                        "estimated_cost_usd": prompt_cost["cost_usd"],
                         "inference_service": inference_service,
                         "model": model,
                     }
@@ -338,21 +338,21 @@ class Jobs(Base):
             df.groupby(["inference_service", "model"])
             .agg(
                 {
-                    "estimated_cost": "sum",
+                    "estimated_cost_usd": "sum",
                     "estimated_input_tokens": "sum",
                     "estimated_output_tokens": "sum",
                 }
             )
             .reset_index()
         )
-        df["estimated_cost"] = df["estimated_cost"] * iterations
+        df["estimated_cost_usd"] = df["estimated_cost_usd"] * iterations
         df["estimated_input_tokens"] = df["estimated_input_tokens"] * iterations
         df["estimated_output_tokens"] = df["estimated_output_tokens"] * iterations
 
         estimated_costs_by_model = df.to_dict("records")
 
         estimated_total_cost = sum(
-            model["estimated_cost"] for model in estimated_costs_by_model
+            model["estimated_cost_usd"] for model in estimated_costs_by_model
         )
         estimated_total_input_tokens = sum(
             model["estimated_input_tokens"] for model in estimated_costs_by_model
@@ -362,7 +362,7 @@ class Jobs(Base):
         )
 
         output = {
-            "estimated_total_cost": estimated_total_cost,
+            "estimated_total_cost_usd": estimated_total_cost,
             "estimated_total_input_tokens": estimated_total_input_tokens,
             "estimated_total_output_tokens": estimated_total_output_tokens,
             "model_costs": estimated_costs_by_model,

--- a/tests/jobs/test_job_cost.py
+++ b/tests/jobs/test_job_cost.py
@@ -38,7 +38,7 @@ def test_prompt_cost_estimation():
 
     assert estimated_cost_dct["input_tokens"] == 7
     assert estimated_cost_dct["output_tokens"] == 6
-    assert estimated_cost_dct["cost"] == 13
+    assert estimated_cost_dct["cost_usd"] == 13
 
     estimated_cost_dct = Jobs.estimate_prompt_cost(
         system_prompt="",
@@ -50,7 +50,7 @@ def test_prompt_cost_estimation():
 
     assert estimated_cost_dct["input_tokens"] == 8
     assert estimated_cost_dct["output_tokens"] == 6
-    assert estimated_cost_dct["cost"] == 14
+    assert estimated_cost_dct["cost_usd"] == 14
 
 
 def test_prompt_cost_estimation_with_piping():
@@ -64,7 +64,7 @@ def test_prompt_cost_estimation_with_piping():
 
     assert estimated_cost_dct["input_tokens"] == 20
     assert estimated_cost_dct["output_tokens"] == 15
-    assert estimated_cost_dct["cost"] == 35
+    assert estimated_cost_dct["cost_usd"] == 35
 
 
 def test_job_cost_estimation():
@@ -85,7 +85,7 @@ def test_job_cost_estimation():
     output_tokens = estimated_cost_dct["estimated_total_output_tokens"]
     assert output_tokens == 12
 
-    cost = estimated_cost_dct["estimated_total_cost"]
+    cost = estimated_cost_dct["estimated_total_cost_usd"]
     assert cost == 27
 
 
@@ -109,7 +109,7 @@ def test_job_cost_estimation_with_iterations():
     output_tokens = estimated_cost_dct["estimated_total_output_tokens"]
     assert output_tokens == 24
 
-    cost = estimated_cost_dct["estimated_total_cost"]
+    cost = estimated_cost_dct["estimated_total_cost_usd"]
     assert cost == 54
 
 
@@ -132,7 +132,7 @@ def test_job_cost_estimation_with_piping():
     output_tokens = estimated_cost_dct["estimated_total_output_tokens"]
     assert output_tokens == 21  # 6 from q0 + 15 from q1
 
-    cost = estimated_cost_dct["estimated_total_cost"]
+    cost = estimated_cost_dct["estimated_total_cost_usd"]
     assert cost == 48  # 7 + 20 + 6 + 15
 
 
@@ -157,5 +157,5 @@ def test_job_cost_estimation_with_piping_and_iterations():
     output_tokens = estimated_cost_dct["estimated_total_output_tokens"]
     assert output_tokens == 42
 
-    cost = estimated_cost_dct["estimated_total_cost"]
+    cost = estimated_cost_dct["estimated_total_cost_usd"]
     assert cost == 96


### PR DESCRIPTION
This is just a clarity thing (see https://github.com/expectedparrot/coopr/issues/229) so users don't think this refers to credits. I do need an EDSL dev version so I can update the code that uses the old naming convention on Coop. 