### PR TITLE
1835 add better options to modeltest

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -677,7 +677,7 @@ class Coop(CoopFunctionsMixin):
         """
         edsl_class = ObjectRegistry.object_type_to_edsl_class.get(object_type)
         response = self._send_server_request(
-            uri="api/v0/objects",
+            uri="api/v0/object/list",
             method="GET",
             params={"type": object_type},
         )

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -684,17 +684,17 @@ class Coop(CoopFunctionsMixin):
         self._resolve_server_response(response)
         objects = []
         for o in response.json():
-            json_string = o.get("json_string")
-            ## check if load from bucket needed.
-            if "load_from:" in json_string[0:12]:
-                load_link = json_string.split("load_from:")[1]
-                object_data = requests.get(load_link)
-                self._resolve_gcs_response(object_data)
-                json_string = object_data.text
+            # json_string = o.get("json_string")
+            # ## check if load from bucket needed.
+            # if "load_from:" in json_string[0:12]:
+            #     load_link = json_string.split("load_from:")[1]
+            #     object_data = requests.get(load_link)
+            #     self._resolve_gcs_response(object_data)
+            #     json_string = object_data.text
 
-            json_string = json.loads(json_string)
+            # json_string = json.loads(json_string)
             object = {
-                "object": edsl_class.from_dict(json_string),
+                # "object": edsl_class.from_dict(json_string),
                 "uuid": o.get("uuid"),
                 "version": o.get("version"),
                 "description": o.get("description"),

--- a/edsl/inference_services/services/test_service.py
+++ b/edsl/inference_services/services/test_service.py
@@ -117,7 +117,7 @@ class TestService(InferenceServiceABC):
                     "usage": {"prompt_tokens": 1, "completion_tokens": 1},
                 }
 
-            def create_canned_response(self, survey):
+            def set_canned_response(self, survey: "Survey") -> None:
                 canned_response = {}
 
                 for q in survey.questions:
@@ -152,7 +152,7 @@ class TestService(InferenceServiceABC):
 
                     elif isinstance(q, QuestionDict):
                         # Return a dict with keys from question_dict_keys if present
-                        keys = getattr(q, "question_dict_keys", ["field1", "field2"])
+                        keys = getattr(q, "answer_keys", ["field1", "field2"])
                         canned_response[name] = {k: f"{k} value" for k in keys}
 
                     elif isinstance(q, QuestionFreeText):

--- a/edsl/inference_services/services/test_service.py
+++ b/edsl/inference_services/services/test_service.py
@@ -14,18 +14,6 @@ if TYPE_CHECKING:
     from ...scenarios.file_store import FileStore as File
 
 
-from edsl import Model
-from edsl.questions import (
-    QuestionMultipleChoice,
-    QuestionCheckBox,
-    QuestionLinearScale,
-    QuestionList,
-    QuestionDict,
-    QuestionNumerical,
-    QuestionFreeText,
-)
-
-
 class TestService(InferenceServiceABC):
     """OpenAI service class."""
 
@@ -118,6 +106,17 @@ class TestService(InferenceServiceABC):
                 }
 
             def set_canned_response(self, survey: "Survey") -> None:
+                from edsl import Model
+                from edsl.questions import (
+                    QuestionMultipleChoice,
+                    QuestionCheckBox,
+                    QuestionLinearScale,
+                    QuestionList,
+                    QuestionDict,
+                    QuestionNumerical,
+                    QuestionFreeText,
+                )
+
                 canned_response = {}
 
                 for q in survey.questions:

--- a/edsl/inference_services/services/test_service.py
+++ b/edsl/inference_services/services/test_service.py
@@ -151,9 +151,33 @@ class TestService(InferenceServiceABC):
                         canned_response[name] = [f"{name} item 1", f"{name} item 2"]
 
                     elif isinstance(q, QuestionDict):
-                        # Return a dict with keys from question_dict_keys if present
+                        # Handle response types for each key
                         keys = getattr(q, "answer_keys", ["field1", "field2"])
-                        canned_response[name] = {k: f"{k} value" for k in keys}
+                        value_types = getattr(q, "value_types", [])
+                        canned_response[name] = {}
+
+                        for i, key in enumerate(keys):
+                            # Check the type for each key and generate the appropriate response
+                            response_type = (
+                                value_types[i] if i < len(value_types) else "string"
+                            )  # Default to "string" if not provided
+
+                            if "str" in response_type:
+                                canned_response[name][key] = f"{key} value"
+                            elif "int" in response_type:
+                                canned_response[name][
+                                    key
+                                ] = 42  # Example integer response
+                            elif "float" in response_type:
+                                canned_response[name][
+                                    key
+                                ] = 42.0  # Example float response
+                            elif "bool" in response_type:
+                                canned_response[name][
+                                    key
+                                ] = True  # Example boolean response
+                            else:
+                                canned_response[name][key] = f"{key} unknown type"
 
                     elif isinstance(q, QuestionFreeText):
                         # Return a string
@@ -162,6 +186,7 @@ class TestService(InferenceServiceABC):
                     else:
                         # Fallback: simple string
                         canned_response[name] = f"Canned fallback for {name}"
+
                 self.canned_response = canned_response
 
         return TestServiceLanguageModel


### PR DESCRIPTION
Adding set_canned_response method to the model "test". The method allows to create the canned responses linked to a survey or job.survey. Using this model we can test fast and at no cost jobs or survey that we want to debug
Code example
```python
from edsl import (
    QuestionFreeText,
    QuestionMultipleChoice,
    QuestionCheckBox,
    QuestionLinearScale,
    QuestionList,
    QuestionDict,
    QuestionNumerical,
    Survey,
    Model
)
from edsl.caching import Cache
# Define questions of each type
q1 = QuestionFreeText(
    question_name="feedback",
    question_text="What did you think about the event overall?"
)

q2 = QuestionMultipleChoice(
    question_name="favorite_part",
    question_text="What was your favorite part of the event?",
    question_options=["Speakers", "Networking", "Workshops", "Food"]
)

q3 = QuestionCheckBox(
    question_name="topics_interested",
    question_text="Which of the following topics would you like to see more of in the future?",
    question_options=["AI", "Climate", "Healthcare", "Finance", "Education"]
)

q4 = QuestionLinearScale(
    question_name="satisfaction",
    question_text="How satisfied were you with the event?",
    question_options=list(range(1, 11))  # 1–10 scale
)

q5 = QuestionList(
    question_name="improvements",
    question_text="List up to three things that could be improved.",
    max_list_items=3
)

q6 = QuestionDict(
    question_name="session_feedback",
    question_text="For each session, provide one word to describe it.",
    answer_keys=["Keynote", "Breakout A", "Breakout B"],
    value_types=["string", "bool", "int"],

)

q7 = QuestionNumerical(
    question_name="attended_events",
    question_text="How many events like this have you attended in the past year?"
)

# Combine into a survey
survey = Survey([
    q1,q2,q3,q4,q6,q5,q7
])


model = Model("test")
model.set_canned_response(survey)
print(model.canned_response)

```