### PR TITLE
Fix issue 1833

### DIFF
--- a/edsl/invigilators/invigilators.py
+++ b/edsl/invigilators/invigilators.py
@@ -399,6 +399,9 @@ class InvigilatorAI(InvigilatorBase):
                 if type(agent_response_dict.edsl_dict.answer) is str
                 or type(agent_response_dict.edsl_dict.answer) is dict
                 or type(agent_response_dict.edsl_dict.answer) is list
+                or type(agent_response_dict.edsl_dict.answer) is int
+                or type(agent_response_dict.edsl_dict.answer) is float
+                or type(agent_response_dict.edsl_dict.answer) is bool
                 else "",
                 "comment": agent_response_dict.edsl_dict.comment
                 if agent_response_dict.edsl_dict.comment

--- a/edsl/invigilators/invigilators.py
+++ b/edsl/invigilators/invigilators.py
@@ -398,6 +398,7 @@ class InvigilatorAI(InvigilatorBase):
                 "answer": agent_response_dict.edsl_dict.answer
                 if type(agent_response_dict.edsl_dict.answer) is str
                 or type(agent_response_dict.edsl_dict.answer) is dict
+                or type(agent_response_dict.edsl_dict.answer) is list
                 else "",
                 "comment": agent_response_dict.edsl_dict.comment
                 if agent_response_dict.edsl_dict.comment

--- a/edsl/invigilators/invigilators.py
+++ b/edsl/invigilators/invigilators.py
@@ -397,6 +397,7 @@ class InvigilatorAI(InvigilatorBase):
             data = {
                 "answer": agent_response_dict.edsl_dict.answer
                 if type(agent_response_dict.edsl_dict.answer) is str
+                or type(agent_response_dict.edsl_dict.answer) is dict
                 else "",
                 "comment": agent_response_dict.edsl_dict.comment
                 if agent_response_dict.edsl_dict.comment


### PR DESCRIPTION
This pull request includes a change to the `_extract_edsl_result_entry_and_validate` method in the `edsl/invigilators/invigilators.py` file to enhance the validation of `edsl_dict.answer`.

Validation enhancements:

* [`edsl/invigilators/invigilators.py`](diffhunk://#diff-e853847cd86174aacc81604c1c4bb65877ccc3dd2fb9ff8bcd789f64de4b8bd9R400-R404): Updated the `_extract_edsl_result_entry_and_validate` method to allow `edsl_dict.answer` to be of types `dict`, `list`, `int`, `float`, or `bool`, in addition to `str`.