### PR TITLE
Fix o3-mini parameter issue

### DIFF
--- a/edsl/inference_services/OpenAIService.py
+++ b/edsl/inference_services/OpenAIService.py
@@ -207,8 +207,10 @@ class OpenAIService(InferenceServiceABC):
                     {"role": "user", "content": content},
                 ]
                 if (
-                    system_prompt == "" and self.omit_system_prompt_if_empty
-                ) or "o1" in self.model:
+                    (system_prompt == "" and self.omit_system_prompt_if_empty)
+                    or "o1" in self.model
+                    or "o3" in self.model
+                ):
                     messages = messages[1:]
 
                 params = {
@@ -222,7 +224,7 @@ class OpenAIService(InferenceServiceABC):
                     "logprobs": self.logprobs,
                     "top_logprobs": self.top_logprobs if self.logprobs else None,
                 }
-                if "o1" in self.model:
+                if "o1" in self.model or "o3" in self.model:
                     params.pop("max_tokens")
                     params["max_completion_tokens"] = self.max_tokens
                     params["temperature"] = 1


### PR DESCRIPTION
o3-mini was not working on production because it was not set up to work with `max_completion_tokens` instead of `max_tokens`