### PR TITLE
Improvements to .humanize()

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -870,7 +870,7 @@ class Coop(CoopFunctionsMixin):
     def create_project(
         self,
         survey: Survey,
-        project_name: str,
+        project_name: str = "Project",
         survey_description: Optional[str] = None,
         survey_alias: Optional[str] = None,
         survey_visibility: Optional[VisibilityType] = "unlisted",
@@ -895,7 +895,8 @@ class Coop(CoopFunctionsMixin):
         return {
             "name": response_json.get("project_name"),
             "uuid": response_json.get("uuid"),
-            "url": f"{self.url}/home/projects/{response_json.get('uuid')}",
+            "admin_url": f"{self.url}/home/projects/{response_json.get('uuid')}",
+            "respondent_url": f"{self.url}/respond/{response_json.get('uuid')}",
         }
 
     ################

--- a/edsl/questions/QuestionBase.py
+++ b/edsl/questions/QuestionBase.py
@@ -432,6 +432,24 @@ class QuestionBase(
 
         return Survey([self])
 
+    def humanize(
+        self,
+        project_name: str = "Project",
+        survey_description: Optional[str] = None,
+        survey_alias: Optional[str] = None,
+        survey_visibility: Optional["VisibilityType"] = "unlisted",
+    ) -> dict:
+        """
+        Turn a single question into a survey and send the survey to Coop.
+
+        Then, create a project on Coop so you can share the survey with human respondents.
+        """
+        s = self.to_survey()
+        project_details = s.humanize(
+            project_name, survey_description, survey_alias, survey_visibility
+        )
+        return project_details
+
     def by(self, *args) -> "Jobs":
         """Turn a single question into a survey and then a Job."""
         from edsl.surveys.Survey import Survey

--- a/edsl/surveys/Survey.py
+++ b/edsl/surveys/Survey.py
@@ -1248,14 +1248,15 @@ class Survey(SurveyExportMixin, Base):
     ###################
     def humanize(
         self,
-        project_name: str,
+        project_name: str = "Project",
         survey_description: Optional[str] = None,
         survey_alias: Optional[str] = None,
         survey_visibility: Optional["VisibilityType"] = "unlisted",
-    ):
+    ) -> dict:
         """
-        Create a survey object on Coop.
-        Then, create a project on Coop so you can share the survey with humans.
+        Send the survey to Coop.
+
+        Then, create a project on Coop so you can share the survey with human respondents.
         """
         from edsl.coop import Coop
 


### PR DESCRIPTION
- You can now run .humanize() with single questions, e.g., q.humanize()
- Default project name now "Project"
- Return both admin url and respondent url when project is created