### PR TITLE
Fix ScenarioList.from_csv() to handle non-UTF-8 encoding

### DIFF
--- a/tests/scenarios/test_ScenarioListEncoding.py
+++ b/tests/scenarios/test_ScenarioListEncoding.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+from pathlib import Path
+
+from edsl.scenarios.scenario_list import ScenarioList
+
+
+class TestScenarioListEncoding(unittest.TestCase):
+    """Tests for ScenarioList encoding handling with CSV files."""
+
+    def setUp(self):
+        # Get the path to the test data file
+        current_dir = Path(__file__).parent
+        self.test_file_path = str(current_dir / "test_data" / "non_utf8_test.csv")
+        
+        # Make sure test file exists
+        self.assertTrue(os.path.exists(self.test_file_path), 
+                        f"Test file not found: {self.test_file_path}")
+    
+    def test_load_non_utf8_csv(self):
+        """Test loading a CSV file with non-UTF8 encoding."""
+        try:
+            # This would fail before the fix
+            scenarios = ScenarioList.from_csv(self.test_file_path)
+            
+            # If we get here, make sure data is properly loaded
+            self.assertEqual(len(scenarios), 5, "Expected 5 scenarios in the list")
+            
+            # Verify some of the content to ensure it's properly decoded
+            self.assertEqual(scenarios[0]["name"], "John Doe")
+            self.assertTrue("María" in scenarios[2]["name"] or "Maria" in scenarios[2]["name"], 
+                           f"Special character name not found, got: {scenarios[2]['name']}")
+            self.assertTrue("François" in scenarios[3]["name"] or "Francois" in scenarios[3]["name"], 
+                           f"Special character name not found, got: {scenarios[3]['name']}")
+            
+        except UnicodeDecodeError:
+            self.fail("Failed to decode non-UTF8 CSV file")
+        except Exception as e:
+            self.fail(f"Unexpected error loading non-UTF8 CSV: {str(e)}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scenarios/test_data/non_utf8_test.csv
+++ b/tests/scenarios/test_data/non_utf8_test.csv
@@ -1,0 +1,6 @@
+name,address,phone
+John Doe,"123 Main St, Apt A",555-1234
+Jane Smith,"456 Oak Ave, Suite B",555-5678
+María García,"789 Pine Blvd, Unit C",555-9012
+François Dupont,"101 Elm Ln, Apt D",555-3456
+Jürgen Müller,"202 Cedar Ct, Suite E",555-7890


### PR DESCRIPTION
## Summary
- Added encoding fallback mechanism to try multiple encodings when reading CSV files
- Added error handling for file opening and reading
- Added unit test with a test CSV file containing non-UTF-8 characters
- Resolves #1781

## Test plan
- Run `poetry run pytest -xv tests/scenarios/test_ScenarioListEncoding.py` to verify that CSV files with non-UTF-8 encodings can be properly read

🤖 Generated with [Claude Code](https://claude.ai/code)