### PR TITLE
1957 taskhistory doesn't preserve data after multiple serializationdeserialization operations

### DIFF
--- a/edsl/interviews/exception_tracking.py
+++ b/edsl/interviews/exception_tracking.py
@@ -205,16 +205,16 @@ class InterviewExceptionEntry:
 
         try:
             # Try to import the module and get the exception class
-            if module_name != "builtins":
-                import importlib
+            # if module_name != "builtins":
+            #     import importlib
 
-                module = importlib.import_module(module_name)
-                exception_class = getattr(module, exception_type, Exception)
-            else:
-                # Look for exception in builtins
-                import builtins
+            #     module = importlib.import_module(module_name)
+            #     exception_class = getattr(module, exception_type, Exception)
+            # else:
+            #     # Look for exception in builtins
+            import builtins
 
-                exception_class = getattr(builtins, exception_type, Exception)
+            exception_class = getattr(builtins, exception_type, Exception)
 
         except (ImportError, AttributeError):
             # Fall back to a generic Exception but preserve the type name

--- a/edsl/interviews/exception_tracking.py
+++ b/edsl/interviews/exception_tracking.py
@@ -16,8 +16,9 @@ class InterviewExceptionEntry:
         invigilator: "InvigilatorBase",
         traceback_format="text",
         answers=None,
+        time=None,  # Added time parameter for deserialization
     ):
-        self.time = datetime.datetime.now().isoformat()
+        self.time = time or datetime.datetime.now().isoformat()
         self.exception = exception
         self.invigilator = invigilator
         self.traceback_format = traceback_format
@@ -130,7 +131,12 @@ class InterviewExceptionEntry:
         'Traceback (most recent call last):...'
         """
         e = self.exception
-        tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+        # Check if the exception has a traceback attribute
+        if hasattr(e, "__traceback__") and e.__traceback__:
+            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+        else:
+            # Use the message as traceback if no traceback available
+            tb_str = f"Exception: {str(e)}"
         return tb_str
 
     @property
@@ -144,14 +150,19 @@ class InterviewExceptionEntry:
 
         console = Console(file=html_output, record=True)
 
-        tb = Traceback.from_exception(
-            type(self.exception),
-            self.exception,
-            self.exception.__traceback__,
-            show_locals=True,
-        )
-        console.print(tb)
-        return html_output.getvalue()
+        # Check if the exception has a traceback attribute
+        if hasattr(self.exception, "__traceback__") and self.exception.__traceback__:
+            tb = Traceback.from_exception(
+                type(self.exception),
+                self.exception,
+                self.exception.__traceback__,
+                show_locals=True,
+            )
+            console.print(tb)
+            return html_output.getvalue()
+        else:
+            # Return a simple string if no traceback available
+            return f"<pre>Exception: {str(self.exception)}</pre>"
 
     @staticmethod
     def serialize_exception(exception: Exception) -> dict:
@@ -160,14 +171,25 @@ class InterviewExceptionEntry:
         >>> entry = InterviewExceptionEntry.example()
         >>> _ = entry.serialize_exception(entry.exception)
         """
-        return {
-            "type": type(exception).__name__,
-            "message": str(exception),
-            "traceback": "".join(
+        # Store the original exception type for proper reconstruction
+        exception_type = type(exception).__name__
+        module_name = getattr(type(exception), "__module__", "builtins")
+
+        # Extract traceback if available
+        if hasattr(exception, "__traceback__") and exception.__traceback__:
+            tb_str = "".join(
                 traceback.format_exception(
                     type(exception), exception, exception.__traceback__
                 )
-            ),
+            )
+        else:
+            tb_str = f"Exception: {str(exception)}"
+
+        return {
+            "type": exception_type,
+            "module": module_name,
+            "message": str(exception),
+            "traceback": tb_str,
         }
 
     @staticmethod
@@ -177,11 +199,31 @@ class InterviewExceptionEntry:
         >>> entry = InterviewExceptionEntry.example()
         >>> _ = entry.deserialize_exception(entry.to_dict()["exception"])
         """
+        exception_type = data.get("type", "Exception")
+        module_name = data.get("module", "builtins")
+        message = data.get("message", "")
+
         try:
-            exception_class = globals()[data["type"]]
-        except KeyError:
-            exception_class = Exception
-        return exception_class(data["message"])
+            # Try to import the module and get the exception class
+            if module_name != "builtins":
+                import importlib
+
+                module = importlib.import_module(module_name)
+                exception_class = getattr(module, exception_type, Exception)
+            else:
+                # Look for exception in builtins
+                import builtins
+
+                exception_class = getattr(builtins, exception_type, Exception)
+
+        except (ImportError, AttributeError):
+            # Fall back to a generic Exception but preserve the type name
+            exception = Exception(message)
+            exception.__class__.__name__ = exception_type
+            return exception
+
+        # Create instance of the original exception type if possible
+        return exception_class(message)
 
     def to_dict(self) -> dict:
         """Return the exception as a dictionary.
@@ -221,7 +263,11 @@ class InterviewExceptionEntry:
             invigilator = None
         else:
             invigilator = InvigilatorAI.from_dict(data["invigilator"])
-        return cls(exception=exception, invigilator=invigilator)
+
+        # Use the original timestamp from serialization
+        time = data.get("time")
+
+        return cls(exception=exception, invigilator=invigilator, time=time)
 
 
 class InterviewExceptionCollection(UserDict):


### PR DESCRIPTION
This pull request introduces several changes to enhance exception handling, serialization, and deserialization in the `InterviewExceptionEntry` and related classes. Key improvements include better support for preserving exception details, handling missing traceback attributes, and maintaining original data during serialization and deserialization processes.

### Exception Handling Enhancements:
* Updated `text_traceback` and `html_traceback` methods to check for the presence of a `__traceback__` attribute in exceptions. If unavailable, a fallback string representation of the exception is used instead. (`[edsl/interviews/exception_tracking.pyR134-R139](diffhunk://#diff-3b8ff51b6665e3c6d6a1fe3c4be07f77c9a2064e8b16ee33f6f418b7709aa9e8R134-R139)`, `F371239fL144R160`)

### Serialization and Deserialization Improvements:
* Enhanced `serialize_exception` to include the exception's type and module, ensuring accurate reconstruction. Added fallback logic for missing traceback attributes. (`[edsl/interviews/exception_tracking.pyL163-R192](diffhunk://#diff-3b8ff51b6665e3c6d6a1fe3c4be07f77c9a2064e8b16ee33f6f418b7709aa9e8L163-R192)`)
* Refactored `deserialize_exception` to dynamically resolve exception classes using their type and module. Added fallback to a generic `Exception` while preserving the original type name if the class cannot be resolved. (`[edsl/interviews/exception_tracking.pyR202-R226](diffhunk://#diff-3b8ff51b6665e3c6d6a1fe3c4be07f77c9a2064e8b16ee33f6f418b7709aa9e8R202-R226)`)
* Modified `from_dict` to support deserialization of the original timestamp (`time`) from serialized data. (`[edsl/interviews/exception_tracking.pyL224-R270](diffhunk://#diff-3b8ff51b6665e3c6d6a1fe3c4be07f77c9a2064e8b16ee33f6f418b7709aa9e8L224-R270)`)

### Data Integrity in `InterviewExceptionCollection`:
* Introduced mechanisms in `InterviewExceptionCollection` to preserve the original data structure, including the interview ID and exceptions, ensuring that re-serialization retains all original details. (`[edsl/tasks/task_history.pyR273-R326](diffhunk://#diff-f843afd239307e5bf01685859fe15f29d3ae33209762dbb9a47adddf4c584898R273-R326)`)