### PR TITLE
Add validation logging system to track and analyze question validation failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,15 @@ backup: ## Backup the code to `edsl/.backups/`
 	echo "Backup created: $${BACKUP_NAME}"
 
 ###############
+##@Validation Reports 🔍
+###############
+validation-report: ## Generate an HTML validation report and open it in a browser
+	python -c "from edsl.questions import generate_and_open_report; generate_and_open_report()"
+
+validation-stats: ## Show validation failure statistics
+	edsl validation stats
+
+###############
 ##@Performance Benchmarks 📊
 ###############
 benchmark-timing: ## Run timing benchmarks
@@ -272,7 +281,7 @@ test-doctests: ## Run doctests
 	# Reordered to avoid circular import
 	pytest --doctest-modules edsl/results
 	pytest --doctest-modules edsl/dataset
-	pytest --doctest-modules --ignore=edsl/buckets/token_bucket_client.py edsl/buckets
+	pytest --doctest-modules --ignore=edsl/buckets/token_bucket_client.py --ignore=edsl/buckets/token_bucket_api.py edsl/buckets
 	pytest --doctest-modules edsl/interviews
 	pytest --doctest-modules edsl/tokens
 	pytest --doctest-modules edsl/jobs/

--- a/edsl/cli.py
+++ b/edsl/cli.py
@@ -6,6 +6,8 @@ This module provides the main entry point for the EDSL command-line tool.
 
 import sys
 import typer
+import json
+from pathlib import Path
 from typing import Optional
 from rich.console import Console
 from importlib import metadata
@@ -19,6 +21,83 @@ from .plugins.cli_typer import app as plugins_app
 
 # Add the plugins subcommand
 app.add_typer(plugins_app, name="plugins")
+
+# Create the validation app
+validation_app = typer.Typer(help="Manage EDSL validation failures")
+app.add_typer(validation_app, name="validation")
+
+@validation_app.command("logs")
+def list_validation_logs(
+    count: int = typer.Option(10, "--count", "-n", help="Number of logs to show"),
+    question_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by question type"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+):
+    """List validation failure logs."""
+    from .questions.validation_logger import get_validation_failure_logs
+    
+    logs = get_validation_failure_logs(n=count)
+    
+    # Filter by question type if provided
+    if question_type:
+        logs = [log for log in logs if log.get("question_type") == question_type]
+    
+    if output:
+        with open(output, "w") as f:
+            json.dump(logs, f, indent=2)
+        console.print(f"[green]Logs written to {output}[/green]")
+    else:
+        console.print_json(json.dumps(logs, indent=2))
+        
+@validation_app.command("clear")
+def clear_validation_logs():
+    """Clear validation failure logs."""
+    from .questions.validation_logger import clear_validation_logs
+    
+    clear_validation_logs()
+    console.print("[green]Validation logs cleared.[/green]")
+        
+@validation_app.command("stats")
+def validation_stats(
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+):
+    """Show validation failure statistics."""
+    from .questions.validation_analysis import get_validation_failure_stats
+    
+    stats = get_validation_failure_stats()
+    
+    if output:
+        with open(output, "w") as f:
+            json.dump(stats, f, indent=2)
+        console.print(f"[green]Stats written to {output}[/green]")
+    else:
+        console.print_json(json.dumps(stats, indent=2))
+        
+@validation_app.command("suggest")
+def suggest_improvements(
+    question_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by question type"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+):
+    """Suggest improvements for fix methods."""
+    from .questions.validation_analysis import suggest_fix_improvements
+    
+    suggestions = suggest_fix_improvements(question_type=question_type)
+    
+    if output:
+        with open(output, "w") as f:
+            json.dump(suggestions, f, indent=2)
+        console.print(f"[green]Suggestions written to {output}[/green]")
+    else:
+        console.print_json(json.dumps(suggestions, indent=2))
+        
+@validation_app.command("report")
+def generate_report(
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+):
+    """Generate a comprehensive validation report."""
+    from .questions.validation_analysis import export_improvements_report
+    
+    report_path = export_improvements_report(output_path=output)
+    console.print(f"[green]Report generated at: {report_path}[/green]")
 
 @app.callback()
 def callback():

--- a/edsl/cli.py
+++ b/edsl/cli.py
@@ -98,6 +98,26 @@ def generate_report(
     
     report_path = export_improvements_report(output_path=output)
     console.print(f"[green]Report generated at: {report_path}[/green]")
+    
+@validation_app.command("html-report")
+def generate_html_report(
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    open_browser: bool = typer.Option(True, "--open/--no-open", help="Open the report in a browser"),
+):
+    """Generate an HTML validation report and optionally open it in a browser."""
+    from .questions.validation_html_report import generate_html_report
+    import webbrowser
+    
+    report_path = generate_html_report(output_path=output)
+    console.print(f"[green]HTML report generated at: {report_path}[/green]")
+    
+    if open_browser:
+        try:
+            webbrowser.open(f"file://{report_path}")
+            console.print("[green]Opened report in browser[/green]")
+        except Exception as e:
+            console.print(f"[yellow]Could not open browser: {e}[/yellow]")
+            console.print(f"[yellow]Report is available at: {report_path}[/yellow]")
 
 @app.callback()
 def callback():

--- a/edsl/config/config_class.py
+++ b/edsl/config/config_class.py
@@ -58,6 +58,10 @@ CONFIG_MAP = {
         "default": "True",
         "info": "This config var determines whether to fetch prices for tokens used in remote inference",
     },
+    "EDSL_LOG_DIR": {
+        "default": str(os.path.join(platformdirs.user_data_dir('edsl'), 'logs')),
+        "info": "This config var determines the directory where logs are stored.",
+    },
     "EDSL_LOG_LEVEL": {
         "default": "ERROR",
         "info": "This config var determines the logging level for the EDSL package (DEBUG, INFO, WARNING, ERROR, CRITICAL).",

--- a/edsl/questions/VALIDATION_README.md
+++ b/edsl/questions/VALIDATION_README.md
@@ -41,8 +41,24 @@ edsl validation suggest
 # Filter suggestions for a specific question type
 edsl validation suggest --type QuestionMultipleChoice
 
-# Generate a comprehensive report
+# Generate a comprehensive JSON report
 edsl validation report
+
+# Generate an HTML report and open it in browser
+edsl validation html-report
+
+# Generate HTML report without opening browser
+edsl validation html-report --no-open
+```
+
+You can also use the `make` command to generate reports:
+
+```bash
+# Generate and open HTML validation report
+make validation-report
+
+# Show validation statistics
+make validation-stats
 ```
 
 ### Programmatic Usage
@@ -56,7 +72,9 @@ from edsl.questions import (
     clear_validation_logs,
     get_validation_failure_stats,
     suggest_fix_improvements,
-    export_improvements_report
+    export_improvements_report,
+    generate_html_report,
+    generate_and_open_report
 )
 
 # Get recent validation failure logs
@@ -68,8 +86,14 @@ stats = get_validation_failure_stats()
 # Get suggestions for improving fix methods
 suggestions = suggest_fix_improvements()
 
-# Generate a report
+# Generate a JSON report
 report_path = export_improvements_report()
+
+# Generate an HTML report
+html_report_path = generate_html_report()
+
+# Generate and open HTML report in browser
+generate_and_open_report()
 ```
 
 ## Implementation Details
@@ -78,7 +102,8 @@ The validation logging system consists of the following components:
 
 1. **Validation Logger**: Logs validation failures to a local file
 2. **Validation Analysis**: Analyzes logs to identify patterns and suggest improvements
-3. **CLI Integration**: Provides command-line tools for working with validation logs
+3. **HTML Report Generator**: Creates user-friendly HTML reports with visualizations
+4. **CLI Integration**: Provides command-line tools for working with validation logs
 
 ### Log Format
 

--- a/edsl/questions/VALIDATION_README.md
+++ b/edsl/questions/VALIDATION_README.md
@@ -1,0 +1,109 @@
+# EDSL Validation Logging System
+
+This system logs validation failures that occur during question answering and provides tools to analyze these failures to improve the "fix" methods for various question types.
+
+## Background
+
+When a language model's response to a question fails validation (e.g., the response doesn't match the expected format or constraints), EDSL throws a `QuestionAnswerValidationError`. To make these validations more robust, we've added a system to log these failures and analyze common patterns.
+
+## Features
+
+- **Validation Logging**: Automatically logs validation failures to a local file
+- **Log Analysis**: Tools to analyze validation failures by question type and error message
+- **Fix Method Suggestions**: Generates suggestions for improving fix methods based on common failure patterns
+- **CLI Interface**: Command-line tools for managing and analyzing validation logs
+
+## Usage
+
+### Command Line Interface
+
+The validation logging system is integrated with the EDSL CLI:
+
+```bash
+# Show recent validation failure logs
+edsl validation logs
+
+# Show recent logs filtered by question type
+edsl validation logs --type QuestionMultipleChoice
+
+# Save logs to a file
+edsl validation logs --output validation_logs.json
+
+# Clear all validation logs
+edsl validation clear
+
+# Show validation failure statistics
+edsl validation stats
+
+# Get suggestions for improving fix methods
+edsl validation suggest
+
+# Filter suggestions for a specific question type
+edsl validation suggest --type QuestionMultipleChoice
+
+# Generate a comprehensive report
+edsl validation report
+```
+
+### Programmatic Usage
+
+You can also use the validation logging system programmatically:
+
+```python
+from edsl.questions import (
+    log_validation_failure,
+    get_validation_failure_logs,
+    clear_validation_logs,
+    get_validation_failure_stats,
+    suggest_fix_improvements,
+    export_improvements_report
+)
+
+# Get recent validation failure logs
+logs = get_validation_failure_logs(n=10)
+
+# Get validation failure statistics
+stats = get_validation_failure_stats()
+
+# Get suggestions for improving fix methods
+suggestions = suggest_fix_improvements()
+
+# Generate a report
+report_path = export_improvements_report()
+```
+
+## Implementation Details
+
+The validation logging system consists of the following components:
+
+1. **Validation Logger**: Logs validation failures to a local file
+2. **Validation Analysis**: Analyzes logs to identify patterns and suggest improvements
+3. **CLI Integration**: Provides command-line tools for working with validation logs
+
+### Log Format
+
+Validation failure logs include the following information:
+
+- Timestamp
+- Question type and name
+- Error message
+- Invalid data that failed validation
+- Model schema used for validation
+- Question details (if available)
+- Stack trace
+
+### Storage Location
+
+Logs are stored in the default EDSL log directory:
+
+- Linux/macOS: `~/.edsl/logs/validation_failures.log`
+- Windows: `%USERPROFILE%\.edsl\logs\validation_failures.log`
+
+## Future Improvements
+
+Potential future improvements to the validation logging system:
+
+1. Integration with coop for cloud storage and analysis of validation failures
+2. Machine learning to automatically suggest fix method improvements
+3. Automated tests using common validation failure patterns
+4. A web-based dashboard for visualizing validation failure statistics

--- a/edsl/questions/__init__.py
+++ b/edsl/questions/__init__.py
@@ -136,6 +136,7 @@ from .validation_analysis import (
     suggest_fix_improvements, 
     export_improvements_report
 )
+from .validation_html_report import generate_html_report, generate_and_open_report
 
 __all__ = [
     # Exceptions
@@ -175,4 +176,6 @@ __all__ = [
     "get_validation_failure_stats",
     "suggest_fix_improvements",
     "export_improvements_report",
+    "generate_html_report",
+    "generate_and_open_report",
 ]

--- a/edsl/questions/__init__.py
+++ b/edsl/questions/__init__.py
@@ -34,6 +34,7 @@ Derived Question Types:
 - QuestionLinearScale: Linear scale with customizable range and labels
 - QuestionYesNo: Simple binary yes/no response
 - QuestionTopK: Selection of top K items from a list of options
+- QuestionMultipleChoiceWithOther: Multiple choice with option to specify "Other" custom response
 
 Technical Architecture:
 ---------------------
@@ -124,8 +125,17 @@ from .question_likert_five import QuestionLikertFive
 from .question_linear_scale import QuestionLinearScale
 from .question_yes_no import QuestionYesNo
 from .question_top_k import QuestionTopK
+from .question_multiple_choice_with_other import QuestionMultipleChoiceWithOther
 
 from .exceptions import QuestionScenarioRenderError
+
+# Import validation modules
+from .validation_logger import log_validation_failure, get_validation_failure_logs, clear_validation_logs
+from .validation_analysis import (
+    get_validation_failure_stats, 
+    suggest_fix_improvements, 
+    export_improvements_report
+)
 
 __all__ = [
     # Exceptions
@@ -156,4 +166,13 @@ __all__ = [
     "QuestionTopK",
     "QuestionLikertFive",
     "QuestionYesNo",
+    "QuestionMultipleChoiceWithOther",
+    
+    # Validation utilities
+    "log_validation_failure",
+    "get_validation_failure_logs",
+    "clear_validation_logs",
+    "get_validation_failure_stats",
+    "suggest_fix_improvements",
+    "export_improvements_report",
 ]

--- a/edsl/questions/exceptions.py
+++ b/edsl/questions/exceptions.py
@@ -72,6 +72,27 @@ class QuestionAnswerValidationError(QuestionErrors):
         self.data = data
         self.model = model
         super().__init__(self.message)
+        
+        # Log validation failure for analysis
+        try:
+            from .validation_logger import log_validation_failure
+            
+            # Get question type and name if available
+            question_type = getattr(model, "question_type", "unknown")
+            question_name = getattr(model, "question_name", "unknown")
+            
+            # Log the validation failure
+            log_validation_failure(
+                question_type=question_type,
+                question_name=question_name,
+                error_message=str(message),
+                invalid_data=data,
+                model_schema=model.model_json_schema(),
+                question_dict=getattr(model, "to_dict", lambda: None)(),
+            )
+        except Exception:
+            # Silently ignore logging errors to not disrupt normal operation
+            pass
 
     def __str__(self):
         if isinstance(self.message, ValidationError):

--- a/edsl/questions/validation_analysis.py
+++ b/edsl/questions/validation_analysis.py
@@ -1,0 +1,180 @@
+"""Analyze validation failures to improve fix methods.
+
+This module provides tools to analyze validation failures that have been logged
+and suggest improvements to the fix methods for various question types.
+"""
+
+import collections
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from ..config import CONFIG
+from .validation_logger import get_validation_failure_logs
+
+
+def get_validation_failure_stats() -> Dict[str, Dict[str, int]]:
+    """
+    Get statistics about validation failures by question type and error message.
+    
+    Returns:
+        Dictionary with stats about validation failures by question type and error message
+    """
+    logs = get_validation_failure_logs(n=1000)  # Get up to 1000 recent logs
+    
+    # Count by question type
+    type_counts = collections.Counter()
+    
+    # Count by question type and error message
+    error_counts = collections.defaultdict(collections.Counter)
+    
+    for log in logs:
+        question_type = log.get("question_type", "unknown")
+        error_message = log.get("error_message", "unknown")
+        
+        type_counts[question_type] += 1
+        error_counts[question_type][error_message] += 1
+    
+    # Convert to dict for cleaner output
+    result = {
+        "by_question_type": dict(type_counts),
+        "by_error_message": {k: dict(v) for k, v in error_counts.items()}
+    }
+    
+    return result
+
+
+def suggest_fix_improvements(question_type: Optional[str] = None) -> Dict[str, List[Dict]]:
+    """
+    Analyze validation failures and suggest improvements for fix methods.
+    
+    Args:
+        question_type: Optional filter for a specific question type
+        
+    Returns:
+        Dictionary with improvement suggestions for fix methods
+    """
+    logs = get_validation_failure_logs(n=1000)  # Get up to 1000 recent logs
+    
+    # Filter by question_type if provided
+    if question_type:
+        logs = [log for log in logs if log.get("question_type") == question_type]
+    
+    # Group by question type
+    grouped_logs = collections.defaultdict(list)
+    for log in logs:
+        grouped_logs[log.get("question_type", "unknown")].append(log)
+    
+    suggestions = {}
+    
+    # Analyze patterns for each question type
+    for qt, logs in grouped_logs.items():
+        qt_suggestions = []
+        
+        # Get common error patterns
+        error_counter = collections.Counter([log.get("error_message", "") for log in logs])
+        common_errors = error_counter.most_common(5)  # Top 5 errors
+        
+        # Create suggestions based on error patterns
+        for error_msg, count in common_errors:
+            if not error_msg:
+                continue
+                
+            # Get example data for this error
+            example_logs = [log for log in logs if log.get("error_message") == error_msg]
+            example = example_logs[0] if example_logs else None
+            
+            suggestion = {
+                "error_message": error_msg,
+                "occurrence_count": count,
+                "suggestion": _generate_suggestion(qt, error_msg, example),
+                "example_data": example.get("invalid_data") if example else None
+            }
+            
+            qt_suggestions.append(suggestion)
+            
+        if qt_suggestions:
+            suggestions[qt] = qt_suggestions
+    
+    return suggestions
+
+
+def _generate_suggestion(question_type: str, error_msg: str, example: Optional[Dict]) -> str:
+    """
+    Generate a suggestion for improving fix methods based on the error pattern.
+    
+    Args:
+        question_type: The question type
+        error_msg: The error message
+        example: An example log entry containing the error
+        
+    Returns:
+        A suggestion string for improving the fix method
+    """
+    # Common validation error patterns and suggestions
+    if "missing" in error_msg.lower() and "key" in error_msg.lower():
+        return (
+            f"The fix method for {question_type} should check for missing keys "
+            f"in the answer and add them with default values."
+        )
+    
+    if "not a valid" in error_msg.lower() and any(t in error_msg.lower() for t in ["integer", "number", "float"]):
+        return (
+            f"The fix method for {question_type} should convert string values to the expected "
+            f"numeric type (int/float) and handle non-numeric strings."
+        )
+    
+    if "must be" in error_msg.lower() and "length" in error_msg.lower():
+        return (
+            f"The fix method for {question_type} should ensure the answer has the correct length "
+            f"requirements, potentially truncating or padding as needed."
+        )
+    
+    if "not a valid" in error_msg.lower() and "list" in error_msg.lower():
+        return (
+            f"The fix method for {question_type} should ensure the answer is a valid list, "
+            f"potentially converting single items to lists when needed."
+        )
+    
+    if "greater than" in error_msg.lower() or "less than" in error_msg.lower():
+        return (
+            f"The fix method for {question_type} should enforce value range constraints "
+            f"by clamping values to the allowed min/max range."
+        )
+    
+    # Default suggestion
+    return (
+        f"Review the validation failures for {question_type} and update the fix method "
+        f"to handle common error patterns more effectively."
+    )
+
+
+def export_improvements_report(output_path: Optional[Path] = None) -> Path:
+    """
+    Generate a report with improvement suggestions for fix methods.
+    
+    Args:
+        output_path: Optional custom path for the report
+        
+    Returns:
+        Path to the generated report
+    """
+    if output_path is None:
+        report_dir = Path(CONFIG.get("EDSL_LOG_DIR", Path.home() / ".edsl" / "logs"))
+        output_path = report_dir / "fix_methods_improvements.json"
+    
+    # Get stats and suggestions
+    stats = get_validation_failure_stats()
+    suggestions = suggest_fix_improvements()
+    
+    # Create report
+    report = {
+        "validation_failure_stats": stats,
+        "fix_method_improvement_suggestions": suggestions
+    }
+    
+    # Write report to file
+    with open(output_path, "w") as f:
+        json.dump(report, f, indent=2)
+    
+    return output_path

--- a/edsl/questions/validation_analysis.py
+++ b/edsl/questions/validation_analysis.py
@@ -160,7 +160,8 @@ def export_improvements_report(output_path: Optional[Path] = None) -> Path:
         Path to the generated report
     """
     if output_path is None:
-        report_dir = Path(CONFIG.get("EDSL_LOG_DIR", Path.home() / ".edsl" / "logs"))
+        default_log_dir = Path.home() / ".edsl" / "logs"
+        report_dir = Path(CONFIG.get("EDSL_LOG_DIR", default=str(default_log_dir)))
         output_path = report_dir / "fix_methods_improvements.json"
     
     # Get stats and suggestions

--- a/edsl/questions/validation_analysis.py
+++ b/edsl/questions/validation_analysis.py
@@ -161,7 +161,11 @@ def export_improvements_report(output_path: Optional[Path] = None) -> Path:
     """
     if output_path is None:
         default_log_dir = Path.home() / ".edsl" / "logs"
-        report_dir = Path(CONFIG.get("EDSL_LOG_DIR", default=str(default_log_dir)))
+        try:
+            report_dir = Path(CONFIG.get("EDSL_LOG_DIR"))
+        except Exception:
+            # If EDSL_LOG_DIR is not defined, use default
+            report_dir = default_log_dir
         output_path = report_dir / "fix_methods_improvements.json"
     
     # Get stats and suggestions

--- a/edsl/questions/validation_cli.py
+++ b/edsl/questions/validation_cli.py
@@ -1,0 +1,131 @@
+"""Command-line interface for validation logging and analysis.
+
+This module provides a command-line interface for managing validation logs,
+generating reports, and suggesting improvements to fix methods.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .validation_analysis import (
+    export_improvements_report,
+    get_validation_failure_stats,
+    suggest_fix_improvements,
+)
+from .validation_logger import clear_validation_logs, get_validation_failure_logs
+
+
+def main():
+    """Run the validation CLI."""
+    parser = argparse.ArgumentParser(
+        description="Manage and analyze question validation failures"
+    )
+    
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+    
+    # List logs command
+    list_parser = subparsers.add_parser("list", help="List validation failure logs")
+    list_parser.add_argument(
+        "-n", "--count", type=int, default=10, 
+        help="Number of logs to show (default: 10)"
+    )
+    list_parser.add_argument(
+        "-t", "--type", type=str,
+        help="Filter by question type"
+    )
+    list_parser.add_argument(
+        "-o", "--output", type=str,
+        help="Output file path (default: stdout)"
+    )
+    
+    # Clear logs command
+    subparsers.add_parser("clear", help="Clear validation failure logs")
+    
+    # Stats command
+    stats_parser = subparsers.add_parser("stats", help="Show validation failure statistics")
+    stats_parser.add_argument(
+        "-o", "--output", type=str,
+        help="Output file path (default: stdout)"
+    )
+    
+    # Suggest improvements command
+    suggest_parser = subparsers.add_parser(
+        "suggest", help="Suggest improvements for fix methods"
+    )
+    suggest_parser.add_argument(
+        "-t", "--type", type=str,
+        help="Filter by question type"
+    )
+    suggest_parser.add_argument(
+        "-o", "--output", type=str,
+        help="Output file path (default: stdout)"
+    )
+    
+    # Generate report command
+    report_parser = subparsers.add_parser(
+        "report", help="Generate a comprehensive report"
+    )
+    report_parser.add_argument(
+        "-o", "--output", type=str,
+        help="Output file path (default: ~/.edsl/logs/fix_methods_improvements.json)"
+    )
+    
+    args = parser.parse_args()
+    
+    if args.command == "list":
+        logs = get_validation_failure_logs(n=args.count)
+        
+        # Filter by question type if provided
+        if args.type:
+            logs = [log for log in logs if log.get("question_type") == args.type]
+        
+        output = json.dumps(logs, indent=2)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+        else:
+            print(output)
+            
+    elif args.command == "clear":
+        clear_validation_logs()
+        print("Validation logs cleared.")
+        
+    elif args.command == "stats":
+        stats = get_validation_failure_stats()
+        output = json.dumps(stats, indent=2)
+        
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+        else:
+            print(output)
+            
+    elif args.command == "suggest":
+        suggestions = suggest_fix_improvements(question_type=args.type)
+        output = json.dumps(suggestions, indent=2)
+        
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+        else:
+            print(output)
+            
+    elif args.command == "report":
+        output_path = None
+        if args.output:
+            output_path = Path(args.output)
+            
+        report_path = export_improvements_report(output_path=output_path)
+        print(f"Report generated at: {report_path}")
+        
+    else:
+        parser.print_help()
+        return 1
+        
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/edsl/questions/validation_html_report.py
+++ b/edsl/questions/validation_html_report.py
@@ -1,0 +1,404 @@
+"""Generate an HTML report for validation failures.
+
+This module provides functionality to create an HTML report of validation failures,
+including statistics, suggestions for improvements, and examples of common failures.
+"""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..config import CONFIG
+from .validation_analysis import (
+    get_validation_failure_stats,
+    suggest_fix_improvements,
+    export_improvements_report
+)
+from .validation_logger import get_validation_failure_logs
+
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EDSL Validation Failures Report</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1, h2, h3, h4 {
+            color: #2c3e50;
+        }
+        .header {
+            border-bottom: 1px solid #eee;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .timestamp {
+            color: #7f8c8d;
+            font-size: 0.9em;
+        }
+        .summary {
+            background-color: #f8f9fa;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .stats-container, .suggestions-container, .examples-container {
+            margin-bottom: 30px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        th, td {
+            padding: 12px 15px;
+            text-align: left;
+            border-bottom: 1px solid #ddd;
+        }
+        th {
+            background-color: #f8f9fa;
+            font-weight: 600;
+        }
+        tr:hover {
+            background-color: #f5f5f5;
+        }
+        .suggestion {
+            background-color: #e3f2fd;
+            border-left: 4px solid #2196f3;
+            padding: 10px 15px;
+            margin-bottom: 10px;
+            border-radius: 0 4px 4px 0;
+        }
+        .card {
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 15px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .card-header {
+            font-weight: 600;
+            margin-bottom: 10px;
+            padding-bottom: 10px;
+            border-bottom: 1px solid #eee;
+        }
+        .example {
+            background-color: #fff8e1;
+            border-left: 4px solid #ffc107;
+            padding: 10px 15px;
+            margin-bottom: 10px;
+            border-radius: 0 4px 4px 0;
+            overflow-x: auto;
+        }
+        pre {
+            background-color: #f5f5f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.9em;
+        }
+        .badge {
+            display: inline-block;
+            padding: 3px 7px;
+            font-size: 0.75em;
+            font-weight: 600;
+            line-height: 1;
+            text-align: center;
+            white-space: nowrap;
+            vertical-align: baseline;
+            border-radius: 10px;
+            background-color: #e9ecef;
+            margin-right: 5px;
+        }
+        .badge-warning {
+            background-color: #fff3cd;
+            color: #856404;
+        }
+        .badge-primary {
+            background-color: #cfe2ff;
+            color: #084298;
+        }
+        .badge-success {
+            background-color: #d1e7dd;
+            color: #0f5132;
+        }
+        .fix-method {
+            background-color: #e8f5e9;
+            border-left: 4px solid #4caf50;
+            padding: 10px 15px;
+            margin: 10px 0;
+            border-radius: 0 4px 4px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>EDSL Validation Failures Report</h1>
+        <span class="timestamp">Generated on {{timestamp}}</span>
+    </div>
+    
+    <div class="summary">
+        <h2>Summary</h2>
+        <p>This report analyzes validation failures that occurred when question answers didn't meet the expected format or constraints. 
+        It provides statistics, improvement suggestions for fix methods, and examples of common failures.</p>
+        <p><strong>Total validation failures:</strong> {{total_failures}}</p>
+        <p><strong>Question types with failures:</strong> {{question_types_count}}</p>
+    </div>
+    
+    <div class="stats-container">
+        <h2>Validation Failure Statistics</h2>
+        
+        <div class="card">
+            <div class="card-header">Failures by Question Type</div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Question Type</th>
+                        <th>Failure Count</th>
+                        <th>Percentage</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{type_stats_rows}}
+                </tbody>
+            </table>
+        </div>
+        
+        <div class="card">
+            <div class="card-header">Top Error Messages</div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Error Message</th>
+                        <th>Occurrence Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{error_stats_rows}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    
+    <div class="suggestions-container">
+        <h2>Fix Method Improvement Suggestions</h2>
+        {{suggestions_content}}
+    </div>
+    
+    <div class="examples-container">
+        <h2>Example Validation Failures</h2>
+        {{examples_content}}
+    </div>
+</body>
+</html>
+"""
+
+
+def _generate_type_stats_rows(stats: Dict) -> str:
+    """Generate HTML table rows for question type statistics."""
+    type_stats = stats.get("by_question_type", {})
+    total_failures = sum(type_stats.values())
+    
+    rows = []
+    for question_type, count in sorted(type_stats.items(), key=lambda x: x[1], reverse=True):
+        percentage = (count / total_failures) * 100 if total_failures > 0 else 0
+        row = (
+            f"<tr>"
+            f"<td>{question_type}</td>"
+            f"<td>{count}</td>"
+            f"<td>{percentage:.1f}%</td>"
+            f"</tr>"
+        )
+        rows.append(row)
+    
+    return "\n".join(rows)
+
+
+def _generate_error_stats_rows(stats: Dict) -> str:
+    """Generate HTML table rows for error message statistics."""
+    error_counts = {}
+    
+    # Aggregate error counts across all question types
+    for question_type, errors in stats.get("by_error_message", {}).items():
+        for error_msg, count in errors.items():
+            error_counts[error_msg] = error_counts.get(error_msg, 0) + count
+    
+    # Sort by count (descending)
+    sorted_errors = sorted(error_counts.items(), key=lambda x: x[1], reverse=True)
+    
+    rows = []
+    for error_msg, count in sorted_errors[:10]:  # Show top 10 errors
+        shortened_msg = error_msg[:100] + "..." if len(error_msg) > 100 else error_msg
+        row = (
+            f"<tr>"
+            f"<td>{shortened_msg}</td>"
+            f"<td>{count}</td>"
+            f"</tr>"
+        )
+        rows.append(row)
+    
+    return "\n".join(rows)
+
+
+def _generate_suggestions_content(suggestions: Dict) -> str:
+    """Generate HTML content for fix method suggestions."""
+    if not suggestions:
+        return "<p>No suggestions available. Log more validation failures to generate improvement suggestions.</p>"
+    
+    content = []
+    
+    for question_type, question_suggestions in suggestions.items():
+        content.append(f"<div class='card'>")
+        content.append(f"<div class='card-header'>{question_type}</div>")
+        
+        for suggestion in question_suggestions:
+            error_msg = suggestion.get("error_message", "")
+            occurrence_count = suggestion.get("occurrence_count", 0)
+            suggestion_text = suggestion.get("suggestion", "")
+            
+            content.append(
+                f"<div class='suggestion'>"
+                f"<p><strong>Error:</strong> {error_msg}</p>"
+                f"<p><strong>Occurrences:</strong> {occurrence_count}</p>"
+                f"<div class='fix-method'>"
+                f"<p><strong>Suggested improvement:</strong></p>"
+                f"<p>{suggestion_text}</p>"
+                f"</div>"
+                f"</div>"
+            )
+        
+        content.append("</div>")
+    
+    return "\n".join(content)
+
+
+def _generate_examples_content(logs: List[Dict]) -> str:
+    """Generate HTML content for example validation failures."""
+    if not logs:
+        return "<p>No validation failure examples available.</p>"
+    
+    content = []
+    
+    # Group logs by question type
+    logs_by_type = {}
+    for log in logs:
+        question_type = log.get("question_type", "unknown")
+        if question_type not in logs_by_type:
+            logs_by_type[question_type] = []
+        logs_by_type[question_type].append(log)
+    
+    # For each question type, show the most recent example
+    for question_type, type_logs in logs_by_type.items():
+        # Sort by timestamp (newest first)
+        sorted_logs = sorted(type_logs, key=lambda x: x.get("timestamp", ""), reverse=True)
+        example_log = sorted_logs[0]
+        
+        error_message = example_log.get("error_message", "")
+        invalid_data = example_log.get("invalid_data", {})
+        model_schema = example_log.get("model_schema", {})
+        
+        content.append(f"<div class='card'>")
+        content.append(f"<div class='card-header'>{question_type}</div>")
+        
+        content.append(
+            f"<div class='example'>"
+            f"<p><strong>Error:</strong> {error_message}</p>"
+            f"<p><strong>Invalid Data:</strong></p>"
+            f"<pre><code>{json.dumps(invalid_data, indent=2)}</code></pre>"
+            f"<p><strong>Expected Schema:</strong></p>"
+            f"<pre><code>{json.dumps(model_schema, indent=2)}</code></pre>"
+            f"</div>"
+        )
+        
+        content.append("</div>")
+    
+    return "\n".join(content)
+
+
+def generate_html_report(output_path: Optional[Path] = None) -> Path:
+    """
+    Generate an HTML report of validation failures.
+    
+    Args:
+        output_path: Optional custom path for the report
+        
+    Returns:
+        Path to the generated HTML report
+    """
+    # Determine output path
+    if output_path is None:
+        default_log_dir = Path.home() / ".edsl" / "logs"
+        try:
+            report_dir = Path(CONFIG.get("EDSL_LOG_DIR"))
+        except Exception:
+            # If EDSL_LOG_DIR is not defined, use default
+            report_dir = default_log_dir
+        os.makedirs(report_dir, exist_ok=True)
+        output_path = report_dir / "validation_report.html"
+    
+    # Get validation data
+    logs = get_validation_failure_logs(n=100)  # Get up to 100 recent logs
+    stats = get_validation_failure_stats()
+    suggestions = suggest_fix_improvements()
+    
+    # Calculate summary statistics
+    total_failures = sum(stats.get("by_question_type", {}).values())
+    question_types_count = len(stats.get("by_question_type", {}))
+    
+    # Generate report content
+    type_stats_rows = _generate_type_stats_rows(stats)
+    error_stats_rows = _generate_error_stats_rows(stats)
+    suggestions_content = _generate_suggestions_content(suggestions)
+    examples_content = _generate_examples_content(logs)
+    
+    # Format timestamp
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    
+    # Fill the template
+    html_content = HTML_TEMPLATE.replace("{{timestamp}}", timestamp)
+    html_content = html_content.replace("{{total_failures}}", str(total_failures))
+    html_content = html_content.replace("{{question_types_count}}", str(question_types_count))
+    html_content = html_content.replace("{{type_stats_rows}}", type_stats_rows)
+    html_content = html_content.replace("{{error_stats_rows}}", error_stats_rows)
+    html_content = html_content.replace("{{suggestions_content}}", suggestions_content)
+    html_content = html_content.replace("{{examples_content}}", examples_content)
+    
+    # Write the report
+    with open(output_path, "w") as f:
+        f.write(html_content)
+    
+    return output_path
+
+
+def generate_and_open_report() -> None:
+    """Generate a validation report and open it in the default browser."""
+    report_path = generate_html_report()
+    print(f"Report generated at: {report_path}")
+    
+    # Try to open the report in a browser
+    try:
+        import webbrowser
+        webbrowser.open(f"file://{report_path}")
+    except Exception as e:
+        print(f"Could not open browser: {e}")
+        print(f"Report is available at: {report_path}")
+
+
+if __name__ == "__main__":
+    generate_and_open_report()

--- a/edsl/questions/validation_logger.py
+++ b/edsl/questions/validation_logger.py
@@ -20,7 +20,8 @@ logger = logging.getLogger("validation_failures")
 logger.setLevel(logging.INFO)
 
 # Determine log directory path
-LOG_DIR = Path(CONFIG.get("EDSL_LOG_DIR", Path.home() / ".edsl" / "logs"))
+DEFAULT_LOG_DIR = Path.home() / ".edsl" / "logs"
+LOG_DIR = Path(CONFIG.get("EDSL_LOG_DIR", default=str(DEFAULT_LOG_DIR)))
 VALIDATION_LOG_FILE = LOG_DIR / "validation_failures.log"
 
 # Create log directory if it doesn't exist

--- a/edsl/questions/validation_logger.py
+++ b/edsl/questions/validation_logger.py
@@ -21,7 +21,11 @@ logger.setLevel(logging.INFO)
 
 # Determine log directory path
 DEFAULT_LOG_DIR = Path.home() / ".edsl" / "logs"
-LOG_DIR = Path(CONFIG.get("EDSL_LOG_DIR", default=str(DEFAULT_LOG_DIR)))
+try:
+    LOG_DIR = Path(CONFIG.get("EDSL_LOG_DIR"))
+except Exception:
+    # If EDSL_LOG_DIR is not defined, use default
+    LOG_DIR = DEFAULT_LOG_DIR
 VALIDATION_LOG_FILE = LOG_DIR / "validation_failures.log"
 
 # Create log directory if it doesn't exist

--- a/edsl/questions/validation_logger.py
+++ b/edsl/questions/validation_logger.py
@@ -1,0 +1,111 @@
+"""Logger for validation failures in questions.
+
+This module provides functionality to log validation failures that occur when
+question answers don't meet the expected format or constraints. The logs can be
+used to improve the "fix" methods for questions.
+"""
+
+import datetime
+import json
+import logging
+import os
+import traceback
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..config import CONFIG
+
+# Set up logging
+logger = logging.getLogger("validation_failures")
+logger.setLevel(logging.INFO)
+
+# Determine log directory path
+LOG_DIR = Path(CONFIG.get("EDSL_LOG_DIR", Path.home() / ".edsl" / "logs"))
+VALIDATION_LOG_FILE = LOG_DIR / "validation_failures.log"
+
+# Create log directory if it doesn't exist
+os.makedirs(LOG_DIR, exist_ok=True)
+
+# Create file handler
+file_handler = logging.FileHandler(VALIDATION_LOG_FILE)
+file_handler.setLevel(logging.INFO)
+
+# Create formatter
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+file_handler.setFormatter(formatter)
+
+# Add handler to logger
+logger.addHandler(file_handler)
+
+
+def log_validation_failure(
+    question_type: str,
+    question_name: str,
+    error_message: str,
+    invalid_data: Dict[str, Any],
+    model_schema: Dict[str, Any],
+    question_dict: Optional[Dict[str, Any]] = None,
+) -> None:
+    """
+    Log a validation failure to the validation failures log file.
+    
+    Args:
+        question_type: The type of question that had a validation failure
+        question_name: The name of the question
+        error_message: The validation error message
+        invalid_data: The data that failed validation
+        model_schema: The schema of the model used for validation
+        question_dict: Optional dictionary representation of the question
+    """
+    log_entry = {
+        "timestamp": datetime.datetime.now().isoformat(),
+        "question_type": question_type,
+        "question_name": question_name,
+        "error_message": error_message,
+        "invalid_data": invalid_data,
+        "model_schema": model_schema,
+        "question_dict": question_dict,
+        "traceback": traceback.format_exc(),
+    }
+    
+    # Log as JSON for easier parsing
+    logger.info(json.dumps(log_entry))
+
+
+def get_validation_failure_logs(n: int = 10) -> list:
+    """
+    Get the latest n validation failure logs.
+    
+    Args:
+        n: Number of logs to return (default: 10)
+        
+    Returns:
+        List of validation failure log entries as dictionaries
+    """
+    logs = []
+    
+    # Check if log file exists
+    if not os.path.exists(VALIDATION_LOG_FILE):
+        return logs
+        
+    with open(VALIDATION_LOG_FILE, "r") as f:
+        for line in f:
+            try:
+                # Skip non-JSON lines (like logger initialization)
+                if not line.strip().startswith("{"):
+                    continue
+                log_entry = json.loads(line.split(" - ")[-1])
+                logs.append(log_entry)
+            except (json.JSONDecodeError, IndexError):
+                # Skip malformed lines
+                continue
+    
+    # Return most recent logs first
+    return sorted(logs, key=lambda x: x.get("timestamp", ""), reverse=True)[:n]
+
+
+def clear_validation_logs() -> None:
+    """Clear all validation failure logs."""
+    if os.path.exists(VALIDATION_LOG_FILE):
+        with open(VALIDATION_LOG_FILE, "w") as f:
+            f.write("")

--- a/tests/questions/test_validation_logger.py
+++ b/tests/questions/test_validation_logger.py
@@ -1,0 +1,224 @@
+"""Tests for the validation logger and analysis tools."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch
+
+from edsl.questions.validation_logger import (
+    log_validation_failure,
+    get_validation_failure_logs,
+    clear_validation_logs,
+    VALIDATION_LOG_FILE
+)
+from edsl.questions.validation_analysis import (
+    get_validation_failure_stats,
+    suggest_fix_improvements,
+    export_improvements_report
+)
+
+
+@pytest.fixture
+def clean_log_file():
+    """Ensure log file is clean for tests."""
+    if os.path.exists(VALIDATION_LOG_FILE):
+        os.remove(VALIDATION_LOG_FILE)
+    yield
+    if os.path.exists(VALIDATION_LOG_FILE):
+        os.remove(VALIDATION_LOG_FILE)
+
+
+def test_log_validation_failure(clean_log_file):
+    """Test that logging validation failures works."""
+    # Log a sample validation failure
+    log_validation_failure(
+        question_type="QuestionMultipleChoice",
+        question_name="test_question",
+        error_message="Value is not a valid integer",
+        invalid_data={"answer": "not_an_integer"},
+        model_schema={"type": "object", "properties": {"answer": {"type": "integer"}}},
+        question_dict={"question_name": "test_question", "question_type": "multiple_choice"}
+    )
+    
+    # Check that the log file exists
+    assert os.path.exists(VALIDATION_LOG_FILE)
+    
+    # Read the log file and check content
+    with open(VALIDATION_LOG_FILE, "r") as f:
+        log_content = f.read()
+    
+    assert "QuestionMultipleChoice" in log_content
+    assert "test_question" in log_content
+    assert "Value is not a valid integer" in log_content
+    assert "not_an_integer" in log_content
+
+
+def test_get_validation_failure_logs(clean_log_file):
+    """Test retrieving validation failure logs."""
+    # Log multiple sample validation failures
+    for i in range(3):
+        log_validation_failure(
+            question_type=f"Question{i}",
+            question_name=f"test_question_{i}",
+            error_message=f"Error {i}",
+            invalid_data={"answer": f"data_{i}"},
+            model_schema={"type": "object"},
+            question_dict={"question_name": f"test_question_{i}"}
+        )
+    
+    # Get logs and verify
+    logs = get_validation_failure_logs()
+    assert len(logs) == 3
+    
+    # Verify log content (newest first)
+    assert logs[0]["question_type"] == "Question2"
+    assert logs[1]["question_type"] == "Question1"
+    assert logs[2]["question_type"] == "Question0"
+    
+    # Test limiting the number of logs
+    limited_logs = get_validation_failure_logs(n=2)
+    assert len(limited_logs) == 2
+    assert limited_logs[0]["question_type"] == "Question2"
+    assert limited_logs[1]["question_type"] == "Question1"
+
+
+def test_clear_validation_logs(clean_log_file):
+    """Test clearing validation logs."""
+    # Log a sample validation failure
+    log_validation_failure(
+        question_type="TestQuestion",
+        question_name="test_question",
+        error_message="Test error",
+        invalid_data={"answer": "test_data"},
+        model_schema={"type": "object"},
+        question_dict=None
+    )
+    
+    # Verify log exists
+    assert os.path.exists(VALIDATION_LOG_FILE)
+    logs = get_validation_failure_logs()
+    assert len(logs) > 0
+    
+    # Clear logs and verify
+    clear_validation_logs()
+    logs_after_clear = get_validation_failure_logs()
+    assert len(logs_after_clear) == 0
+
+
+def test_get_validation_failure_stats(clean_log_file):
+    """Test getting validation failure statistics."""
+    # Log sample validation failures with patterns
+    for _ in range(3):
+        log_validation_failure(
+            question_type="QuestionMultipleChoice",
+            question_name="test_mc",
+            error_message="Value is not a valid integer",
+            invalid_data={"answer": "not_an_integer"},
+            model_schema={"type": "object"},
+            question_dict=None
+        )
+    
+    for _ in range(2):
+        log_validation_failure(
+            question_type="QuestionMultipleChoice",
+            question_name="test_mc",
+            error_message="Value is not in valid options",
+            invalid_data={"answer": "invalid_option"},
+            model_schema={"type": "object"},
+            question_dict=None
+        )
+    
+    for _ in range(1):
+        log_validation_failure(
+            question_type="QuestionNumerical",
+            question_name="test_num",
+            error_message="Value is not a valid number",
+            invalid_data={"answer": "not_a_number"},
+            model_schema={"type": "object"},
+            question_dict=None
+        )
+    
+    # Get statistics and verify
+    stats = get_validation_failure_stats()
+    
+    # Check counts by question type
+    assert stats["by_question_type"]["QuestionMultipleChoice"] == 5
+    assert stats["by_question_type"]["QuestionNumerical"] == 1
+    
+    # Check counts by error message
+    assert stats["by_error_message"]["QuestionMultipleChoice"]["Value is not a valid integer"] == 3
+    assert stats["by_error_message"]["QuestionMultipleChoice"]["Value is not in valid options"] == 2
+    assert stats["by_error_message"]["QuestionNumerical"]["Value is not a valid number"] == 1
+
+
+def test_suggest_fix_improvements(clean_log_file):
+    """Test suggesting fix method improvements."""
+    # Log sample validation failures
+    log_validation_failure(
+        question_type="QuestionMultipleChoice",
+        question_name="test_mc",
+        error_message="Value is not a valid integer",
+        invalid_data={"answer": "not_an_integer"},
+        model_schema={"type": "object"},
+        question_dict=None
+    )
+    
+    log_validation_failure(
+        question_type="QuestionNumerical",
+        question_name="test_num",
+        error_message="Value is greater than maximum",
+        invalid_data={"answer": 100},
+        model_schema={"type": "object"},
+        question_dict=None
+    )
+    
+    # Get suggestions and verify
+    suggestions = suggest_fix_improvements()
+    
+    # Check suggestions for QuestionMultipleChoice
+    assert "QuestionMultipleChoice" in suggestions
+    mc_suggestion = suggestions["QuestionMultipleChoice"][0]
+    assert "error_message" in mc_suggestion
+    assert "suggestion" in mc_suggestion
+    assert "occurrence_count" in mc_suggestion
+    
+    # Check suggestions for QuestionNumerical
+    assert "QuestionNumerical" in suggestions
+    num_suggestion = suggestions["QuestionNumerical"][0]
+    assert "greater than" in num_suggestion["error_message"]
+    assert "value range constraints" in num_suggestion["suggestion"]
+    
+    # Check filtering by question type
+    filtered_suggestions = suggest_fix_improvements(question_type="QuestionNumerical")
+    assert "QuestionMultipleChoice" not in filtered_suggestions
+    assert "QuestionNumerical" in filtered_suggestions
+
+
+def test_export_improvements_report(clean_log_file, tmpdir):
+    """Test exporting improvements report."""
+    # Log sample validation failures
+    log_validation_failure(
+        question_type="QuestionMultipleChoice",
+        question_name="test_mc",
+        error_message="Value is not a valid integer",
+        invalid_data={"answer": "not_an_integer"},
+        model_schema={"type": "object"},
+        question_dict=None
+    )
+    
+    # Create a temporary output file
+    output_path = tmpdir.join("test_report.json")
+    
+    # Export report
+    report_path = export_improvements_report(output_path=output_path)
+    
+    # Verify report exists
+    assert os.path.exists(report_path)
+    
+    # Check report content
+    with open(report_path, "r") as f:
+        report = json.load(f)
+    
+    assert "validation_failure_stats" in report
+    assert "fix_method_improvement_suggestions" in report
+    assert "QuestionMultipleChoice" in report["fix_method_improvement_suggestions"]

--- a/tests/questions/test_validation_logger.py
+++ b/tests/questions/test_validation_logger.py
@@ -21,9 +21,16 @@ from edsl.questions.validation_analysis import (
 @pytest.fixture
 def clean_log_file():
     """Ensure log file is clean for tests."""
+    # Make sure the log directory exists
+    os.makedirs(os.path.dirname(VALIDATION_LOG_FILE), exist_ok=True)
+    
+    # Clean up existing log file
     if os.path.exists(VALIDATION_LOG_FILE):
         os.remove(VALIDATION_LOG_FILE)
+    
     yield
+    
+    # Clean up after test
     if os.path.exists(VALIDATION_LOG_FILE):
         os.remove(VALIDATION_LOG_FILE)
 


### PR DESCRIPTION
## Summary
This PR adds a system to log validation failures that occur when question answers don't meet expected formats or constraints. The goal is to improve the "fix" methods for questions by analyzing common validation failure patterns.

Features:
- Logs validation failures to a local file with detailed context
- Provides analysis tools to identify common failure patterns
- Suggests improvements for fix methods based on analysis
- Generates HTML reports to visualize validation failures
- Adds CLI commands for managing and viewing validation logs
- Includes tests and documentation

## Test plan
- Run the validation logger tests: Session starting
============================= test session starts ==============================
platform darwin -- Python 3.11.0, pytest-8.3.5, pluggy-1.5.0 -- /Users/johnhorton/.pyenv/versions/3.11.0/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/johnhorton/tools/ep/edsl/tests
configfile: pytest.ini
plugins: env-1.1.5, anyio-4.7.0, Faker-37.0.0
collecting ... collected 6 items

tests/questions/test_validation_logger.py::test_log_validation_failure Cleaning tempfiles...
[ ! -f .coverage ] || rm .coverage
[ ! -d .edsl_cache ] || rm  -rf .edsl_cache
[ ! -d .mypy_cache ] || rm -rf .mypy_cache
[ ! -d .temp ] || rm -rf .temp
[ ! -d dist ] || rm -rf dist
[ ! -d htmlcov ] || rm -rf htmlcov
[ ! -f output.html ] || rm output.html
[ ! -d prof ] || rm -rf prof
[ ! -f test.dta ] || rm test.dta
[ ! -f *.docx ] || rm *.docx
[ ! -f *.html ] || rm *.html
[ ! -f *.json ] || rm *.json
find . -type d -name '.venv' -prune -o -type f -name '*.db' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type f -name '*.db.bak' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type f -name '*.log' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type d -name '.pytest_cache' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type d -name '__pycache__' -exec rm -rf {} +
[ ! -d dist ] || rm -rf dist
[ ! -d htmlcov ] || rm -rf htmlcov
[ ! -d prof ] || rm -rf prof
[ ! -d tests/temp_outputs ] || rm -rf tests/temp_outputs
[ ! -f tests/edsl_cache_test.db ] || rm tests/edsl_cache_test.db
[ ! -f tests/interview.log ] || rm tests/interview.log
[ ! -f tests/test_pytest_report.html ] || rm tests/test_pytest_report.html
FAILEDCleaning tempfiles...
[ ! -f .coverage ] || rm .coverage
[ ! -d .edsl_cache ] || rm  -rf .edsl_cache
[ ! -d .mypy_cache ] || rm -rf .mypy_cache
[ ! -d .temp ] || rm -rf .temp
[ ! -d dist ] || rm -rf dist
[ ! -d htmlcov ] || rm -rf htmlcov
[ ! -f output.html ] || rm output.html
[ ! -d prof ] || rm -rf prof
[ ! -f test.dta ] || rm test.dta
[ ! -f *.docx ] || rm *.docx
[ ! -f *.html ] || rm *.html
[ ! -f *.json ] || rm *.json
find . -type d -name '.venv' -prune -o -type f -name '*.db' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type f -name '*.db.bak' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type f -name '*.log' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type d -name '.pytest_cache' -exec rm -rf {} +
find . -type d -name '.venv' -prune -o -type d -name '__pycache__' -exec rm -rf {} +
[ ! -d dist ] || rm -rf dist
[ ! -d htmlcov ] || rm -rf htmlcov
[ ! -d prof ] || rm -rf prof
[ ! -d tests/temp_outputs ] || rm -rf tests/temp_outputs
[ ! -f tests/edsl_cache_test.db ] || rm tests/edsl_cache_test.db
[ ! -f tests/interview.log ] || rm tests/interview.log
[ ! -f tests/test_pytest_report.html ] || rm tests/test_pytest_report.html


=================================== FAILURES ===================================
_________________________ test_log_validation_failure __________________________

clean_log_file = None

    def test_log_validation_failure(clean_log_file):
        """Test that logging validation failures works."""
        # Log a sample validation failure
        log_validation_failure(
            question_type="QuestionMultipleChoice",
            question_name="test_question",
            error_message="Value is not a valid integer",
            invalid_data={"answer": "not_an_integer"},
            model_schema={"type": "object", "properties": {"answer": {"type": "integer"}}},
            question_dict={"question_name": "test_question", "question_type": "multiple_choice"}
        )
    
        # Check that the log file exists
>       assert os.path.exists(VALIDATION_LOG_FILE)
E       AssertionError: assert False
E        +  where False = <function exists at 0x1009df420>(PosixPath('/Users/johnhorton/.edsl/logs/validation_failures.log'))
E        +    where <function exists at 0x1009df420> = <module 'posixpath' (frozen)>.exists
E        +      where <module 'posixpath' (frozen)> = os.path

tests/questions/test_validation_logger.py:51: AssertionError
------------------------------ Captured log call -------------------------------
INFO     validation_failures:validation_logger.py:77 {"timestamp": "2025-04-05T14:38:15.215446", "question_type": "QuestionMultipleChoice", "question_name": "test_question", "error_message": "Value is not a valid integer", "invalid_data": {"answer": "not_an_integer"}, "model_schema": {"type": "object", "properties": {"answer": {"type": "integer"}}}, "question_dict": {"question_name": "test_question", "question_type": "multiple_choice"}, "traceback": "NoneType: None\n"}
=============================== warnings summary ===============================
edsl/coop/ep_key_handling.py:151
edsl/coop/ep_key_handling.py:151
  /Users/johnhorton/tools/ep/edsl/edsl/coop/ep_key_handling.py:151: UserWarning: WARNING: The Expected Parrot API key from the environment variable differs from the one stored in the config directory. Using the one from the environment variable.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/questions/test_validation_logger.py::test_log_validation_failure
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
======================== 1 failed, 2 warnings in 1.09s =========================
- Try the CLI commands: [] and {
  "by_question_type": {},
  "by_error_message": {}
}
- Generate an HTML report: HTML report generated at: /Users/johnhorton/Library/Application 
Support/edsl/logs/validation_report.html
Opened report in browser or python -c "from edsl.questions import generate_and_open_report; generate_and_open_report()"
Report generated at: /Users/johnhorton/Library/Application Support/edsl/logs/validation_report.html
- Generate validation failures by running questions with invalid responses

Fixes #954: Start logging validation failures with goal of improving "fix" methods

🤖 Generated with [Claude Code](https://claude.ai/code)