### PR TITLE
replace NaN with None in question options

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-# [submodule "edsl/widgets/src"]
-# 	path = edsl/widgets/src
-# 	url = git@github.com:expectedparrot/edsl-widgets-src.git

--- a/edsl/questions/question_multiple_choice.py
+++ b/edsl/questions/question_multiple_choice.py
@@ -344,9 +344,9 @@ class QuestionMultipleChoice(QuestionBase):
 
     question_type = "multiple_choice"
     purpose = "When options are known and limited"
-    question_options: Union[list[str], list[list], list[float], list[int]] = (
-        QuestionOptionsDescriptor()
-    )
+    question_options: Union[
+        list[str], list[list], list[float], list[int]
+    ] = QuestionOptionsDescriptor()
     _response_model = None
     response_validator_class = MultipleChoiceResponseValidator
 
@@ -427,7 +427,7 @@ class QuestionMultipleChoice(QuestionBase):
         """
         self.question_name = question_name
         self.question_text = question_text
-        self.question_options = question_options
+        self.question_options = self._clean_nan_from_options(question_options)
 
         self._include_comment = include_comment
         self.use_code = use_code
@@ -438,6 +438,29 @@ class QuestionMultipleChoice(QuestionBase):
     ################
     # Answer methods
     ################
+
+    def _clean_nan_from_options(self, options):
+        """
+        Clean NaN values from question options, replacing them with None.
+
+        Args:
+            options: The original options list
+
+        Returns:
+            List with NaN values replaced by None
+        """
+        import math
+
+        if not isinstance(options, list):
+            return options
+
+        cleaned_options = []
+        for option in options:
+            if isinstance(option, float) and math.isnan(option):
+                cleaned_options.append(None)
+            else:
+                cleaned_options.append(option)
+        return cleaned_options
 
     def create_response_model(self, replacement_dict: dict = None):
         if replacement_dict is None:
@@ -455,7 +478,6 @@ class QuestionMultipleChoice(QuestionBase):
     def _translate_question_options(
         question_options, substitution_dict: dict
     ) -> list[str]:
-
         if isinstance(question_options, str):
             # If dynamic options are provided like {{ options }}, render them with the scenario
             # We can check if it's in the Scenario.


### PR DESCRIPTION
This pull request improves the handling of multiple choice question options in the `QuestionMultipleChoice` class to ensure that invalid option values (specifically NaN floats) are cleaned and replaced with `None`. This helps prevent potential issues when processing or displaying question options.

Improvements to option handling:

* Added the `_clean_nan_from_options` method to `QuestionMultipleChoice`, which scans the provided options list and replaces any NaN float values with `None` for safer downstream usage.
* Updated the `__init__` method of `QuestionMultipleChoice` to automatically clean NaN values from `question_options` during initialization by invoking `_clean_nan_from_options`.

Code style and consistency:

* Minor formatting adjustment to the declaration of `question_options` for improved readability.

Other:

* Minor whitespace change in the `_translate_question_options` method for consistency.