### PR TITLE
append cache to results obtained from remote inference

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -666,6 +666,8 @@ class Coop(CoopFunctionsMixin):
             )
         edsl_class = ObjectRegistry.object_type_to_edsl_class.get(object_type)
         object = edsl_class.from_dict(json.loads(json_string))
+        if object_type == "results":
+            object.initialize_cache_from_results()
         return object
 
     def get_all(self, object_type: ObjectType) -> list[dict[str, Any]]:

--- a/edsl/results/results.py
+++ b/edsl/results/results.py
@@ -44,10 +44,10 @@ from typing import Optional, Callable, Any, Union, List, TYPE_CHECKING
 from bisect import bisect_left
 
 from ..base import Base
+from ..caching import Cache, CacheEntry
 
 if TYPE_CHECKING:
     from ..surveys import Survey
-    from ..caching import Cache
     from ..agents import AgentList
     from ..scenarios import ScenarioList
     from ..results import Result
@@ -707,12 +707,42 @@ class Results(UserList, ResultsOperationsMixin, Base):
             "b_not_a": [other_results[i] for i in indices_other],
         }
 
+    def initialize_cache_from_results(self):
+        cache = Cache(data={})
+
+        for result in self.data:
+            for key in result.data["prompt"]:
+                if key.endswith("_system_prompt"):
+                    question_name = key.removesuffix("_system_prompt")
+                    system_prompt = result.data["prompt"][key].text
+                    user_key = f"{question_name}_user_prompt"
+                    if user_key in result.data["prompt"]:
+                        user_prompt = result.data["prompt"][user_key].text
+                    else:
+                        user_prompt = ""
+
+                    # Get corresponding model response
+                    response_key = f"{question_name}_raw_model_response"
+                    output = result.data["raw_model_response"].get(response_key, "")
+
+                    entry = CacheEntry(
+                        model=result.model.model,
+                        parameters=result.model.parameters,
+                        system_prompt=system_prompt,
+                        user_prompt=user_prompt,
+                        output=json.dumps(output),
+                        iteration=0,
+                    )
+                    cache.data[entry.key] = entry
+                    print(entry.key)
+
+        self.cache = cache
+
     @property
     def has_unfixed_exceptions(self) -> bool:
         return self.task_history.has_unfixed_exceptions
 
     def __hash__(self) -> int:
-
         return dict_hash(
             self.to_dict(sort=True, add_edsl_version=False, include_cache_info=False)
         )

--- a/edsl/results/results.py
+++ b/edsl/results/results.py
@@ -734,7 +734,6 @@ class Results(UserList, ResultsOperationsMixin, Base):
                         iteration=0,
                     )
                     cache.data[entry.key] = entry
-                    print(entry.key)
 
         self.cache = cache
 

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -28,8 +28,8 @@ def coop_object_api_workflows(object_type, object_examples):
         response = coop.create(object, visibility=visibility)
         if object_type == "results":
             remote_ojbect = coop.get(response.get("uuid"))
-            remote_ojbect.cache=None 
-            object.cache=None
+            remote_ojbect.cache=object.cache 
+            
             assert remote_ojbect == object, "Expected object to be the same as the one created. "
         else:
             assert (
@@ -43,7 +43,10 @@ def coop_object_api_workflows(object_type, object_examples):
     for i, response in enumerate(responses):
         object, visibility = object_examples[i]
         if visibility != "private":
-            assert coop2.get(response.get("uuid")) == object
+            remote_ojbect = coop2.get(response.get("uuid"))
+            if object_type == "results":
+                remote_ojbect.cache=object.cache
+            assert remote_ojbect == object
         else:
             from edsl.coop.exceptions import CoopServerResponseError
             with pytest.raises(CoopServerResponseError):

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -28,8 +28,8 @@ def coop_object_api_workflows(object_type, object_examples):
         response = coop.create(object, visibility=visibility)
         if object_type == "results":
             remote_ojbect = coop.get(response.get("uuid"))
-            if object.cache == None:
-                remote_ojbect.cache=None 
+            remote_ojbect.cache=None 
+            object.cache=None
             assert remote_ojbect == object, "Expected object to be the same as the one created. "
         else:
             assert (

--- a/tests/coop/test_coop_objects.py
+++ b/tests/coop/test_coop_objects.py
@@ -26,10 +26,16 @@ def coop_object_api_workflows(object_type, object_examples):
     responses = []
     for object, visibility in object_examples:
         response = coop.create(object, visibility=visibility)
-        assert (
-            coop.get(response.get("uuid")) == object
-        ), "Expected object to be the same as the one created. "
-        # assert coop.get(response.get("url")) == object
+        if object_type == "results":
+            remote_ojbect = coop.get(response.get("uuid"))
+            if object.cache == None:
+                remote_ojbect.cache=None 
+            assert remote_ojbect == object, "Expected object to be the same as the one created. "
+        else:
+            assert (
+                coop.get(response.get("uuid")) == object
+            ), "Expected object to be the same as the one created. "
+            # assert coop.get(response.get("url")) == object
         responses.append(response)
 
     # 3. Test visibility with different clients


### PR DESCRIPTION
This pull request introduces a new method to initialize a cache from results in the `edsl/results/results.py` file and updates the `edsl/coop/coop.py` file to call this method when the object type is "results". These changes aim to enhance the caching mechanism and improve performance.

Enhancements to caching mechanism:

* [`edsl/results/results.py`](diffhunk://#diff-656c798f74349331bdb70659e62ad5f8379289de3dacb2ec93d95a61d8059d35R710-L715): Added the `initialize_cache_from_results` method to the `Results` class, which initializes a cache based on the results data.
* [`edsl/coop/coop.py`](diffhunk://#diff-e9dcb9357440f77d6502dcb2812bbf12457c9e617feced7309671a6f4561ead5R669-R670): Updated the `get` method to call `initialize_cache_from_results` when the object type is "results".

Code import adjustments:

* [`edsl/results/results.py`](diffhunk://#diff-656c798f74349331bdb70659e62ad5f8379289de3dacb2ec93d95a61d8059d35R47-L50): Adjusted imports to include `Cache` and `CacheEntry` from the `caching` module.