### PR TITLE
update to support pip install edsl[services]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ urllib3 = ">=1.25.4,<1.27"
 google-generativeai = "^0.8.2"
 tabulate = "^0.9.0"
 pypdf2 = "^3.0.1"
+fastapi = {version = "^0.112.1", optional = true}
+uvicorn = {version = "^0.30.6", optional = true}
 python-pptx = "^1.0.2"
 platformdirs = "^4.3.6"
 pluggy = "^1.3.0"
@@ -65,11 +67,11 @@ version = "^0.9.0"
 
 [tool.poetry.extras]
 screenshots = ["playwright"]
+services = ["fastapi", "uvicorn"]
 
 [tool.poetry.group.dev.dependencies]
 click = "^8.0.0"
 coverage = "^7.3.3"
-fastapi = "^0.112.1"
 mypy = "^1.7.1"
 myst-parser = "^3.0.1"
 nbformat = "^5.9.2"
@@ -93,7 +95,6 @@ sphinx-fontawesome = "^0.0.6"
 sphinx-rtd-theme = "^2.0.0"
 toml = "^0.10.2"
 toml-sort = "^0.23.1"
-uvicorn = "^0.30.6"
 
 [tool.poetry.scripts]
 edsl = "edsl.__main__:main"


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to include optional dependencies for FastAPI and Uvicorn under a new `services` extra, while removing their direct inclusion in the development dependencies. These changes streamline dependency management and improve modularity.

### Dependency Management Updates:

* Added `fastapi` and `uvicorn` as optional dependencies under `[tool.poetry.dependencies]` to support FastAPI-based services.
* Introduced a new `services` extra, grouping `fastapi` and `uvicorn` for optional installation.
* Removed `fastapi` and `uvicorn` from `[tool.poetry.group.dev.dependencies]` and `[tool.poetry.group.dev.dependencies]` to avoid redundant inclusion. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R70-L72) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L96)