### PR TITLE
Add dynamic doc URL generation to BaseException

### DIFF
--- a/edsl/surveys/exceptions.py
+++ b/edsl/surveys/exceptions.py
@@ -12,7 +12,7 @@ class SurveyError(BaseException):
     - Question names don't meet validation requirements
     - Survey operations encounter general errors not covered by more specific exceptions
     """
-    relevant_doc = "https://docs.expectedparrot.com/en/latest/surveys.html"
+    doc_page = "surveys"
 
 
 class SurveyCreationError(SurveyError):
@@ -38,7 +38,7 @@ class SurveyCreationError(SurveyError):
         survey.add_rules_to_question(EndOfSurvey)  # Raises SurveyCreationError
         ```
     """
-    relevant_doc = "https://docs.expectedparrot.com/en/latest/surveys.html#creating-surveys"
+    doc_anchor = "creating-surveys"
 
 
 class SurveyHasNoRulesError(SurveyError):

--- a/tests/base/test_BaseException_doc_url.py
+++ b/tests/base/test_BaseException_doc_url.py
@@ -1,0 +1,27 @@
+import pytest
+from edsl.base import BaseException
+from edsl.surveys.exceptions import SurveyError, SurveyCreationError
+
+
+def test_base_exception_doc_url():
+    """Test that the get_doc_url method works correctly."""
+    # Base class with no doc_page should return the base URL
+    assert BaseException.get_doc_url() == "https://docs.expectedparrot.com/en/latest/"
+    
+    # SurveyError with doc_page but no doc_anchor
+    assert SurveyError.get_doc_url() == "https://docs.expectedparrot.com/en/latest/surveys.html"
+    
+    # SurveyCreationError inherits doc_page from SurveyError and adds doc_anchor
+    assert SurveyCreationError.get_doc_url() == "https://docs.expectedparrot.com/en/latest/surveys.html#creating-surveys"
+    
+    # Test that the URL is included in the exception message
+    survey_error = SurveyError("Test error")
+    assert "https://docs.expectedparrot.com/en/latest/surveys.html" in str(survey_error)
+    
+    survey_creation_error = SurveyCreationError("Test error")
+    assert "https://docs.expectedparrot.com/en/latest/surveys.html#creating-surveys" in str(survey_creation_error)
+
+
+if __name__ == "__main__":
+    test_base_exception_doc_url()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary
- Added `get_doc_url()` method to BaseException to generate documentation URLs dynamically
- Introduced `doc_page` and `doc_anchor` attributes to replace hardcoded URLs in exception classes
- Updated SurveyError and SurveyCreationError classes as examples of the new pattern
- Added test coverage to verify URL generation works correctly

## Test plan
- Run the new test file: `pytest -xvs tests/base/test_BaseException_doc_url.py`
- The test verifies that URLs are generated correctly for different classes
- Ensures inheritance of attributes works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)