### PR TITLE
Refactor view methods in file handlers to accept width and height parameters

### DIFF
--- a/edsl/scenarios/file_methods.py
+++ b/edsl/scenarios/file_methods.py
@@ -71,18 +71,18 @@ class FileMethods(ABC):
         return list(cls._handlers.keys())
 
     @abstractmethod
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         ...
 
     @abstractmethod
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         ...
 
-    def view(self):
+    def view(self, width: int = None, height: int = None):
         if is_notebook():
-            self.view_notebook()
+            self.view_notebook(width=width, height=height)
         else:
-            self.view_system()
+            self.view_system(width=width, height=height)
 
     @abstractmethod
     def example(self):

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -459,10 +459,10 @@ class FileStore(Scenario):
 
         return temp_file.name
 
-    def view(self) -> None:
+    def view(self, width: int = None, height: int = None) -> None:
         handler = FileMethods.get_handler(self.suffix)
         if handler:
-            handler(self.path).view()
+            handler(self.path).view(width=width, height=height)
         else:
             print(f"Viewing of {self.suffix} files is not supported.")
 

--- a/edsl/scenarios/handlers/csv_file_store.py
+++ b/edsl/scenarios/handlers/csv_file_store.py
@@ -4,7 +4,7 @@ from ..file_methods import FileMethods
 class CsvMethods(FileMethods):
     suffix = "csv"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -21,7 +21,7 @@ class CsvMethods(FileMethods):
         else:
             print("CSV file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         import pandas as pd
         from IPython.display import display
 

--- a/edsl/scenarios/handlers/docx_file_store.py
+++ b/edsl/scenarios/handlers/docx_file_store.py
@@ -19,7 +19,7 @@ class DocxMethods(FileMethods):
         text = "\n".join(full_text)
         return text
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -36,7 +36,7 @@ class DocxMethods(FileMethods):
         else:
             print("DOCX file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         try:
             import mammoth
         except ImportError:
@@ -44,10 +44,13 @@ class DocxMethods(FileMethods):
             return
         from IPython.display import HTML, display
 
+        _width = width if width is not None else 800
+        _height = height if height is not None else 800
+
         with open(self.path, "rb") as docx_file:
             result = mammoth.convert_to_html(docx_file)
             html = f"""
-            <div style="width: 800px; height: 800px; padding: 20px; 
+            <div style="width: {_width}px; height: {_height}px; padding: 20px; 
                        border: 1px solid #ccc; overflow-y: auto;">
                 {result.value}
             </div>

--- a/edsl/scenarios/handlers/html_file_store.py
+++ b/edsl/scenarios/handlers/html_file_store.py
@@ -4,7 +4,7 @@ from ..file_methods import FileMethods
 class HtmlMethods(FileMethods):
     suffix = "html"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import webbrowser
 
         # with open(self.path, "r") as f:
@@ -14,10 +14,12 @@ class HtmlMethods(FileMethods):
         # webbrowser.open("file://" + html_path)
         webbrowser.open("file://" + self.path)
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import IFrame, display
 
-        display(IFrame(self.path, width=800, height=800))
+        _width = width if width is not None else 800
+        _height = height if height is not None else 800
+        display(IFrame(self.path, width=_width, height=_height))
 
     def example(self):
         html_string = b"""

--- a/edsl/scenarios/handlers/jpeg_file_store.py
+++ b/edsl/scenarios/handlers/jpeg_file_store.py
@@ -5,7 +5,7 @@ from ..file_methods import FileMethods
 class JpegMethods(FileMethods):
     suffix = "jpeg"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -22,10 +22,10 @@ class JpegMethods(FileMethods):
         else:
             print("JPEG file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import Image, display
 
-        display(Image(filename=self.path))
+        display(Image(filename=self.path, width=width, height=height))
 
     def example(self):
         import matplotlib.pyplot as plt

--- a/edsl/scenarios/handlers/json_file_store.py
+++ b/edsl/scenarios/handlers/json_file_store.py
@@ -7,7 +7,7 @@ from ..file_methods import FileMethods
 class JsonMethods(FileMethods):
     suffix = "json"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -24,7 +24,7 @@ class JsonMethods(FileMethods):
         else:
             print("JSON file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import FileLink, JSON, display
         import json
 

--- a/edsl/scenarios/handlers/md_file_store.py
+++ b/edsl/scenarios/handlers/md_file_store.py
@@ -5,7 +5,7 @@ from ..file_methods import FileMethods
 class MarkdownMethods(FileMethods):
     suffix = "md"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -22,7 +22,7 @@ class MarkdownMethods(FileMethods):
         else:
             print("Markdown file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import FileLink, Markdown, display
 
         # First display the content of the markdown file

--- a/edsl/scenarios/handlers/mp4_file_store.py
+++ b/edsl/scenarios/handlers/mp4_file_store.py
@@ -11,7 +11,7 @@ class Mp4Methods(FileMethods):
     """
     suffix = "mp4"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         """
         Open the MP4 file with the system's default video player.
         """
@@ -31,12 +31,15 @@ class Mp4Methods(FileMethods):
         else:
             print("MP4 file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         """
         Display the MP4 video in a Jupyter notebook using IPython's HTML display.
         """
         from IPython.display import HTML, display
         import base64
+        
+        _width = width if width is not None else 640
+        _height = height if height is not None else 360
         
         # Read the video file and encode it as base64
         with open(self.path, 'rb') as f:
@@ -46,7 +49,7 @@ class Mp4Methods(FileMethods):
         
         # Create an HTML5 video element with the base64-encoded video
         video_html = f"""
-        <video width="640" height="360" controls>
+        <video width="{_width}" height="{_height}" controls>
             <source src="data:video/mp4;base64,{video_base64}" type="video/mp4">
             Your browser does not support the video tag.
         </video>

--- a/edsl/scenarios/handlers/pdf_file_store.py
+++ b/edsl/scenarios/handlers/pdf_file_store.py
@@ -26,7 +26,7 @@ class PdfMethods(FileMethods):
 
         return text
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import subprocess
 
         if os.path.exists(self.path):
@@ -42,8 +42,11 @@ class PdfMethods(FileMethods):
         else:
             print("PDF file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import HTML, display
+
+        _width = width if width is not None else 800
+        _height = height if height is not None else 800
 
         with open(self.path, "rb") as f:
             base64_pdf = base64.b64encode(f.read()).decode("utf-8")
@@ -51,8 +54,8 @@ class PdfMethods(FileMethods):
         html = f"""
         <iframe
             src="data:application/pdf;base64,{base64_pdf}"
-            width="800px"
-            height="800px"
+            width="{_width}px"
+            height="{_height}px"
             type="application/pdf"
         ></iframe>
         """

--- a/edsl/scenarios/handlers/png_file_store.py
+++ b/edsl/scenarios/handlers/png_file_store.py
@@ -5,7 +5,7 @@ from ..file_methods import FileMethods
 class PngMethods(FileMethods):
     suffix = "png"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -22,10 +22,10 @@ class PngMethods(FileMethods):
         else:
             print("PNG file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import Image, display
 
-        display(Image(filename=self.path))
+        display(Image(filename=self.path, width=width, height=height))
 
     def example(self):
         import matplotlib.pyplot as plt

--- a/edsl/scenarios/handlers/pptx_file_store.py
+++ b/edsl/scenarios/handlers/pptx_file_store.py
@@ -23,7 +23,7 @@ class PptxMethods(FileMethods):
         text = "\n\n".join(full_text)
         return text
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -40,9 +40,12 @@ class PptxMethods(FileMethods):
         else:
             print("PPTX file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from pptx import Presentation
         from IPython.display import HTML, display
+
+        _width = width if width is not None else 800
+        _height = height if height is not None else 800
 
         prs = Presentation(self.path)
 
@@ -64,7 +67,7 @@ class PptxMethods(FileMethods):
             )
 
         html = f"""
-        <div style="width: 800px; height: 800px; padding: 20px; 
+        <div style="width: {_width}px; height: {_height}px; padding: 20px; 
                    border: 1px solid #ccc; overflow-y: auto;">
             {''.join(html_content)}
         </div>

--- a/edsl/scenarios/handlers/py_file_store.py
+++ b/edsl/scenarios/handlers/py_file_store.py
@@ -11,7 +11,7 @@ from ..file_methods import FileMethods
 class PyMethods(FileMethods):
     suffix = "py"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         """Open the Python file in the system's default editor."""
         import os
         import subprocess
@@ -29,7 +29,7 @@ class PyMethods(FileMethods):
         else:
             print("Python file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         """Display the Python file with syntax highlighting in a notebook."""
         from IPython.display import FileLink, display, HTML
         import pygments

--- a/edsl/scenarios/handlers/sql_file_store.py
+++ b/edsl/scenarios/handlers/sql_file_store.py
@@ -9,7 +9,7 @@ from ..file_methods import FileMethods
 class SqlMethods(FileMethods):
     suffix = "sql"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -26,7 +26,7 @@ class SqlMethods(FileMethods):
         else:
             print("SQL file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from IPython.display import FileLink, display, HTML
         import pygments
         from pygments.lexers import SqlLexer

--- a/edsl/scenarios/handlers/sqlite_file_store.py
+++ b/edsl/scenarios/handlers/sqlite_file_store.py
@@ -46,7 +46,7 @@ class SQLiteMethods(FileMethods):
 
         return "\n".join(full_text)
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         """
         Opens the database with the system's default SQLite viewer if available.
         """
@@ -70,12 +70,16 @@ class SQLiteMethods(FileMethods):
         else:
             print("SQLite database file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         """
         Displays database contents in a Jupyter notebook.
         """
         import pandas as pd
         from IPython.display import HTML, display
+        import sqlite3
+
+        _width = width if width is not None else 800
+        _height = height if height is not None else 800
 
         with sqlite3.connect(self.path) as conn:
             # Get all table names
@@ -99,7 +103,7 @@ class SQLiteMethods(FileMethods):
 
             # Combine all tables into one scrollable div
             html = f"""
-            <div style="width: 800px; height: 800px; padding: 20px; 
+            <div style="width: {_width}px; height: {_height}px; padding: 20px; 
                        border: 1px solid #ccc; overflow-y: auto;">
                 {''.join(html_parts)}
             </div>

--- a/edsl/scenarios/handlers/txt_file_store.py
+++ b/edsl/scenarios/handlers/txt_file_store.py
@@ -5,7 +5,7 @@ from ..file_methods import FileMethods
 class TxtMethods(FileMethods):
     suffix = "txt"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         import os
         import subprocess
 
@@ -22,7 +22,7 @@ class TxtMethods(FileMethods):
         else:
             print("TXT file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         from ...display import FileLink, display
 
         display(FileLink(self.path))

--- a/edsl/scenarios/handlers/webm_file_store.py
+++ b/edsl/scenarios/handlers/webm_file_store.py
@@ -12,7 +12,7 @@ class WebmMethods(FileMethods):
     """
     suffix = "webm"
 
-    def view_system(self):
+    def view_system(self, width: int = None, height: int = None):
         """
         Open the WebM file with the system's default video player.
         """
@@ -32,13 +32,16 @@ class WebmMethods(FileMethods):
         else:
             print("WebM file was not found.")
 
-    def view_notebook(self):
+    def view_notebook(self, width: int = None, height: int = None):
         """
         Display the WebM video in a Jupyter notebook using IPython's HTML display.
         """
         from IPython.display import HTML, display
         import base64
         
+        _width = width if width is not None else 640
+        _height = height if height is not None else 360
+
         # Read the video file and encode it as base64
         with open(self.path, 'rb') as f:
             video_data = f.read()
@@ -47,7 +50,7 @@ class WebmMethods(FileMethods):
         
         # Create an HTML5 video element with the base64-encoded video
         video_html = f"""
-        <video width="640" height="360" controls>
+        <video width="{_width}" height="{_height}" controls>
             <source src="data:video/webm;base64,{video_base64}" type="video/webm">
             Your browser does not support the video tag.
         </video>


### PR DESCRIPTION
Related to [Issue #1779 ](https://github.com/expectedparrot/edsl/issues/1779).
Hi, I'm new here, I want to start with something simple starting to contribute to this project.
This update introduces optional `width` and `height` parameters to the `view_()` functions, allowing users to specify the size of the display when viewing images or files. This change enhances the flexibility of the `view()` function, enabling better control over how the content is rendered.
Now, users can specify the desired display size with the following syntax:
```python
from edsl import FileStore
fs = FileStore(path="/Users/johnhorton/Downloads/things.png")
fs.view(width=100, height=100)  # The width and height are now customizable
fs.view(100)  # Width first
```
