### PR TITLE
check if answer from previous quesiton is used

### DIFF
--- a/edsl/language_models/language_model.py
+++ b/edsl/language_models/language_model.py
@@ -754,6 +754,7 @@ class LanguageModel(
             invigilator is not None
             and "{{" in invigilator.question.question_text
             and "}}" in invigilator.question.question_text
+            and ".answer" in invigilator.question.question_text
         ):
             remote_fetch = True
         else:


### PR DESCRIPTION
This pull request introduces enhancements to the remote caching mechanism and refines the logic for determining model call outcomes. The changes aim to improve functionality, error handling, and clarity in both areas.

### Remote caching improvements:
* [`edsl/caching/cache.py`](diffhunk://#diff-134d597945f74dc8304cd45c6ef343f01ee399a5d98a010bb5eab416076868ceR239-R271): Enhanced `_fetch_from_remote_cache` to handle multiple cache statuses (`found`, `not_found`, `invalid`, and unexpected responses) with verbose logging for better debugging. Added logic to parse cache data only when a valid entry is found.

### Model call outcome refinement:
* [`edsl/language_models/language_model.py`](diffhunk://#diff-89bb27d2b2309cf732c3ce9c77d4dbaac68ce12f0464ce0bf3c4485757032991R757): Updated `_async_get_intended_model_call_outcome` to include an additional condition (`".answer"`) for determining whether a remote fetch is required.