### PR TITLE
Add logic to test extensions locally.

### DIFF
--- a/edsl/extensions/__init__.py
+++ b/edsl/extensions/__init__.py
@@ -6,21 +6,12 @@ This module provides functionality for:
 2. Creating new EDSL services without FastAPI knowledge using the service framework
 """
 
+# Core extension functionality - no heavy dependencies
 from .gateway_client import (
     ExtensionGatewayClient,
     call_service,
     list_services,
     create_service,
-)
-
-from .service_framework import (
-    edsl_service,
-    input_param,
-    output_schema,
-    run_service,
-    validate_service,
-    generate_service_files,
-    ServiceFrameworkException,
 )
 
 from .extension_interface import (
@@ -31,13 +22,64 @@ from .extension_interface import (
     extensions,
 )
 
+
+# Service framework imports - only available if uvicorn is installed
+def __getattr__(name):
+    """Lazy import for service framework components to avoid uvicorn dependency for basic extensions"""
+    if name in [
+        "edsl_service",
+        "input_param",
+        "output_schema",
+        "run_service",
+        "validate_service",
+        "generate_service_files",
+        "ServiceFrameworkException",
+    ]:
+        try:
+            from .service_framework import (
+                edsl_service,
+                input_param,
+                output_schema,
+                run_service,
+                validate_service,
+                generate_service_files,
+                ServiceFrameworkException,
+            )
+
+            globals().update(
+                {
+                    "edsl_service": edsl_service,
+                    "input_param": input_param,
+                    "output_schema": output_schema,
+                    "run_service": run_service,
+                    "validate_service": validate_service,
+                    "generate_service_files": generate_service_files,
+                    "ServiceFrameworkException": ServiceFrameworkException,
+                }
+            )
+            return globals()[name]
+        except ImportError as e:
+            raise ImportError(
+                f"Service framework component '{name}' requires uvicorn. "
+                f"Install with: pip install 'edsl[services]' or pip install fastapi uvicorn. "
+                f"Original error: {e}"
+            )
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
 __all__ = [
     # Gateway client for calling services
     "ExtensionGatewayClient",
     "call_service",
     "list_services",
     "create_service",
-    # Service framework for creating services
+    # Extension interface
+    "ExtensionManager",
+    "Extensions",
+    "ExtensionService",
+    "extension",
+    "extensions",
+    # Service framework (lazy loaded)
     "edsl_service",
     "input_param",
     "output_schema",
@@ -45,10 +87,4 @@ __all__ = [
     "validate_service",
     "generate_service_files",
     "ServiceFrameworkException",
-    # Extension interface
-    "ExtensionManager",
-    "Extensions",
-    "ExtensionService",
-    "extension",
-    "extensions",
 ]

--- a/edsl/extensions/extension_interface.py
+++ b/edsl/extensions/extension_interface.py
@@ -61,6 +61,10 @@ class ExtensionService:
         # Prepare headers
         headers = {"Content-Type": "application/json"}
 
+        # Use EXPECTED_PARROT_API_KEY as default if no token provided
+        if token is None:
+            token = os.environ.get("EXPECTED_PARROT_API_KEY")
+
         # Add authorization if token provided
         if token:
             headers["Authorization"] = f"Bearer {token}"
@@ -155,12 +159,17 @@ class ExtensionService:
 
             if self.local_mode:
                 # Direct call to service bypassing gateway
-                token = kwargs.pop("ep_api_token", None)
+                # Set default ep_api_token if not provided
+                if "ep_api_token" not in kwargs:
+                    env_token = os.environ.get("EXPECTED_PARROT_API_KEY")
+                    if env_token:
+                        kwargs["ep_api_token"] = env_token
+
                 return self._call_service_directly(
                     path=path,
                     method="POST",
                     json_data=kwargs,
-                    token=token,
+                    token=None,  # Token is passed in the JSON body for local services
                 )
             else:
                 # Call through gateway (existing behavior)


### PR DESCRIPTION
Calling local extension services using extension.local syntax
```python
from edsl.extensions import extension

# Optional: Set custom service URL if your service runs on a different port
# Default is http://localhost:8000 - only change if you used a different port
extension.service_url = "http://localhost:8000"

# Use your specific service name
result = extension.local["my-extension"].my_extension_method(topic="AI ethics", num_agents=3)
print(result)

# Or visit http://localhost:8000/docs for interactive API documentation
```