### PR TITLE
update github timeout to 30 minute

### DIFF
--- a/.github/workflows/build_package_source.yml
+++ b/.github/workflows/build_package_source.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow configuration. It increases the timeout for the `build` job from 15 minutes to 30 minutes to allow more time for the build process to complete.

* [`.github/workflows/build_package_source.yml`](diffhunk://#diff-e40bd784b469374280d12acdd660dd6dbdec1dda82681a7ca2e1d00cbab8f58eL20-R20): Increased the `timeout-minutes` value for the `build` job from 15 to 30.