### PR TITLE
add get profile

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2944,6 +2944,29 @@ class Coop(CoopFunctionsMixin):
         self._resolve_server_response(response)
         return response.json()
 
+    def get_profile(self) -> dict:
+        """
+        Get the current user's profile information.
+
+        This method retrieves the authenticated user's profile information from
+        the Expected Parrot platform using their API key.
+
+        Returns:
+            dict: User profile information including:
+                - username: The user's username
+                - email: The user's email address
+
+        Raises:
+            CoopServerResponseError: If there's an error communicating with the server
+
+        Example:
+            >>> profile = coop.get_profile()
+            >>> print(f"Welcome, {profile['username']}!")
+        """
+        response = self._send_server_request(uri="api/v0/users/profile", method="GET")
+        self._resolve_server_response(response)
+        return response.json()
+
     def login_gradio(self, timeout: int = 120, launch: bool = True, **launch_kwargs):
         """
         Start the EDSL auth token login flow inside a **Gradio** application.


### PR DESCRIPTION
This pull request introduces a new method to the `Coop` class in `edsl/coop/coop.py`. The method, `get_profile`, enables retrieval of the authenticated user's profile information from the Expected Parrot platform.

Key additions:

* **New Method for Profile Retrieval**:
  - [`get_profile`](diffhunk://#diff-e9dcb9357440f77d6502dcb2812bbf12457c9e617feced7309671a6f4561ead5R2947-R2969): Added a method to fetch the current user's profile information, including username and email, by making a GET request to the `api/v0/users/profile` endpoint. It raises `CoopServerResponseError` if server communication fails.