### PR TITLE
Allow users to pull new format jobs

### DIFF
--- a/edsl/base/base_class.py
+++ b/edsl/base/base_class.py
@@ -331,8 +331,16 @@ class PersistenceMixin:
         """
         from edsl.coop import Coop
         from edsl.coop import ObjectRegistry
+        from edsl.jobs import Jobs
 
         coop = Coop(url=expected_parrot_url)
+
+        if issubclass(cls, Jobs):
+            job_data = coop.new_remote_inference_get(
+                str(url_or_uuid), include_json_string=True
+            )
+            job_dict = json.loads(job_data.get("job_json_string"))
+            return cls.from_dict(job_dict)
 
         object_type = ObjectRegistry.get_object_type_by_edsl_class(cls)
 

--- a/edsl/coop/coop_jobs_objects.py
+++ b/edsl/coop/coop_jobs_objects.py
@@ -26,7 +26,7 @@ class CoopJobsObjects(CoopObjects):
 
         c = Coop()
         job_details = [
-            c.remote_inference_get(obj["uuid"], include_json_string=True)
+            c.new_remote_inference_get(obj["uuid"], include_json_string=True)
             for obj in self
         ]
 

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -176,7 +176,7 @@ class JobsRemoteInferenceHandler:
         from ..coop import Coop
 
         coop = Coop()
-        return coop.remote_inference_get(job_uuid)
+        return coop.new_remote_inference_get(job_uuid)
 
     def _construct_remote_job_fetcher(
         self, testing_simulated_response: Optional[Any] = None
@@ -445,9 +445,9 @@ class JobsRemoteInferenceHandler:
             model_cost_dict["input_cost_credits_with_cache"] = converter.usd_to_credits(
                 input_cost_with_cache
             )
-            model_cost_dict[
-                "output_cost_credits_with_cache"
-            ] = converter.usd_to_credits(output_cost_with_cache)
+            model_cost_dict["output_cost_credits_with_cache"] = (
+                converter.usd_to_credits(output_cost_with_cache)
+            )
         return list(expenses_by_model.values())
 
     def _fetch_results_and_log(


### PR DESCRIPTION
These changes allow users to retrieve jobs that are stored in Google Cloud Storage (jobs have been added to GCS since the ORM migration). 