### PR TITLE
Specify tempfile encoding as utf-8

### DIFF
--- a/edsl/scenarios/FileStore.py
+++ b/edsl/scenarios/FileStore.py
@@ -15,7 +15,6 @@ import time
 from typing import Dict, Any, IO, Optional, List, Union, Literal
 
 
-
 class FileStore(Scenario):
     __documentation__ = "https://docs.expectedparrot.com/en/latest/filestore.html"
 
@@ -342,7 +341,7 @@ class FileStore(Scenario):
         # Create a named temporary file
         mode = "wb" if self.binary else "w"
         temp_file = tempfile.NamedTemporaryFile(
-            delete=False, suffix="." + suffix, mode=mode
+            delete=False, suffix="." + suffix, encoding="utf-8", mode=mode
         )
 
         if self.binary:


### PR DESCRIPTION
Currently, FileStore objects are not decoded correctly on Windows:
![image](https://github.com/user-attachments/assets/652b828e-fc17-4d70-8f0a-6f94a0664db6)

I think it's a cross-platform encoding issue - specifying the encoding as UTF-8 seems to fix the error:
![image](https://github.com/user-attachments/assets/ec8d8408-4cc9-4537-9cdf-1f11c3d7afff)

Someone on Mac should also check to make sure this still works for them.