### PR TITLE
add patch for scenario nan

### DIFF
--- a/edsl/scenarios/scenario.py
+++ b/edsl/scenarios/scenario.py
@@ -574,12 +574,16 @@ class Scenario(Base, UserDict):
         {'food': 'wood chips'}
 
         """
+        import math
         from edsl.scenarios import FileStore
         from edsl.prompts import Prompt
 
         d = self.data.copy()
         for key, value in d.items():
-            if isinstance(value, FileStore) or isinstance(value, Prompt):
+            # Check for NaN values and replace with None for JSON serialization
+            if isinstance(value, float) and math.isnan(value):
+                d[key] = None
+            elif isinstance(value, FileStore) or isinstance(value, Prompt):
                 value_dict = value.to_dict(add_edsl_version=add_edsl_version)
                 if (
                     offload_base64


### PR DESCRIPTION
This pull request updates the `to_dict` method in `edsl/scenarios/scenario.py` to handle NaN values during JSON serialization. The most important change ensures that NaN values are replaced with `None` to make the output JSON-compatible.

### Key change:
* [`edsl/scenarios/scenario.py`](diffhunk://#diff-5e4b59995f773c9b6188a378e9f493eee86bce7ce75c3772dbf8eec1d8a3fd70R577-R586): Modified the `to_dict` method to check for NaN values in `float` types and replace them with `None` for proper JSON serialization. This change prevents issues when serializing data containing NaN values.