### PR TITLE
Fix typo in Jobs.humanize()

### DIFF
--- a/edsl/jobs/jobs.py
+++ b/edsl/jobs/jobs.py
@@ -1120,7 +1120,7 @@ class Jobs(Base):
             raise CoopValueError(
                 "You must specify both a scenario list and a scenario list method to use scenarios with your survey."
             )
-        elif scenario_list_method is "loop":
+        elif scenario_list_method == "loop":
             questions, long_scenario_list = self.survey.to_long_format(self.scenarios)
 
             # Replace the questions with new ones from the loop method


### PR DESCRIPTION
The typo was resulting in the following SyntaxWarning:
```
SyntaxWarning: "is" with a literal. Did you mean "=="?
```