### PR TITLE
Fix show_prompts() double display issue

### DIFF
--- a/edsl/jobs/jobs.py
+++ b/edsl/jobs/jobs.py
@@ -451,9 +451,9 @@ class Jobs(Base):
     def show_prompts(self, all: bool = False) -> None:
         """Print the prompts."""
         if all:
-            return self.prompts().to_scenario_list().table()
+            print(self.prompts().to_scenario_list().table())
         else:
-            return (
+            print(
                 self.prompts().to_scenario_list().table("user_prompt", "system_prompt")
             )
 

--- a/edsl/surveys/survey.py
+++ b/edsl/surveys/survey.py
@@ -1264,17 +1264,17 @@ class Survey(Base):
 
         return Jobs(survey=self)
 
-    def show_prompts(self):
+    def show_prompts(self, all: bool = False) -> None:
         """Display the prompts that will be used when running the survey.
 
         This method converts the survey to a Jobs object and shows the prompts that
         would be sent to a language model. This is useful for debugging and understanding
         how the survey will be presented.
 
-        Returns:
-            The detailed prompts for the survey.
+        Args:
+            all: If True, show all prompt fields; if False (default), show only user_prompt and system_prompt.
         """
-        return self.to_jobs().show_prompts()
+        self.to_jobs().show_prompts(all=all)
 
     def __call__(
         self,


### PR DESCRIPTION
## Summary
Fixes the double display issue in `show_prompts()` method where prompts were being displayed twice in REPL/notebook environments.

## Problem
The `show_prompts()` method was returning `TableDisplay` objects instead of printing them directly. This caused:
1. The table to be displayed when the method executed 
2. The returned `TableDisplay` object to be displayed again by the REPL/notebook environment

## Solution
- **Jobs.show_prompts()**: Changed from `return table()` to `print(table())`
- **Survey.show_prompts()**: Added support for `all` parameter and updated to not return values
- Updated return type annotations to `-> None` to match actual behavior
- Enhanced docstrings to document the new parameter

## Testing
✅ Verified `show_prompts()` displays content only once  
✅ Verified `show_prompts(all=True)` works correctly  
✅ Confirmed method returns `None` (no double display)  
✅ Tested in both command line and notebook environments

## Closes
Fixes #2142

🤖 Generated with [Claude Code](https://claude.ai/code)