### PR TITLE
Fix progress bar exception tracking

### DIFF
--- a/edsl/interviews/exception_tracking.py
+++ b/edsl/interviews/exception_tracking.py
@@ -5,6 +5,7 @@ import json
 
 from ..invigilators import InvigilatorBase
 
+
 class InterviewExceptionEntry:
     """Class to record an exception that occurred during the interview."""
 
@@ -218,7 +219,6 @@ class InterviewExceptionEntry:
         return cls(exception=exception, invigilator=invigilator)
 
 
-
 class InterviewExceptionCollection(UserDict):
     """A collection of exceptions that occurred during the interview."""
 
@@ -230,6 +230,14 @@ class InterviewExceptionCollection(UserDict):
     def unfixed_exceptions(self) -> list:
         """Return a list of unfixed exceptions."""
         return {k: v for k, v in self.data.items() if k not in self.fixed}
+
+    def num_exceptions(self) -> int:
+        """Return the total number of exceptions."""
+        return sum(len(v) for v in self.data.values())
+
+    def num_unfixed_exceptions(self) -> int:
+        """Return the number of unfixed exceptions."""
+        return sum(len(v) for v in self.unfixed_exceptions().values())
 
     def num_unfixed(self) -> int:
         """Return a list of unfixed questions."""

--- a/edsl/jobs/async_interview_runner.py
+++ b/edsl/jobs/async_interview_runner.py
@@ -14,6 +14,7 @@ from edsl.data_transfer_models import EDSLResultObjectInput
 from ..results import Result
 from ..interviews import Interview
 from ..config import Config
+
 config = Config()
 
 if TYPE_CHECKING:
@@ -21,15 +22,17 @@ if TYPE_CHECKING:
 
 from .data_structures import RunConfig
 
+
 @dataclass
 class InterviewResult:
     """Container for the result of an interview along with metadata.
-    
+
     Attributes:
         result: The Result object containing the interview answers
         interview: The Interview object used to conduct the interview
         order: The original position of this interview in the processing queue
     """
+
     result: Result
     interview: Interview
     order: int
@@ -38,10 +41,10 @@ class InterviewResult:
 class AsyncInterviewRunner:
     """
     Runs interviews asynchronously with controlled concurrency.
-    
+
     This class manages the parallel execution of multiple interviews while
     respecting concurrency limits and handling errors appropriately.
-    
+
     Examples:
         >>> from unittest.mock import MagicMock, AsyncMock
         >>> mock_jobs = MagicMock()
@@ -52,13 +55,13 @@ class AsyncInterviewRunner:
         >>> isinstance(runner._initialized, asyncio.Event)
         True
     """
-    
+
     MAX_CONCURRENT = int(config.EDSL_MAX_CONCURRENT_TASKS)
 
     def __init__(self, jobs: "Jobs", run_config: RunConfig):
         """
         Initialize the AsyncInterviewRunner.
-        
+
         Args:
             jobs: The Jobs object that generates interviews
             run_config: Configuration for running the interviews
@@ -70,13 +73,13 @@ class AsyncInterviewRunner:
     def _expand_interviews(self) -> Generator["Interview", None, None]:
         """
         Create multiple copies of each interview based on the run configuration.
-        
+
         This method expands interviews for repeated runs and ensures each has
         the proper cache configuration.
-        
+
         Yields:
             Interview objects ready to be conducted
-            
+
         Examples:
             >>> from unittest.mock import MagicMock
             >>> mock_jobs = MagicMock()
@@ -105,16 +108,16 @@ class AsyncInterviewRunner:
     ) -> Tuple["Result", "Interview"]:
         """
         Asynchronously conduct a single interview.
-        
+
         This method performs the interview and creates a Result object with
         the extracted answers and model responses.
-        
+
         Args:
             interview: The interview to conduct
-            
+
         Returns:
             Tuple containing the Result object and the Interview object
-            
+
         Notes:
             'extracted_answers' contains the processed and validated answers
             from the interview, which may differ from the raw model output.
@@ -137,14 +140,14 @@ class AsyncInterviewRunner:
     ) -> AsyncGenerator[tuple[Result, Interview], None]:
         """
         Run all interviews asynchronously and yield results as they complete.
-        
+
         This method processes interviews in chunks based on MAX_CONCURRENT,
         maintaining controlled concurrency while yielding results as soon as
         they become available.
-        
+
         Yields:
             Tuples of (Result, Interview) as interviews complete
-            
+
         Notes:
             - Uses structured concurrency patterns for proper resource management
             - Handles exceptions according to the run configuration
@@ -159,7 +162,7 @@ class AsyncInterviewRunner:
             try:
                 result, interview = await self._conduct_interview(interview)
                 self.run_config.environment.jobs_runner_status.add_completed_interview(
-                    result
+                    interview
                 )
                 result.order = idx
                 return InterviewResult(result, interview, idx)
@@ -200,5 +203,6 @@ class AsyncInterviewRunner:
 
 
 if __name__ == "__main__":
-    import doctest 
+    import doctest
+
     doctest.testmod()

--- a/edsl/jobs/jobs_runner_status.py
+++ b/edsl/jobs/jobs_runner_status.py
@@ -171,16 +171,12 @@ class JobsRunnerStatusBase(ABC):
         status_dict["language_model_queues"] = model_queues
         return status_dict
 
-    def add_completed_interview(self, result):
+    def add_completed_interview(self, interview):
         """Records a completed interview without storing the full interview data."""
         self.stats_tracker.add_completed_interview(
-            model=result.model.model,
-            num_exceptions=(
-                len(result.exceptions) if hasattr(result, "exceptions") else 0
-            ),
-            num_unfixed=(
-                result.exceptions.num_unfixed() if hasattr(result, "exceptions") else 0
-            ),
+            model=interview.model.model,
+            num_exceptions=interview.exceptions.num_exceptions(),
+            num_unfixed=interview.exceptions.num_unfixed_exceptions(),
         )
 
     def _compute_statistic(self, stat_name: str):


### PR DESCRIPTION
The progress bar currently reports zero exceptions, regardless of the actual number.

The progress bar code has been updated to reflect that exceptions are tracked in interviews, not results.

Related to https://github.com/expectedparrot/coopr/issues/729