### PR TITLE
Add inference service to tables

### DIFF
--- a/edsl/language_models/ModelList.py
+++ b/edsl/language_models/ModelList.py
@@ -60,7 +60,7 @@ class ModelList(Base, UserList):
 
         sl = ScenarioList()
         for model in self:
-            d = {"model": model.model}
+            d = {"model": model.model, "inference_service": model._inference_service_}
             d.update(model.parameters)
             sl.append(Scenario(d))
         return sl

--- a/edsl/results/Result.py
+++ b/edsl/results/Result.py
@@ -154,7 +154,9 @@ class Result(Base, UserDict):
     @staticmethod
     def _create_model_sub_dict(model) -> dict:
         return {
-            "model": model.parameters | {"model": model.model},
+            "model": model.parameters
+            | {"model": model.model}
+            | {"inference_service": model._inference_service_},
         }
 
     @staticmethod

--- a/edsl/results/Results.py
+++ b/edsl/results/Results.py
@@ -647,7 +647,7 @@ class Results(UserList, Mixins, Base):
 
         >>> r = Results.example()
         >>> r.model_keys
-        ['frequency_penalty', 'logprobs', 'max_tokens', 'model', 'model_index', 'presence_penalty', 'temperature', 'top_logprobs', 'top_p']
+        ['frequency_penalty', 'inference_service', 'logprobs', 'max_tokens', 'model', 'model_index', 'presence_penalty', 'temperature', 'top_logprobs', 'top_p']
         """
         return sorted(self._data_type_to_keys["model"])
 


### PR DESCRIPTION
This should enable the following:
- Inference service shows up when you display a model list (e.g., with `results.models` or `jobs.models`):
```python
from edsl import ModelList

m = ModelList.example()

m
```

- You can select inference service from a Results object, as in:

```python
from edsl import Results

r = Results.example()

r.select("model.inference_service")
```

Fixes #1510 