### PR TITLE
Use relative imports within the EDSL package

### DIFF
--- a/edsl/caching/cache.py
+++ b/edsl/caching/cache.py
@@ -7,7 +7,7 @@ import json
 import os
 import warnings
 from typing import Optional, Union, TYPE_CHECKING
-from edsl.base import Base
+from ..base import Base
 
 from ..utilities import remove_edsl_version, dict_hash
 from .exceptions import CacheError
@@ -418,7 +418,7 @@ class Cache(Base):
     def to_dict(self, add_edsl_version=True) -> dict:
         d = {k: v.to_dict() for k, v in self.data.items()}
         if add_edsl_version:
-            from edsl import __version__
+            from .. import __version__
 
             d["edsl_version"] = __version__
             d["edsl_class_name"] = "Cache"

--- a/edsl/config.py
+++ b/edsl/config.py
@@ -3,7 +3,7 @@
 import os
 import platformdirs
 from dotenv import load_dotenv, find_dotenv
-from edsl.exceptions.configuration import (
+from .exceptions.configuration import (
     InvalidEnvironmentVariableError,
     MissingEnvironmentVariableError,
 )

--- a/edsl/conversation/Conversation.py
+++ b/edsl/conversation/Conversation.py
@@ -2,13 +2,13 @@ from collections import UserList
 import asyncio
 import inspect
 from typing import Optional, Callable
-from edsl import Agent, QuestionFreeText, Results, AgentList, ScenarioList, Scenario
-from edsl.questions import QuestionBase
-from edsl.results.Result import Result
+from .. import Agent, QuestionFreeText, Results, AgentList, ScenarioList, Scenario
+from ..questions import QuestionBase
+from ..results.Result import Result
 from jinja2 import Template
-from edsl.caching import Cache
+from ..caching import Cache
 
-from edsl.conversation.next_speaker_utilities import (
+from .next_speaker_utilities import (
     default_turn_taking_generator,
     speaker_closure,
 )
@@ -83,7 +83,7 @@ class Conversation:
 
         self.agent_list = agent_list
 
-        from edsl import Model
+        from .. import Model
 
         for agent in self.agent_list:
             if not hasattr(agent, "model"):
@@ -200,7 +200,7 @@ What do you say next?"""
         """Get the next statement from the speaker."""
         q = self.next_statement_question
         # assert q.parameters == {"agent_name", "conversation"}, q.parameters
-        from edsl import Scenario
+        from .. import Scenario
 
         if self.per_round_message_template is None:
             round_message = None

--- a/edsl/conversation/car_buying.py
+++ b/edsl/conversation/car_buying.py
@@ -1,6 +1,6 @@
-from edsl import Agent, AgentList, QuestionFreeText
-from edsl import Cache
-from edsl.conversation.Conversation import Conversation, ConversationList
+from .. import Agent, AgentList, QuestionFreeText
+from .. import Cache
+from .Conversation import Conversation, ConversationList
 
 a1 = Agent(
     name="Alice",
@@ -46,7 +46,7 @@ q = QuestionFreeText(
     question_name="car_brand",
 )
 
-from edsl import QuestionList
+from .. import QuestionList
 
 q_actors = QuestionList(
     question_text="""This was a conversation about buying a car: {{ transcript }}. 

--- a/edsl/conversation/chips.py
+++ b/edsl/conversation/chips.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
-from edsl import Agent, AgentList, QuestionFreeText
-from edsl import Cache
-from edsl import QuestionList
-from edsl import Model
+from .. import Agent, AgentList, QuestionFreeText
+from .. import Cache
+from .. import QuestionList
+from .. import Model
 
-from edsl.conversation.Conversation import Conversation, ConversationList
+from .Conversation import Conversation, ConversationList
 
 m = Model("gemini-1.5-flash")
 
@@ -79,7 +79,7 @@ with Cache() as c:
         question_name="actors",
     )
 
-    from edsl import QuestionList
+    from .. import QuestionList
 
     q_transfers = QuestionList(
         question_text="""This was a conversation/negotiation: {{ transcript }}. 

--- a/edsl/inference_services/available_model_fetcher.py
+++ b/edsl/inference_services/available_model_fetcher.py
@@ -189,7 +189,7 @@ class AvailableModelFetcher:
 
 
 def main():
-    from edsl.inference_services.OpenAIService import OpenAIService
+    from .services.open_ai_service import OpenAIService
 
     af = AvailableModelFetcher([OpenAIService()], {}, verbose=True)
     # print(af.available(service="openai"))
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     doctest.testmod(optionflags=doctest.ELLIPSIS)
     # main()
 
-    # from edsl.inference_services.OpenAIService import OpenAIService
+    # from .services.open_ai_service import OpenAIService
 
     # af = AvailableModelFetcher([OpenAIService()], {}, verbose=True)
     # # print(af.available(service="openai"))

--- a/edsl/instructions/instruction.py
+++ b/edsl/instructions/instruction.py
@@ -1,7 +1,7 @@
 from typing import Union, Optional, List, Generator, Dict
-from edsl.utilities.remove_edsl_version import remove_edsl_version
-from edsl.base import RepresentationMixin
-#from edsl.surveys import Survey
+from ..utilities.remove_edsl_version import remove_edsl_version
+from ..base import RepresentationMixin
+#from ..surveys import Survey
 
 
 class Instruction(RepresentationMixin):
@@ -30,19 +30,19 @@ class Instruction(RepresentationMixin):
             "preamble": self.preamble,
         }
         if add_edsl_version:
-            from edsl import __version__
+            from .. import __version__
 
             d["edsl_version"] = __version__
             d["edsl_class_name"] = "Instruction"
         return d
 
     def add_question(self, question) -> "Survey":
-        from edsl.surveys import Survey
+        from ..surveys import Survey
         return Survey([self, question])
 
     def __hash__(self) -> int:
         """Return a hash of the question."""
-        from edsl.utilities.utilities import dict_hash
+        from ..utilities.utilities import dict_hash
 
         return dict_hash(self.to_dict(add_edsl_version=False))
 

--- a/edsl/interviews/ReportErrors.py
+++ b/edsl/interviews/ReportErrors.py
@@ -1,7 +1,7 @@
 import json
 import requests
 import threading
-from edsl.coop import Coop
+from ..coop import Coop
 
 
 class ReportErrors:
@@ -41,7 +41,7 @@ class ReportErrors:
 
 
 def main():
-    from edsl.jobs.interviews.ReportErrors import ReportErrors
+    # Use the class directly since we're already in the module
 
     class TaskHistory:
         def __init__(self, data):

--- a/edsl/interviews/answering_function.py
+++ b/edsl/interviews/answering_function.py
@@ -20,7 +20,7 @@ from .exception_tracking import InterviewExceptionEntry
 
 
 class RetryConfig:
-    from edsl.config import CONFIG
+    from ..config import CONFIG
 
     EDSL_BACKOFF_START_SEC = float(CONFIG.get("EDSL_BACKOFF_START_SEC"))
     EDSL_BACKOFF_MAX_SEC = float(CONFIG.get("EDSL_BACKOFF_MAX_SEC"))

--- a/edsl/interviews/interview.py
+++ b/edsl/interviews/interview.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from ..agents import Agent
     from ..surveys import Survey
     from ..scenarios import Scenario
-    from ..data.Cache import Cache
+    from ..caching import Cache
     from ..language_models import LanguageModel
     from ..tokens import InterviewTokenUsage
     from ..invigilators import InvigilatorBase

--- a/edsl/interviews/interview_task_manager.py
+++ b/edsl/interviews/interview_task_manager.py
@@ -3,10 +3,10 @@ import asyncio
 from typing import Any, Type, List, Generator, Optional, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...questions import QuestionBase
+    from ..questions import QuestionBase
     from ..tokens import InterviewTokenUsage
-    from ..interviews import InterviewStatusDictionary
-    from ..interviews import InterviewStatusLog
+    from . import InterviewStatusDictionary
+    from . import InterviewStatusLog
 
 
 class InterviewTaskManager:
@@ -14,7 +14,7 @@ class InterviewTaskManager:
 
     def __init__(self, survey, iteration=0):
         from ..tasks import TaskCreators
-        from ..interviews import InterviewStatusLog
+        from . import InterviewStatusLog
 
         self.survey = survey
         self.iteration = iteration

--- a/edsl/jobs/fetch_invigilator.py
+++ b/edsl/jobs/fetch_invigilator.py
@@ -1,10 +1,10 @@
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from edsl.questions.QuestionBase import QuestionBase
-    from edsl.agents.InvigilatorBase import InvigilatorBase
-    from edsl.language_models.key_management.KeyLookup import KeyLookup
-    from edsl.jobs.interviews.Interview import Interview
+    from ..questions import QuestionBase
+    from ..agents import InvigilatorBase
+    from ..language_models.key_management import KeyLookup
+    from .interviews import Interview
 
 
 class FetchInvigilator:

--- a/edsl/key_management/key_lookup.py
+++ b/edsl/key_management/key_lookup.py
@@ -1,7 +1,7 @@
 from collections import UserDict
 from dataclasses import asdict
 
-from edsl.enums import service_to_api_keyname
+from ..enums import service_to_api_keyname
 
 from .models import LanguageModelInput
 

--- a/edsl/key_management/key_lookup_builder.py
+++ b/edsl/key_management/key_lookup_builder.py
@@ -63,7 +63,7 @@ class KeyLookupBuilder:
         fetch_order: Optional[tuple[str]] = None,
         coop: Optional["Coop"] = None,
     ):
-        from edsl.coop import Coop
+        from ..coop import Coop
 
         # Fetch order goes from lowest priority to highest priority
         if fetch_order is None:
@@ -170,7 +170,7 @@ class KeyLookupBuilder:
         return dict(list(self.coop.fetch_rate_limit_config_vars().items()))
 
     def _config_key_value_pairs(self):
-        from edsl.config import CONFIG
+        from ..config import CONFIG
 
         return dict(list(CONFIG.items()))
 

--- a/edsl/language_models/repair.py
+++ b/edsl/language_models/repair.py
@@ -22,7 +22,7 @@ async def async_repair(
         return valid_dict, success
 
     try:
-        from edsl.utilities.repair_functions import extract_json_from_string
+        from ..utilities.repair_functions import extract_json_from_string
 
         valid_dict = extract_json_from_string(s)
         success = True
@@ -32,11 +32,11 @@ async def async_repair(
     else:
         return valid_dict, success
 
-    from edsl.language_models.model import Model
+    from .model import Model
 
     m = Model()
 
-    from edsl.questions.QuestionExtract import QuestionExtract
+    from ..questions.QuestionExtract import QuestionExtract
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)

--- a/edsl/notebooks/notebook.py
+++ b/edsl/notebooks/notebook.py
@@ -5,8 +5,8 @@ import json
 from typing import Dict, List, Optional, Union
 from uuid import uuid4
 
-from edsl.base import Base
-from edsl.utilities.decorators import remove_edsl_version
+from ..base import Base
+from ..utilities.decorators import remove_edsl_version
 
 class Notebook(Base):
     """
@@ -102,7 +102,7 @@ class Notebook(Base):
         """
         Allow the model to be used as a key in a dictionary.
         """
-        from edsl.utilities.utilities import dict_hash
+        from ..utilities.utilities import dict_hash
 
         return dict_hash(self.data["cells"])
 
@@ -112,7 +112,7 @@ class Notebook(Base):
         """
         d = {"name": self.name, "data": self.data}
         if add_edsl_version:
-            from edsl import __version__
+            from .. import __version__
 
             d["edsl_version"] = __version__
             d["edsl_class_name"] = self.__class__.__name__
@@ -241,7 +241,7 @@ class Notebook(Base):
         Return the code that could be used to create this Notebook.
         """
         lines = []
-        lines.append("from edsl import Notebook")
+        lines.append("from edsl import Notebook")  # Keep as absolute for code generation
         lines.append(f'nb = Notebook(data={self.data}, name="""{self.name}""")')
         return lines
 
@@ -257,6 +257,6 @@ class Notebook(Base):
 
 
 if __name__ == "__main__":
-    from edsl import Notebook
+    from .. import Notebook
     notebook = Notebook.example()
     assert notebook == notebook.from_dict(notebook.to_dict())

--- a/edsl/questions/derived/question_likert_five.py
+++ b/edsl/questions/derived/question_likert_five.py
@@ -145,8 +145,7 @@ class QuestionLikertFive(QuestionMultipleChoice):
 
 def main():
     """Test QuestionLikertFive."""
-    from edsl.questions.derived.QuestionLikertFive import QuestionLikertFive
-
+    # Use the class directly since we're already in the module
     q = QuestionLikertFive.example()
     q.question_text
     q.question_options

--- a/edsl/questions/derived/question_yes_no.py
+++ b/edsl/questions/derived/question_yes_no.py
@@ -54,8 +54,7 @@ class QuestionYesNo(QuestionMultipleChoice):
 
 def main():
     """Create an example of a yes/no question and demonstrate its functionality."""
-    from edsl.questions.derived.QuestionYesNo import QuestionYesNo
-
+    # Use the class directly since we're already in the module
     q = QuestionYesNo.example()
     q.question_text
     q.question_options

--- a/edsl/utilities/repair_functions.py
+++ b/edsl/utilities/repair_functions.py
@@ -1,5 +1,5 @@
 import json
-from edsl.utilities.utilities import valid_json
+from .utilities import valid_json
 
 
 def extract_json_from_string(s):


### PR DESCRIPTION
## Summary
- Convert absolute imports to relative imports within the edsl package
- Fix deep imports that bypass `__init__.py` files
- Fix circular imports in several modules

## Test plan
- No functional changes, only import structure changes
- All tests should continue to pass
- Package should work correctly when installed from PyPI

🤖 Generated with [Claude Code](https://claude.ai/code)