### PR TITLE
Update cache logic

### DIFF
--- a/edsl/caching/cache.py
+++ b/edsl/caching/cache.py
@@ -240,9 +240,6 @@ class Cache(Base):
                 entry_data = json.loads(data["json_string"])
                 cache_entry = CacheEntry.from_dict(entry_data)
 
-                if self.verbose:
-                    print(f"Remote cache hit for key: {cache_key}")
-
                 # Store in local cache for future use
                 if self.immediate_write:
                     self.data[cache_key] = cache_entry
@@ -274,6 +271,7 @@ class Cache(Base):
         user_prompt: str,
         iteration: int,
         validated: bool = False,
+        remote_fetch: bool = False,
     ) -> tuple(Union[None, str], str):
         """Retrieve a cached language model response if available.
 
@@ -325,7 +323,7 @@ class Cache(Base):
                 print(f"Local cache miss for key: {key}")
 
             # Try to fetch from remote cache on local miss only if coop is available
-            if self.coop is not None:
+            if self.coop is not None and remote_fetch:
                 if self.verbose:
                     print(f"Attempting to fetch from remote cache for key: {key}")
                 entry = self._fetch_from_remote_cache(key)

--- a/edsl/caching/cache.py
+++ b/edsl/caching/cache.py
@@ -286,6 +286,7 @@ class Cache(Base):
         user_prompt: str,
         iteration: int,
         validated: bool = False,
+        enable_remote_cache: bool = False,
     ) -> tuple(Union[None, str], str):
         """Retrieve a cached language model response if available.
 

--- a/edsl/caching/cache.py
+++ b/edsl/caching/cache.py
@@ -326,9 +326,15 @@ class Cache(Base):
 
             # Try to fetch from remote cache on local miss only if coop is available
             if self.coop is not None:
-                print(f"Attempting to fetch from remote cache for key: {key}")
+                if self.verbose:
+                    print(f"Attempting to fetch from remote cache for key: {key}")
                 entry = self._fetch_from_remote_cache(key)
-                print(f"Fetched from remote cache: {entry}")
+                if self.verbose:
+                    if entry is not None:
+                        print(f"Remote cache hit for key: {key}")
+                    else:
+                        print(f"Remote cache miss for key: {key}")
+
                 if entry is not None:
                     self.fetched_data[key] = entry
 

--- a/edsl/language_models/language_model.py
+++ b/edsl/language_models/language_model.py
@@ -750,7 +750,17 @@ class LanguageModel(
         }
 
         # Try to fetch from cache
-        cached_response, cache_key = cache.fetch(**cache_call_params)
+        if (
+            "{{" in invigilator.question.question_text
+            and "}}" in invigilator.question.question_text
+        ):
+            remote_fetch = True
+        else:
+            remote_fetch = False
+
+        cached_response, cache_key = cache.fetch(
+            **cache_call_params, remote_fetch=remote_fetch
+        )
         if cache_used := cached_response is not None:
             # Cache hit - use the cached response
             response = json.loads(cached_response)

--- a/edsl/language_models/language_model.py
+++ b/edsl/language_models/language_model.py
@@ -751,7 +751,8 @@ class LanguageModel(
 
         # Try to fetch from cache
         if (
-            "{{" in invigilator.question.question_text
+            invigilator is not None
+            and "{{" in invigilator.question.question_text
             and "}}" in invigilator.question.question_text
         ):
             remote_fetch = True


### PR DESCRIPTION
This pull request introduces functionality for fetching cache entries from a remote universal cache when local cache misses occur. It also updates the `fetch` method and its related logic to support this new feature. Below is a summary of the most important changes:

### Remote Cache Integration:

- **Added `_fetch_from_remote_cache` method**: Implements logic to retrieve cache entries from a remote universal cache endpoint using `requests`. Handles responses, errors, and stores retrieved entries in the local cache. (`edsl/caching/cache.py`, [edsl/caching/cache.pyR216-R264](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceR216-R264))
- **Updated `fetch` method**: Added a `remote_fetch` parameter to enable fetching from the remote cache when local cache misses occur. Enhanced verbose logging to differentiate between local and remote cache hits/misses. (`edsl/caching/cache.py`, [[1]](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceR274) [[2]](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceR299) [[3]](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceL267-R338)

### Integration with Language Model Logic:

- **Modified `_async_get_intended_model_call_outcome`**: Added logic to conditionally enable `remote_fetch` based on the presence of specific delimiters (`{{` and `}}`) in the `invigilator` question text. (`edsl/language_models/language_model.py`, [edsl/language_models/language_model.pyL753-R764](diffhunk://#diff-89bb27d2b2309cf732c3ce9c77d4dbaac68ce12f0464ce0bf3c4485757032991L753-R764))

### Dependency Update:

- **Imported `requests`**: Added the `requests` library import to support HTTP requests for remote cache integration. (`edsl/caching/cache.py`, [edsl/caching/cache.pyR40](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceR40))