### PR TITLE
conjure as plugin

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -68,5 +68,61 @@ from .study import __all__ as study_all
 from .study import *
 __all__.extend(study_all)
 
+# Load plugins
+try:
+    logger.info("Loading plugins")
+    import pluggy
+    import pkg_resources
+    
+    logger.info("Available edsl entrypoints: %s", [ep for ep in pkg_resources.iter_entry_points("edsl")])
+    
+    # Define the plugin hooks specification
+    hookspec = pluggy.HookspecMarker("edsl")
+    
+    class EDSLHookSpecs:
+        """Hook specifications for edsl plugins."""
+        
+        @hookspec
+        def conjure_plugin(self):
+            """Return the Conjure class for integration with edsl."""
+    
+    # Create plugin manager and register specs
+    pm = pluggy.PluginManager("edsl")
+    pm.add_hookspecs(EDSLHookSpecs)
+    
+    # Load all plugins
+    logger.info("Loading setuptools entrypoints...")
+    pm.load_setuptools_entrypoints("edsl")
+    
+    # Get registered plugins 
+    registered_plugins = [
+        plugin_name 
+        for plugin_name, _ in pm.list_name_plugin()
+        if plugin_name != "EDSLHookSpecs"
+    ]
+    logger.info("Registered plugins: %s", registered_plugins)
+    
+    # Get plugins and add to __all__
+    logger.info("Calling conjure_plugin hook...")
+    try:
+        results = pm.hook.conjure_plugin()
+        logger.info("Results: %s", results)
+        if results:
+            # Get the Conjure class from the plugin
+            Conjure = results[0]
+            globals()["Conjure"] = Conjure
+            __all__.append("Conjure")
+            logger.info("Loaded Conjure plugin")
+    except Exception as e:
+        logger.error("Error calling conjure_plugin hook: %s", e)
+except ImportError as e:
+    # pluggy not available
+    logger.info("pluggy not available, skipping plugin loading: %s", e)
+    logger.debug("pluggy not available, skipping plugin loading: %s", e)
+except Exception as e:
+    # Error loading plugins
+    logger.error("Error loading plugins: %s", e)
+    logger.debug("Error loading plugins: %s", e)
+
 # Now that all modules are loaded, configure logging from the config
 logger.configure_from_config()

--- a/edsl/results/results_selector.py
+++ b/edsl/results/results_selector.py
@@ -106,7 +106,9 @@ class Selector:
             to_fetch = self._get_columns_to_fetch(columns)
             new_data = self._fetch_data(to_fetch)
         except ResultsColumnNotFoundError as e:
-            if is_notebook():
+            # Check is_notebook with explicit import to ensure mock works
+            from edsl.utilities import is_notebook as is_notebook_check
+            if is_notebook_check():
                 print("Error:", e, file=sys.stderr)
                 return None
             else:

--- a/edsl/results/results_selector.py
+++ b/edsl/results/results_selector.py
@@ -11,8 +11,8 @@ from typing import Union, List, Dict, Any, Optional, Tuple, Callable
 import sys
 from collections import defaultdict
 
-from ..dataset import Dataset
-from ..utilities import is_notebook
+# Import is_notebook but defer Dataset import to avoid potential circular imports
+from edsl.utilities import is_notebook
 
 from .exceptions import ResultsColumnNotFoundError
 
@@ -67,7 +67,7 @@ class Selector:
         self.columns = columns
         self.items_in_order = []  # Tracks column order for consistent output
 
-    def select(self, *columns: Union[str, List[str]]) -> Optional[Dataset]:
+    def select(self, *columns: Union[str, List[str]]) -> Optional["Dataset"]:
         """
         Select specific columns from the data and return as a Dataset.
         
@@ -111,6 +111,9 @@ class Selector:
                 return None
             else:
                 raise e
+                
+        # Import Dataset here to avoid circular import issues
+        from edsl.dataset import Dataset
         return Dataset(new_data)
 
     def _normalize_columns(self, columns: Union[str, List[str]]) -> Tuple[str, ...]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -5989,4 +5989,4 @@ screenshots = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.1,<3.13"
-content-hash = "56aba716cd1d2bd7b07ee8af70df8dd46901ebfe6704ff3f481892a416f71727"
+content-hash = "f858c3eafaa22f2031753c3f058d469e349a6397d1fe492e17cb43711609dfd6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ tabulate = "^0.9.0"
 pypdf2 = "^3.0.1"
 python-pptx = "^1.0.2"
 platformdirs = "^4.3.6"
+pluggy = "^1.3.0"
 
 [tool.poetry.extras]
 screenshots = [ "playwright",]

--- a/tests/results/test_ResultsSelector.py
+++ b/tests/results/test_ResultsSelector.py
@@ -260,7 +260,7 @@ class TestSelector(unittest.TestCase):
         with patch.object(self.selector, '_normalize_columns') as mock_normalize:
             with patch.object(self.selector, '_get_columns_to_fetch') as mock_get_cols:
                 with patch.object(self.selector, '_fetch_data') as mock_fetch:
-                    with patch('edsl.results.results_selector.Dataset') as mock_dataset:
+                    with patch('edsl.dataset.Dataset') as mock_dataset:
                         # Set up the mocks to return expected values
                         mock_normalize.return_value = ('question1',)
                         mock_get_cols.return_value = {'answer': ['question1']}
@@ -280,7 +280,7 @@ class TestSelector(unittest.TestCase):
         with patch.object(self.selector, '_normalize_columns') as mock_normalize:
             with patch.object(self.selector, '_get_columns_to_fetch') as mock_get_cols:
                 with patch.object(self.selector, '_fetch_data') as mock_fetch:
-                    with patch('edsl.results.results_selector.Dataset') as mock_dataset:
+                    with patch('edsl.dataset.Dataset') as mock_dataset:
                         # Set up the mocks to return expected values
                         mock_normalize.return_value = ('question1', 'name')
                         mock_get_cols.return_value = {'answer': ['question1'], 'agent': ['name']}
@@ -304,7 +304,7 @@ class TestSelector(unittest.TestCase):
         with patch.object(self.selector, '_normalize_columns') as mock_normalize:
             with patch.object(self.selector, '_get_columns_to_fetch') as mock_get_cols:
                 with patch.object(self.selector, '_fetch_data') as mock_fetch:
-                    with patch('edsl.results.results_selector.Dataset') as mock_dataset:
+                    with patch('edsl.dataset.Dataset') as mock_dataset:
                         # Set up the mocks to return expected values
                         mock_normalize.return_value = ('answer.*',)
                         mock_get_cols.return_value = {'answer': ['question1', 'question2']}
@@ -328,7 +328,7 @@ class TestSelector(unittest.TestCase):
         with patch.object(self.selector, '_normalize_columns') as mock_normalize:
             with patch.object(self.selector, '_get_columns_to_fetch') as mock_get_cols:
                 with patch.object(self.selector, '_fetch_data') as mock_fetch:
-                    with patch('edsl.results.results_selector.Dataset') as mock_dataset:
+                    with patch('edsl.dataset.Dataset') as mock_dataset:
                         # Set up the mocks to return expected values
                         mock_normalize.return_value = ('*.*',)
                         

--- a/tests/results/test_ResultsSelector.py
+++ b/tests/results/test_ResultsSelector.py
@@ -354,7 +354,7 @@ class TestSelector(unittest.TestCase):
                         mock_fetch.assert_called_once_with(to_fetch)
                         mock_dataset.assert_called_once_with(mock_data)
 
-    @patch("edsl.results.results_selector.is_notebook")
+    @patch("edsl.utilities.is_notebook")
     @patch("sys.stderr")
     def test_select_error_handling_notebook(self, mock_stderr, mock_is_notebook):
         """Test error handling in notebook environment."""
@@ -372,7 +372,7 @@ class TestSelector(unittest.TestCase):
             # Verify that None was returned
             self.assertIsNone(result)
 
-    @patch("edsl.results.results_selector.is_notebook")
+    @patch("edsl.utilities.is_notebook")
     def test_select_error_handling_non_notebook(self, mock_is_notebook):
         """Test error handling in non-notebook environment."""
         mock_is_notebook.return_value = False


### PR DESCRIPTION
This pull request includes several changes to improve the plugin system, avoid circular imports, and update tests accordingly. The most important changes include adding plugin loading functionality, deferring imports to prevent circular dependencies, and updating test cases to reflect these changes.

### Plugin System Enhancements:
* [`edsl/__init__.py`](diffhunk://#diff-754b7b610fcc8025cb5c0d434d25532db9e8be0085f4bf76c2bad5a4f5e2ec59R71-R126): Added functionality to load plugins using `pluggy`, including defining hook specifications and managing plugin registration and loading.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R53): Added `pluggy` as a dependency to support the new plugin system.

### Circular Import Prevention:
* [`edsl/results/results_selector.py`](diffhunk://#diff-5b393be02c7daf29c69360fcede9c7dba23c7a65ee3d403cba8b88ed461b76a8L14-R15): Deferred the import of `Dataset` to avoid potential circular imports and updated the `select` method to use a forward reference for the `Dataset` type. [[1]](diffhunk://#diff-5b393be02c7daf29c69360fcede9c7dba23c7a65ee3d403cba8b88ed461b76a8L14-R15) [[2]](diffhunk://#diff-5b393be02c7daf29c69360fcede9c7dba23c7a65ee3d403cba8b88ed461b76a8L70-R70) [[3]](diffhunk://#diff-5b393be02c7daf29c69360fcede9c7dba23c7a65ee3d403cba8b88ed461b76a8L109-R118)

### Test Updates:
* [`tests/results/test_ResultsSelector.py`](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL263-R263): Updated test cases to patch `Dataset` from `edsl.dataset` instead of `edsl.results.results_selector` and adjusted the import of `is_notebook` for better test isolation. [[1]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL263-R263) [[2]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL283-R283) [[3]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL307-R307) [[4]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL331-R331) [[5]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL357-R357) [[6]](diffhunk://#diff-ef9ec2862a5f5f150174433f367bb88e49350bac830abbe5b11e65c4e3ac10ceL375-R375)