### PR TITLE
Add remote inference benchmark script

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -52,7 +52,7 @@ def plot_times(disable_remote_inference=False):
 ####################
 # Main
 disable_remote_inference=True
-
+nr_jobs=20
 run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=20)
 
 plot_times(disable_remote_inference=disable_remote_inference)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -53,6 +53,6 @@ def plot_times(disable_remote_inference=False):
 # Main
 disable_remote_inference=True
 
-run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=100)
+run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=20)
 
 plot_times(disable_remote_inference=disable_remote_inference)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,58 @@
+from edsl import Jobs
+import requests 
+import json
+from edsl import QuestionCheckBox,QuestionFreeText,QuestionList
+import time
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import matplotlib
+from edsl import Survey,Results
+from edsl import Cache
+import matplotlib.pyplot as plt
+
+
+running_time = {}
+def test_1(disable_remote_inference=False,th_id=0):
+
+    start = time.time()
+    try:
+        q = QuestionCheckBox.example()
+        cache = Cache()
+
+        res = Survey(questions=[q]).run(disable_remote_inference=disable_remote_inference,disable_remote_cache=True,cache=cache)
+
+    except Exception as e:
+        print(e)    
+    end = time.time()
+    print("Time taken to run the survey: ", end-start)
+    running_time[th_id] = end-start
+
+def run_tests_in_parallel(disable_remote_inference=False,nr_jobs=2):
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        futures = [executor.submit(test_1,disable_remote_inference=disable_remote_inference,th_id=i) for i in range(nr_jobs)]
+        for future in futures:
+            future.result()
+def plot_times(disable_remote_inference=False):
+    fig = plt.figure()
+
+    values = [running_time[k] for k in range(len(running_time))]
+    max_value = max(values)
+    plt.plot(values)
+    plt.ylim(0, max(max_value, 12))
+    plt.xlabel('Job Number')
+    plt.ylabel('Execution Time (s)')
+    plt.title('Execution Time per Job')
+    plt.xticks(range(len(running_time)))  # Set x-axis to display only integer positions
+    if disable_remote_inference:
+        plt.savefig(f'plot_{len(running_time)}_no_remote.png')
+    else:
+        plt.savefig(f'plot_{len(running_time)}.png')
+    plt.show()
+
+####################
+# Main
+disable_remote_inference=True
+
+run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=100)
+
+plot_times(disable_remote_inference=disable_remote_inference)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -53,6 +53,6 @@ def plot_times(disable_remote_inference=False):
 # Main
 disable_remote_inference=True
 nr_jobs=20
-run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=20)
+run_tests_in_parallel(disable_remote_inference=disable_remote_inference, nr_jobs=nr_jobs)
 
 plot_times(disable_remote_inference=disable_remote_inference)


### PR DESCRIPTION
@johnjosephhorton Regarding your comment on issue #1201. I've added a benchmark script for remote inference.
Here are some results running it in two modes (local run and remote run on testing env (chick)).

## 20 jobs

### Local run 

![plot_20_no_remote](https://github.com/user-attachments/assets/5d7533f6-b560-4a69-88b5-bf567a258c9c)

### Remote run
![plot_20](https://github.com/user-attachments/assets/a00eb979-777b-4e78-a0c9-96c55e400009)

## 100 jobs

### Local run (some spikes are happening on local running triggered by interview exceptions)

![plot_100_no_remote_1](https://github.com/user-attachments/assets/90e4845a-7f93-4554-9c93-d22c998ce6c5)

### Remote run

![plot_100](https://github.com/user-attachments/assets/661c95e9-12b2-4665-abfe-f6f91382f8d5)
