### PR TITLE
Fix dropped raw model response issue

### DIFF
--- a/edsl/agents/PromptConstructor.py
+++ b/edsl/agents/PromptConstructor.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 from typing import Dict, Any, Optional, Set, Union, TYPE_CHECKING, Literal
 from functools import cached_property
-from multiprocessing import Pool, freeze_support, get_context
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 import time
 import logging
 
 from edsl.prompts.Prompt import Prompt
 
-from dataclasses import dataclass
-
-from .prompt_helpers import PromptPlan
-from .QuestionTemplateReplacementsBuilder import (
+from edsl.agents.prompt_helpers import PromptPlan
+from edsl.agents.QuestionTemplateReplacementsBuilder import (
     QuestionTemplateReplacementsBuilder,
 )
-from .question_option_processor import QuestionOptionProcessor
+from edsl.agents.question_option_processor import QuestionOptionProcessor
 
 if TYPE_CHECKING:
     from edsl.agents.InvigilatorBase import InvigilatorBase
@@ -146,23 +142,29 @@ class PromptConstructor:
         return self.agent.prompt()
 
     def prior_answers_dict(self) -> dict[str, "QuestionBase"]:
-        """This is a dictionary of prior answers, if they exist."""
+        """This is a dictionary of prior answers, if they exist.
+        
+        >>> from edsl.agents.InvigilatorBase import InvigilatorBase
+        >>> i = InvigilatorBase.example()
+        >>> i.prompt_constructor.prior_answers_dict()
+        {'q0': ..., 'q1': ...}
+        """
         return self._add_answers(
             self.survey.question_names_to_questions(), self.current_answers
         )
 
     @staticmethod
-    def _extract_quetion_and_entry_type(key_entry) -> tuple[str, str]:
+    def _extract_question_and_entry_type(key_entry) -> tuple[str, str]:
         """
         Extracts the question name and type for the current answer dictionary key entry.
 
-        >>> PromptConstructor._extract_quetion_and_entry_type("q0")
+        >>> PromptConstructor._extract_question_and_entry_type("q0")
         ('q0', 'answer')
-        >>> PromptConstructor._extract_quetion_and_entry_type("q0_comment")
+        >>> PromptConstructor._extract_question_and_entry_type("q0_comment")
         ('q0', 'comment')
-        >>> PromptConstructor._extract_quetion_and_entry_type("q0_alternate_generated_tokens")
+        >>> PromptConstructor._extract_question_and_entry_type("q0_alternate_generated_tokens")
         ('q0_alternate', 'generated_tokens')
-        >>> PromptConstructor._extract_quetion_and_entry_type("q0_alt_comment")
+        >>> PromptConstructor._extract_question_and_entry_type("q0_alt_comment")
         ('q0_alt', 'comment')
         """
         split_list = key_entry.rsplit("_", maxsplit=1)
@@ -192,7 +194,7 @@ class PromptConstructor:
         d = defaultdict(dict)
         for key, value in current_answers.items():
             question_name, entry_type = (
-                PromptConstructor._extract_quetion_and_entry_type(key)
+                PromptConstructor._extract_question_and_entry_type(key)
             )
             d[question_name][entry_type] = value
         return dict(d)
@@ -273,7 +275,7 @@ class PromptConstructor:
             question_name, self.current_answers
         )
 
-    def get_prompts(self, parallel: Literal["thread", "process", None] = None) -> Dict[str, Any]:
+    def get_prompts(self) -> Dict[str, Any]:
         """Get the prompts for the question."""
         start = time.time()
         
@@ -312,36 +314,7 @@ class PromptConstructor:
         # Get arranged components first
         arranged = self.prompt_plan.arrange_components(**components)
         
-        if parallel == "process":
-            pass
-            # ctx = get_context('fork')
-            # with ctx.Pool() as pool:
-            #     results = pool.map(_process_prompt, [
-            #         (arranged["user_prompt"], {}),
-            #         (arranged["system_prompt"], {})
-            #     ])
-            #     prompts = {
-            #         "user_prompt": results[0],
-            #         "system_prompt": results[1]
-            #     }
-            
-        elif parallel == "thread":
-            pass
-            # with ThreadPoolExecutor() as executor:
-            #     user_prompt_list = arranged["user_prompt"]
-            #     system_prompt_list = arranged["system_prompt"]
-                
-            #     # Process both prompt lists in parallel
-            #     rendered_user = executor.submit(_process_prompt, (user_prompt_list, {}))
-            #     rendered_system = executor.submit(_process_prompt, (system_prompt_list, {}))
-                
-            #     prompts = {
-            #         "user_prompt": rendered_user.result(),
-            #         "system_prompt": rendered_system.result()
-            #     }
-                
-        else:  # sequential processing
-            prompts = self.prompt_plan.get_prompts(**components)
+        prompts = self.prompt_plan.get_prompts(**components)
 
         plan_end = time.time()
         logger.debug(f"Time taken for prompt processing: {plan_end - plan_start:.4f}s")
@@ -368,4 +341,5 @@ def _process_prompt(args):
 
 
 if __name__ == '__main__':
-    freeze_support()
+    import doctest
+    doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/edsl/agents/PromptConstructor.py
+++ b/edsl/agents/PromptConstructor.py
@@ -280,64 +280,37 @@ class PromptConstructor:
         start = time.time()
         
         # Build all the components
-        instr_start = time.time()
         agent_instructions = self.agent_instructions_prompt
-        instr_end = time.time()
-        logger.debug(f"Time taken for agent instructions: {instr_end - instr_start:.4f}s")
-        
-        persona_start = time.time()
         agent_persona = self.agent_persona_prompt
-        persona_end = time.time()
-        logger.debug(f"Time taken for agent persona: {persona_end - persona_start:.4f}s")
-        
-        q_instr_start = time.time()
         question_instructions = self.question_instructions_prompt
-        q_instr_end = time.time()
-        logger.debug(f"Time taken for question instructions: {q_instr_end - q_instr_start:.4f}s")
-        
-        memory_start = time.time()
         prior_question_memory = self.prior_question_memory_prompt
-        memory_end = time.time()
-        logger.debug(f"Time taken for prior question memory: {memory_end - memory_start:.4f}s")
-
+        
         # Get components dict
         components = {
             "agent_instructions": agent_instructions.text,
             "agent_persona": agent_persona.text,
             "question_instructions": question_instructions.text,
             "prior_question_memory": prior_question_memory.text,
-        }
-
-        # Use PromptPlan's get_prompts method
-        plan_start = time.time()
-        
+        }        
         # Get arranged components first
         arranged = self.prompt_plan.arrange_components(**components)
         
         prompts = self.prompt_plan.get_prompts(**components)
-
-        plan_end = time.time()
-        logger.debug(f"Time taken for prompt processing: {plan_end - plan_start:.4f}s")
         
         # Handle file keys if present
         if hasattr(self, 'question_file_keys') and self.question_file_keys:
-            files_start = time.time()
             files_list = []
             for key in self.question_file_keys:
                 files_list.append(self.scenario[key])
             prompts["files_list"] = files_list
-            files_end = time.time()
-            logger.debug(f"Time taken for file key processing: {files_end - files_start:.4f}s")
         
-        end = time.time()
-        logger.debug(f"Total time in get_prompts: {end - start:.4f}s")
         return prompts
 
 
-def _process_prompt(args):
-    """Helper function to process a single prompt list with its replacements."""
-    prompt_list, replacements = args
-    return prompt_list.reduce()
+# def _process_prompt(args):
+#     """Helper function to process a single prompt list with its replacements."""
+#     prompt_list, replacements = args
+#     return prompt_list.reduce()
 
 
 if __name__ == '__main__':

--- a/edsl/agents/QuestionInstructionPromptBuilder.py
+++ b/edsl/agents/QuestionInstructionPromptBuilder.py
@@ -21,17 +21,33 @@ class QuestionInstructionPromptBuilder:
 
     @classmethod
     def from_prompt_constructor(cls, prompt_constructor: "PromptConstructor"):
-        
+
         model = prompt_constructor.model
         survey = prompt_constructor.survey
         question = prompt_constructor.question
         scenario = prompt_constructor.scenario
         prior_answers_dict = prompt_constructor.prior_answers_dict()
         agent = prompt_constructor.agent
-        return cls(prompt_constructor, model, survey, question, scenario, prior_answers_dict, agent)
+        return cls(
+            prompt_constructor,
+            model,
+            survey,
+            question,
+            scenario,
+            prior_answers_dict,
+            agent,
+        )
 
-    def __init__(self, prompt_constructor: "PromptConstructor", model:"Model", survey:"Survey", question:"QuestionBase", scenario:"Scenario", prior_answers_dict:Dict[str, Any], agent:"Agent"):
-        #self.prompt_constructor = prompt_constructor
+    def __init__(
+        self,
+        prompt_constructor: "PromptConstructor",
+        model: "Model",
+        survey: "Survey",
+        question: "QuestionBase",
+        scenario: "Scenario",
+        prior_answers_dict: Dict[str, Any],
+        agent: "Agent",
+    ):
 
         self.qtrb = QTRB(scenario, question, prior_answers_dict, agent)
 
@@ -41,7 +57,6 @@ class QuestionInstructionPromptBuilder:
         self.agent = agent
         self.scenario = scenario
         self.prior_answers_dict = prior_answers_dict
-
 
     def build(self) -> Prompt:
         """Builds the complete question instructions prompt with all necessary components.
@@ -90,19 +105,23 @@ class QuestionInstructionPromptBuilder:
         """
         # Create base prompt
         base_prompt = self._create_base_prompt()
-        
+
         # Enrich with options
-        enriched_prompt = self._enrich_with_question_options(prompt_data=base_prompt, scenario=self.scenario, prior_answers_dict=self.prior_answers_dict)
-        
+        enriched_prompt = self._enrich_with_question_options(
+            prompt_data=base_prompt,
+            scenario=self.scenario,
+            prior_answers_dict=self.prior_answers_dict,
+        )
+
         # Render prompt
         rendered_prompt = self._render_prompt(enriched_prompt)
-        
+
         # Validate template variables
         self._validate_template_variables(rendered_prompt)
-        
+
         # Append survey instructions
         final_prompt = self._append_survey_instructions(rendered_prompt)
-        
+
         return final_prompt
 
     def _create_base_prompt(self) -> Dict[str, Union[Prompt, Dict[str, Any]]]:
@@ -123,7 +142,9 @@ class QuestionInstructionPromptBuilder:
         }
 
     @staticmethod
-    def _process_question_options(question_data: Dict, scenario: 'Scenario', prior_answers_dict: Dict) -> Dict:
+    def _process_question_options(
+        question_data: Dict, scenario: "Scenario", prior_answers_dict: Dict
+    ) -> Dict:
         """Processes and replaces question options in the question data if they exist.
 
         The question_options could be intended to be replaced with data from a scenario or prior answers.
@@ -144,16 +165,18 @@ class QuestionInstructionPromptBuilder:
         """
         if "question_options" in question_data:
             from edsl.agents.question_option_processor import QuestionOptionProcessor
-            
-            question_options = (QuestionOptionProcessor(scenario, prior_answers_dict)
-                                .get_question_options(question_data=question_data)
-            )
+
+            question_options = QuestionOptionProcessor(
+                scenario, prior_answers_dict
+            ).get_question_options(question_data=question_data)
             question_data["question_options"] = question_options
-            
+
         return question_data
 
     @staticmethod
-    def _enrich_with_question_options(prompt_data: Dict, scenario: 'Scenario', prior_answers_dict: Dict) -> Dict:
+    def _enrich_with_question_options(
+        prompt_data: Dict, scenario: "Scenario", prior_answers_dict: Dict
+    ) -> Dict:
         """Enriches the prompt data with processed question options if they exist.
 
         Args:
@@ -164,8 +187,10 @@ class QuestionInstructionPromptBuilder:
         Returns:
             Dict: Enriched prompt data
         """
-        prompt_data["data"] = QuestionInstructionPromptBuilder._process_question_options(
-            prompt_data["data"], scenario, prior_answers_dict
+        prompt_data["data"] = (
+            QuestionInstructionPromptBuilder._process_question_options(
+                prompt_data["data"], scenario, prior_answers_dict
+            )
         )
         return prompt_data
 
@@ -179,10 +204,8 @@ class QuestionInstructionPromptBuilder:
             Prompt: Rendered instructions
         """
         # Build replacement dict
-        replacement_dict = self.qtrb.build_replacement_dict(
-            prompt_data["data"]
-        )
-        
+        replacement_dict = self.qtrb.build_replacement_dict(prompt_data["data"])
+
         # Render with dict
         return prompt_data["prompt"].render(replacement_dict)
 
@@ -212,7 +235,9 @@ class QuestionInstructionPromptBuilder:
         """
         for question_name in self.survey.question_names:
             if question_name in undefined_vars:
-                logging.warning(f"Question name found in undefined_template_variables: {question_name}")
+                logging.warning(
+                    f"Question name found in undefined_template_variables: {question_name}"
+                )
 
     def _append_survey_instructions(self, rendered_prompt: Prompt) -> Prompt:
         """Appends any relevant survey instructions to the rendered prompt.
@@ -239,4 +264,5 @@ class QuestionInstructionPromptBuilder:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/edsl/agents/QuestionInstructionPromptBuilder.py
+++ b/edsl/agents/QuestionInstructionPromptBuilder.py
@@ -17,15 +17,16 @@ class QuestionInstructionPromptBuilder:
         model = prompt_constructor.model
         survey = prompt_constructor.survey
         question = prompt_constructor.question
-        return cls(prompt_constructor, model, survey, question)
+        scenario = prompt_constructor.scenario
+        return cls(prompt_constructor, model, survey, question, scenario)
 
-    def __init__(self, prompt_constructor: "PromptConstructor", model:"Model", survey:"Survey", question:"QuestionBase"):
+    def __init__(self, prompt_constructor: "PromptConstructor", model:"Model", survey:"Survey", question:"QuestionBase", scenario:"Scenario"):
         self.prompt_constructor = prompt_constructor
         self.model = model
         self.survey = survey
         self.question = question
 
-        self.scenario = prompt_constructor.scenario
+        self.scenario = scenario
         self.prior_answers_dict = prompt_constructor.prior_answers_dict()
 
         self.qtrb = QTRB.from_prompt_constructor(self.prompt_constructor)

--- a/edsl/agents/QuestionInstructionPromptBuilder.py
+++ b/edsl/agents/QuestionInstructionPromptBuilder.py
@@ -1,7 +1,15 @@
-from typing import Dict, List, Set, Any, Union
+from typing import Dict, List, Set, Any, Union, TYPE_CHECKING
 from warnings import warn
 import logging
 from edsl.prompts.Prompt import Prompt
+
+if TYPE_CHECKING:
+    from edsl.agents.PromptConstructor import PromptConstructor
+    from edsl import Model
+    from edsl import Survey
+    from edsl.questions.QuestionBase import QuestionBase
+    from edsl import Scenario
+    from edsl import Agent
 
 from edsl.agents.QuestionTemplateReplacementsBuilder import (
     QuestionTemplateReplacementsBuilder as QTRB,
@@ -18,18 +26,21 @@ class QuestionInstructionPromptBuilder:
         survey = prompt_constructor.survey
         question = prompt_constructor.question
         scenario = prompt_constructor.scenario
-        return cls(prompt_constructor, model, survey, question, scenario)
+        prior_answers_dict = prompt_constructor.prior_answers_dict()
+        agent = prompt_constructor.agent
+        return cls(prompt_constructor, model, survey, question, scenario, prior_answers_dict, agent)
 
-    def __init__(self, prompt_constructor: "PromptConstructor", model:"Model", survey:"Survey", question:"QuestionBase", scenario:"Scenario"):
-        self.prompt_constructor = prompt_constructor
+    def __init__(self, prompt_constructor: "PromptConstructor", model:"Model", survey:"Survey", question:"QuestionBase", scenario:"Scenario", prior_answers_dict:Dict[str, Any], agent:"Agent"):
+        #self.prompt_constructor = prompt_constructor
+
+        self.qtrb = QTRB(scenario, question, prior_answers_dict, agent)
+
         self.model = model
         self.survey = survey
         self.question = question
-
+        self.agent = agent
         self.scenario = scenario
-        self.prior_answers_dict = prompt_constructor.prior_answers_dict()
-
-        self.qtrb = QTRB.from_prompt_constructor(self.prompt_constructor)
+        self.prior_answers_dict = prior_answers_dict
 
 
     def build(self) -> Prompt:

--- a/edsl/agents/QuestionTemplateReplacementsBuilder.py
+++ b/edsl/agents/QuestionTemplateReplacementsBuilder.py
@@ -125,6 +125,14 @@ class QuestionTemplateReplacementsBuilder:
     def _scenario_replacements(
         self, replacement_string: str = "<see file {key}>"
     ) -> dict[str, Any]:
+        """
+        >>> from edsl import Scenario
+        >>> from edsl import QuestionFreeText; 
+        >>> q = QuestionFreeText(question_text = "How are you {{ scenario.friend }}?", question_name = "test")
+        >>> s = Scenario({'friend':'john'}) 
+        >>> q.by(s).prompts().select('user_prompt')
+        Dataset([{'user_prompt': [Prompt(text=\"""How are you john?\""")]}])
+        """
         # File references dictionary
         file_refs = {
             key: replacement_string.format(key=key) for key in self.scenario_file_keys()
@@ -134,7 +142,9 @@ class QuestionTemplateReplacementsBuilder:
         scenario_items = {
             k: v for k, v in self.scenario.items() if k not in self.scenario_file_keys()
         }
-        return {**file_refs, **scenario_items}
+        scenario_items_with_prefix = {'scenario': scenario_items}
+        
+        return {**file_refs, **scenario_items, **scenario_items_with_prefix}
 
     @staticmethod
     def _question_data_replacements(
@@ -169,7 +179,7 @@ class QuestionTemplateReplacementsBuilder:
         >>> q = QuestionMultipleChoice(question_text="What do you think of this file: {{ file1 }}, {{ first_name}}", question_name = "q0", question_options = ["good", "bad"])
         >>> qtrb = QuestionTemplateReplacementsBuilder(scenario = s, question = q, prior_answers_dict = {'q0': 'q0'}, agent = "agent")
         >>> qtrb.build_replacement_dict(q.data)
-        {'file1': '<see file file1>', 'first_name': 'John', 'use_code': False, 'include_comment': True, 'question_name': 'q0', 'question_text': 'What do you think of this file: {{ file1 }}, {{ first_name}}', 'question_options': ['good', 'bad'], 'q0': 'q0', 'agent': 'agent'}
+        {'file1': '<see file file1>', 'first_name': 'John', 'scenario': {'first_name': 'John'}, 'use_code': False, 'include_comment': True, 'question_name': 'q0', 'question_text': 'What do you think of this file: {{ file1 }}, {{ first_name}}', 'question_options': ['good', 'bad'], 'q0': 'q0', 'agent': 'agent'}
 
 
         """

--- a/edsl/jobs/AnswerQuestionFunctionConstructor.py
+++ b/edsl/jobs/AnswerQuestionFunctionConstructor.py
@@ -66,10 +66,14 @@ class SkipHandler:
             )
         )
 
+
         def cancel_between(start, end):
             """Cancel the tasks for questions between the start and end indices."""
             for i in range(start, end):
-                self.interview.tasks[i].cancel()
+                #print(f"Cancelling task {i}")
+                #self.interview.tasks[i].cancel()
+                #self.interview.tasks[i].set_result("skipped")
+                self.interview.skip_flags[self.interview.survey.questions[i].question_name] = True
 
         if (next_question_index := next_question.next_q) == EndOfSurvey:
             cancel_between(
@@ -79,6 +83,8 @@ class SkipHandler:
 
         if next_question_index > (current_question_index + 1):
             cancel_between(current_question_index + 1, next_question_index)
+
+        
 
 
 class AnswerQuestionFunctionConstructor:
@@ -160,6 +166,11 @@ class AnswerQuestionFunctionConstructor:
         )
         async def attempt_answer():
             invigilator = self.invigilator_fetcher(question)
+
+            if self.interview.skip_flags.get(question.question_name, False):
+                return invigilator.get_failed_task_result(
+                    failure_reason="Question skipped."
+                )
 
             if self.skip_handler.should_skip(question):
                 return invigilator.get_failed_task_result(

--- a/edsl/jobs/interviews/Interview.py
+++ b/edsl/jobs/interviews/Interview.py
@@ -238,9 +238,6 @@ class Interview:
         >>> run_config = RunConfig(parameters = RunParameters(), environment = RunEnvironment())
         >>> run_config.parameters.stop_on_exception = True
         >>> result, _ = asyncio.run(i.async_conduct_interview(run_config))
-        Traceback (most recent call last):
-        ...
-        asyncio.exceptions.CancelledError
         """
         from edsl.jobs.Jobs import RunConfig, RunParameters, RunEnvironment
 

--- a/edsl/jobs/interviews/Interview.py
+++ b/edsl/jobs/interviews/Interview.py
@@ -262,6 +262,8 @@ class Interview:
         if model_buckets is None or hasattr(self.agent, "answer_question_directly"):
             model_buckets = ModelBuckets.infinity_bucket()
 
+        self.skip_flags = {q.question_name: False for q in self.survey.questions}
+
         # was "self.tasks" - is that necessary?
         self.tasks = self.task_manager.build_question_tasks(
             answer_func=AnswerQuestionFunctionConstructor(
@@ -310,6 +312,10 @@ class Interview:
         def handle_task(task, invigilator):
             try:
                 result: Answers = task.result()
+                if result == "skipped":
+                    result = invigilator.get_failed_task_result(
+                        failure_reason="Task was skipped."
+                    )
             except asyncio.CancelledError as e:  # task was cancelled
                 result = invigilator.get_failed_task_result(
                     failure_reason="Task was cancelled."

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -379,8 +379,10 @@ class LanguageModel(
         cached_response, cache_key = cache.fetch(**cache_call_params)
 
         if cache_used := cached_response is not None:
+ #           print("cache used")
             response = json.loads(cached_response)
         else:
+#            print("cache not used")
             f = (
                 self.remote_async_execute_model_call
                 if hasattr(self, "remote") and self.remote
@@ -400,7 +402,10 @@ class LanguageModel(
             )  # store the response in the cache
             assert new_cache_key == cache_key  # should be the same
 
+        #breakpoint()
+
         cost = self.cost(response)
+        #breakpoint()
         return ModelResponse(
             response=response,
             cache_used=cache_used,
@@ -465,6 +470,7 @@ class LanguageModel(
             model_outputs=model_outputs,
             edsl_dict=edsl_dict,
         )
+        #breakpoint()
         return agent_response_dict
 
     get_response = sync_wrapper(async_get_response)

--- a/edsl/questions/question_base_gen_mixin.py
+++ b/edsl/questions/question_base_gen_mixin.py
@@ -140,6 +140,8 @@ class QuestionBaseGenMixin:
             k: v for k, v in replacement_dict.items() if not isinstance(v, Scenario)
         }
 
+        strings_only_replacement_dict['scenario'] = strings_only_replacement_dict
+
         def _has_unrendered_variables(template_str: str, env: Environment) -> bool:
             """Check if the template string has any unrendered variables."""
             if not isinstance(template_str, str):


### PR DESCRIPTION
The problem was the skipping a question (say q1) was causing other questions in the "gather" to be cancelled as well (even though the question was actually answered). The q0 task when the return a cancelled exception when the interview results are being collected, at which point the "EDSResults" was just getting populated with the boilerplate we use for a real cancelled task. Good catch @onmyraedar !

It's now fixed by not cancelling skipped tasks directly but rather maintain a list of questions to skip and checking it before executing the task - if it's meant to be skipped, the boilerplate  skipped question stuff gets added. 