### PR TITLE
Add auto update

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -208,9 +208,10 @@ def _check_version_on_import():
             # Silently fail
             pass
 
-    # Run in a separate thread to avoid blocking imports
-    thread = threading.Thread(target=check_in_background, daemon=True)
-    thread.start()
+    check_in_background()
+    # # Run in a separate thread to avoid blocking imports
+    # thread = threading.Thread(target=check_in_background, daemon=True)
+    # thread.start()
 
 
 # Run version check on import

--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -150,3 +150,68 @@ BaseException.install_exception_hook()
 
 # Log the total number of items in __all__ for debugging
 logger.debug(f"EDSL initialization complete with {len(__all__)} items in __all__")
+
+
+def check_for_updates(silent: bool = False) -> dict:
+    """
+    Check if there's a newer version of EDSL available.
+
+    Args:
+        silent: If True, don't print any messages to console
+
+    Returns:
+        dict with version info if update is available, None otherwise
+    """
+    from edsl.coop import Coop
+
+    coop = Coop()
+    return coop.check_for_updates(silent=silent)
+
+
+# Add check_for_updates to exports
+__all__.append("check_for_updates")
+
+
+# Perform version check on import (non-blocking)
+def _check_version_on_import():
+    """Check for updates on package import in a non-blocking way."""
+    import threading
+    import os
+
+    # Check if version check is disabled
+    if os.getenv("EDSL_DISABLE_VERSION_CHECK", "").lower() in ["1", "true", "yes"]:
+        return
+
+    # Check if we've already checked recently (within 24 hours)
+    cache_file = os.path.join(os.path.expanduser("~"), ".edsl_version_check")
+    try:
+        if os.path.exists(cache_file):
+            with open(cache_file, "r") as f:
+                last_check = float(f.read().strip())
+                if time.time() - last_check < 86400:  # 24 hours
+                    return
+    except Exception:
+        pass
+
+    def check_in_background():
+        try:
+            # Update cache file
+            with open(cache_file, "w") as f:
+                f.write(str(time.time()))
+
+            # Perform the check
+            from edsl.coop import Coop
+
+            coop = Coop()
+            coop.check_for_updates(silent=False)
+        except Exception:
+            # Silently fail
+            pass
+
+    # Run in a separate thread to avoid blocking imports
+    thread = threading.Thread(target=check_in_background, daemon=True)
+    thread.start()
+
+
+# Run version check on import
+_check_version_on_import()

--- a/edsl/cli.py
+++ b/edsl/cli.py
@@ -26,91 +26,113 @@ app.add_typer(plugins_app, name="plugins")
 validation_app = typer.Typer(help="Manage EDSL validation failures")
 app.add_typer(validation_app, name="validation")
 
+
 @validation_app.command("logs")
 def list_validation_logs(
     count: int = typer.Option(10, "--count", "-n", help="Number of logs to show"),
-    question_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by question type"),
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    question_type: Optional[str] = typer.Option(
+        None, "--type", "-t", help="Filter by question type"
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
 ):
     """List validation failure logs."""
     from .questions.validation_logger import get_validation_failure_logs
-    
+
     logs = get_validation_failure_logs(n=count)
-    
+
     # Filter by question type if provided
     if question_type:
         logs = [log for log in logs if log.get("question_type") == question_type]
-    
+
     if output:
         with open(output, "w") as f:
             json.dump(logs, f, indent=2)
         console.print(f"[green]Logs written to {output}[/green]")
     else:
         console.print_json(json.dumps(logs, indent=2))
-        
+
+
 @validation_app.command("clear")
 def clear_validation_logs():
     """Clear validation failure logs."""
     from .questions.validation_logger import clear_validation_logs
-    
+
     clear_validation_logs()
     console.print("[green]Validation logs cleared.[/green]")
-        
+
+
 @validation_app.command("stats")
 def validation_stats(
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
 ):
     """Show validation failure statistics."""
     from .questions.validation_analysis import get_validation_failure_stats
-    
+
     stats = get_validation_failure_stats()
-    
+
     if output:
         with open(output, "w") as f:
             json.dump(stats, f, indent=2)
         console.print(f"[green]Stats written to {output}[/green]")
     else:
         console.print_json(json.dumps(stats, indent=2))
-        
+
+
 @validation_app.command("suggest")
 def suggest_improvements(
-    question_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by question type"),
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    question_type: Optional[str] = typer.Option(
+        None, "--type", "-t", help="Filter by question type"
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
 ):
     """Suggest improvements for fix methods."""
     from .questions.validation_analysis import suggest_fix_improvements
-    
+
     suggestions = suggest_fix_improvements(question_type=question_type)
-    
+
     if output:
         with open(output, "w") as f:
             json.dump(suggestions, f, indent=2)
         console.print(f"[green]Suggestions written to {output}[/green]")
     else:
         console.print_json(json.dumps(suggestions, indent=2))
-        
+
+
 @validation_app.command("report")
 def generate_report(
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
 ):
     """Generate a comprehensive validation report."""
     from .questions.validation_analysis import export_improvements_report
-    
+
     report_path = export_improvements_report(output_path=output)
     console.print(f"[green]Report generated at: {report_path}[/green]")
-    
+
+
 @validation_app.command("html-report")
 def generate_html_report(
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
-    open_browser: bool = typer.Option(True, "--open/--no-open", help="Open the report in a browser"),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+    open_browser: bool = typer.Option(
+        True, "--open/--no-open", help="Open the report in a browser"
+    ),
 ):
     """Generate an HTML validation report and optionally open it in a browser."""
     from .questions.validation_html_report import generate_html_report
     import webbrowser
-    
+
     report_path = generate_html_report(output_path=output)
     console.print(f"[green]HTML report generated at: {report_path}[/green]")
-    
+
     if open_browser:
         try:
             webbrowser.open(f"file://{report_path}")
@@ -119,14 +141,16 @@ def generate_html_report(
             console.print(f"[yellow]Could not open browser: {e}[/yellow]")
             console.print(f"[yellow]Report is available at: {report_path}[/yellow]")
 
+
 @app.callback()
 def callback():
     """
     Expected Parrot EDSL Command Line Interface.
-    
+
     A toolkit for creating, managing, and running surveys with language models.
     """
     pass
+
 
 @app.command()
 def version():
@@ -135,8 +159,50 @@ def version():
         version = metadata.version("edsl")
         console.print(f"[bold cyan]EDSL version:[/bold cyan] {version}")
     except metadata.PackageNotFoundError:
-        console.print("[yellow]EDSL package not installed or version not available.[/yellow]")
+        console.print(
+            "[yellow]EDSL package not installed or version not available.[/yellow]"
+        )
+
+
+@app.command()
+def check_updates():
+    """Check for available EDSL updates."""
+    try:
+        from edsl import check_for_updates
+
+        console.print("[cyan]Checking for updates...[/cyan]")
+        update_info = check_for_updates(silent=True)
+
+        if update_info:
+            console.print("\n[bold yellow]📦 Update Available![/bold yellow]")
+            console.print(
+                f"[cyan]Current version:[/cyan] {update_info['current_version']}"
+            )
+            console.print(
+                f"[green]Latest version:[/green] {update_info['latest_version']}"
+            )
+            if update_info.get("update_info"):
+                console.print(f"[cyan]Update info:[/cyan] {update_info['update_info']}")
+            console.print(f"\n[bold]To update:[/bold] {update_info['update_command']}")
+        else:
+            console.print(
+                "[green]✓ You are running the latest version of EDSL![/green]"
+            )
+    except Exception as e:
+        console.print(f"[red]Error checking for updates: {str(e)}[/red]")
+
 
 def main():
     """Main entry point for the EDSL CLI."""
+    # Check for updates on startup if environment variable is set
+    import os
+
+    if os.getenv("EDSL_CHECK_UPDATES_ON_STARTUP", "").lower() in ["1", "true", "yes"]:
+        try:
+            from edsl import check_for_updates
+
+            check_for_updates(silent=False)
+        except Exception:
+            pass  # Silently fail if update check fails
+
     app()


### PR DESCRIPTION
This pull request introduces an update mechanism for the EDSL library, including both automated and manual update checks, along with enhancements to the CLI commands for better usability and code formatting improvements. The changes span across multiple files, focusing on adding functionality for version checking and improving the user experience in the CLI.

### New Update Mechanism:

* [`edsl/__init__.py`](diffhunk://#diff-754b7b610fcc8025cb5c0d434d25532db9e8be0085f4bf76c2bad5a4f5e2ec59R153-R218): Added the `check_for_updates` function to check for newer EDSL versions, integrated a non-blocking version check on package import, and updated `__all__` exports accordingly.
* [`edsl/coop/coop.py`](diffhunk://#diff-e9dcb9357440f77d6502dcb2812bbf12457c9e617feced7309671a6f4561ead5R276-R423): Implemented the `check_for_updates` method in the `Coop` class to interact with the server for update information, including handling forced updates and providing detailed instructions for manual updates.

### Enhanced CLI Commands:

* [`edsl/cli.py`](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R154-R207): Added a new `check_updates` command to the CLI for checking available updates, and improved argument formatting across existing commands for better readability. [[1]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R154-R207) [[2]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R29-R38)

### Code Formatting and Cleanup:

* [`edsl/cli.py`](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R29-R38): Refactored argument definitions for CLI commands to improve readability and maintain consistency. [[1]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R29-R38) [[2]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R65-R70) [[3]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R84-R92) [[4]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R106-R127) [[5]](diffhunk://#diff-73a2085fd927577e75822e9075b4b2fa0a9ab34b1c06487824d4fecdb138f303R144)