### PR TITLE
Add interview counts for partially failed jobs

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -1222,6 +1222,7 @@ class Coop(CoopFunctionsMixin):
                 "results_url": results_url,
                 "latest_error_report_uuid": latest_error_report_uuid,
                 "latest_error_report_url": latest_error_report_url,
+                "latest_failure_description": data.get("latest_failure_details"),
                 "status": data.get("status"),
                 "reason": data.get("latest_failure_reason"),
                 "credits_consumed": data.get("price"),

--- a/edsl/jobs/html_table_job_logger.py
+++ b/edsl/jobs/html_table_job_logger.py
@@ -362,7 +362,11 @@ class HTMLTableJobLogger(JobLogger):
         other_fields = []
 
         for field, _ in self.jobs_info.__annotations__.items():
-            if field != "pretty_names":
+            if field not in [
+                "pretty_names",
+                "completed_interviews",
+                "failed_interviews",
+            ]:
                 value = getattr(self.jobs_info, field)
                 if not value:
                     continue
@@ -522,6 +526,14 @@ class HTMLTableJobLogger(JobLogger):
 
         display_style = "block" if self.is_expanded else "none"
 
+        header_status_text = status_text
+        if (
+            current_status == JobsStatus.PARTIALLY_FAILED
+            and self.jobs_info.completed_interviews is not None
+            and self.jobs_info.failed_interviews is not None
+        ):
+            header_status_text += f" ({self.jobs_info.completed_interviews:,} completed, {self.jobs_info.failed_interviews:,} failed)"
+
         return f"""
         {css}
         <div class="jobs-container">
@@ -539,7 +551,7 @@ class HTMLTableJobLogger(JobLogger):
                     <span id="arrow-{self.log_id}" class="expand-toggle">{'&#8963;' if self.is_expanded else '&#8964;'}</span>
                     Job Status 🦜
                 </div>
-                <div class="{status_class}">{status_text}</div>
+                <div class="{status_class}">{header_status_text}</div>
             </div>
             <div id="content-{self.log_id}" class="jobs-content" style="display: {display_style};">
                 {content_html}

--- a/edsl/jobs/jobs_remote_inference_logger.py
+++ b/edsl/jobs/jobs_remote_inference_logger.py
@@ -30,6 +30,8 @@ class JobsInfo:
     error_report_url: str = None
     results_uuid: str = None
     results_url: str = None
+    completed_interviews: int = None
+    failed_interviews: int = None
 
     pretty_names = {
         "job_uuid": "Job UUID",
@@ -53,6 +55,8 @@ class JobLogger(ABC):
             "error_report_url",
             "results_uuid",
             "results_url",
+            "completed_interviews",
+            "failed_interviews",
         ],
         value: str,
     ):

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional, Union, Literal, TYPE_CHECKING, NewType, Callable, Any
 from dataclasses import dataclass
 from ..coop import CoopServerResponseError
@@ -200,10 +201,35 @@ class JobsRemoteInferenceHandler:
             status=JobsStatus.FAILED,
         )
 
+    def _handle_partially_failed_job_interview_details(
+        self, job_info: RemoteJobInfo, remote_job_data: RemoteInferenceResponse
+    ) -> None:
+        "Extracts the interview details from the remote job data."
+        try:
+            # Job details is a string of the form "64 out of 1,758 interviews failed"
+            job_details = remote_job_data.get("latest_failure_description")
+
+            text_without_commas = job_details.replace(",", "")
+
+            # Find all numbers in the text
+            numbers = [int(num) for num in re.findall(r"\d+", text_without_commas)]
+
+            failed = numbers[0]
+            total = numbers[1]
+            completed = total - failed
+
+            job_info.logger.add_info("completed_interviews", completed)
+            job_info.logger.add_info("failed_interviews", failed)
+        # This is mainly helpful metadata, and any errors here should not stop the code
+        except:
+            pass
+
     def _handle_partially_failed_job(
         self, job_info: RemoteJobInfo, remote_job_data: RemoteInferenceResponse
     ) -> None:
         "Handles a partially failed job by logging the error and updating the job status."
+        self._handle_partially_failed_job_interview_details(job_info, remote_job_data)
+
         latest_error_report_url = remote_job_data.get("latest_error_report_url")
 
         if latest_error_report_url:
@@ -256,6 +282,7 @@ class JobsRemoteInferenceHandler:
                 f"View partial results [here]({results_url})",
                 status=JobsStatus.PARTIALLY_FAILED,
             )
+
         results.job_uuid = job_info.job_uuid
         results.results_uuid = results_uuid
         return results


### PR DESCRIPTION
Instead of just displaying "Partially failed" in the job status table header, this will display "Partially failed (x completed, y failed)", where x is the number of completed interviews and y is the number of failed interviews