### PR TITLE
Do not require "path=" when creating a notebook

### DIFF
--- a/edsl/notebooks/Notebook.py
+++ b/edsl/notebooks/Notebook.py
@@ -17,8 +17,8 @@ class Notebook(Base):
 
     def __init__(
         self,
-        data: Optional[Dict] = None,
         path: Optional[str] = None,
+        data: Optional[Dict] = None,
         name: Optional[str] = None,
     ):
         """
@@ -33,12 +33,16 @@ class Notebook(Base):
         import nbformat
 
         # Load current notebook path as fallback (VS Code only)
-        path = path or globals().get("__vsc_ipynb_file__")
-        if data is not None:
+        current_notebook_path = globals().get("__vsc_ipynb_file__")
+        if path is not None:
+            with open(path, mode="r", encoding="utf-8") as f:
+                data = nbformat.read(f, as_version=4)
+            self.data = json.loads(json.dumps(data))
+        elif data is not None:
             nbformat.validate(data)
             self.data = data
-        elif path is not None:
-            with open(path, mode="r", encoding="utf-8") as f:
+        elif current_notebook_path is not None:
+            with open(current_notebook_path, mode="r", encoding="utf-8") as f:
                 data = nbformat.read(f, as_version=4)
             self.data = json.loads(json.dumps(data))
         else:

--- a/tests/notebooks/test_Notebook.py
+++ b/tests/notebooks/test_Notebook.py
@@ -61,21 +61,26 @@ def test_notebook_creation_from_data_invalid():
     with pytest.raises(NotebookValidationError):
         invalid_data = valid_data.copy()
         invalid_data.pop("cells")
-        notebook = Notebook(invalid_data)
+        notebook = Notebook(data=invalid_data)
     # Missing metadata
     with pytest.raises(NotebookValidationError):
         invalid_data = valid_data.copy()
         invalid_data.pop("metadata")
-        notebook = Notebook(invalid_data)
+        notebook = Notebook(data=invalid_data)
     # Missing cell_type for first cell
     with pytest.raises(NotebookValidationError):
         invalid_dict = deepcopy(valid_data)
         invalid_dict["cells"][0].pop("cell_type")
-        notebook = Notebook(invalid_data)
+        notebook = Notebook(data=invalid_data)
 
 
 def test_notebook_creation_from_path_valid():
     """Tests that a notebook can be created from a filepath."""
+
+    notebook = Notebook("docs/notebooks/starter_tutorial.ipynb")
+    assert notebook.data["nbformat"] == 4
+    assert notebook.data["nbformat_minor"] == 5
+    assert notebook.data["cells"][0]["cell_type"] == "markdown"
 
     notebook = Notebook(path="docs/notebooks/starter_tutorial.ipynb")
     assert notebook.data["nbformat"] == 4
@@ -88,12 +93,10 @@ def test_notebook_creation_from_path_invalid():
 
     # No such file
     with pytest.raises(FileNotFoundError):
-        notebook = Notebook(
-            path="docs/notebooks/invalid_path_to_starter_tutorial.ipynb"
-        )
+        notebook = Notebook("docs/notebooks/invalid_path_to_starter_tutorial.ipynb")
     # File exists, but is not JSON
     with pytest.raises(NotJSONError):
-        notebook = Notebook(path="docs/agents.rst")
+        notebook = Notebook("docs/agents.rst")
     # No path - not implemented in environments other than VS Code
     with pytest.raises(NotImplementedError):
         notebook = Notebook()
@@ -104,14 +107,14 @@ def test_notebook_equality():
 
     # Test equality (only checks data, not name)
     notebook1 = Notebook.example()
-    notebook2 = Notebook(valid_data, name="second_notebook")
+    notebook2 = Notebook(data=valid_data, name="second_notebook")
     assert notebook1 == notebook2
 
 
 def test_notebook_serialization():
     """Tests notebook serialization."""
 
-    notebook = Notebook(valid_data)
+    notebook = Notebook(data=valid_data)
     notebook2 = Notebook.from_dict(notebook.to_dict())
     assert isinstance(notebook, Notebook)
     assert type(notebook) == type(notebook2)


### PR DESCRIPTION
Related to https://github.com/expectedparrot/coopr/issues/368

Most people are creating from path, so it makes sense to have path as the first param instead of data