### PR TITLE
OpenAI fixes: remove deprecated `max_tokens` param; add reasoning model list

### DIFF
--- a/edsl/inference_services/services/open_ai_service.py
+++ b/edsl/inference_services/services/open_ai_service.py
@@ -6,6 +6,7 @@ import openai
 
 from ..inference_service_abc import InferenceServiceABC
 from .message_builder import MessageBuilder
+from .service_enums import OPENAI_REASONING_MODELS
 
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class OpenAIParameterBuilder:
 
         default_max_tokens = model_params.get("max_tokens", 1000)
         default_temperature = model_params.get("temperature", 0.5)
-        if "o1" in model or "o3" in model or model == "gpt-5":
+        if model in OPENAI_REASONING_MODELS:
             # For reasoning models, use much higher completion tokens to allow for reasoning + response
             max_tokens = max(default_max_tokens, 5000)
             temperature = 1

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -5,6 +5,7 @@ import os
 import openai
 
 from ..inference_service_abc import InferenceServiceABC
+from .service_enums import OPENAI_REASONING_MODELS
 
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
@@ -210,8 +211,7 @@ class OpenAIServiceV2(InferenceServiceABC):
 
                 # Check if this is a reasoning model (o-series models)
                 is_reasoning_model = any(
-                    tag in self.model
-                    for tag in ["o1", "o1-mini", "o3", "o3-mini", "o1-pro", "o4-mini"]
+                    tag in self.model for tag in OPENAI_REASONING_MODELS
                 )
 
                 # Only add reasoning parameter for reasoning models

--- a/edsl/inference_services/services/service_enums.py
+++ b/edsl/inference_services/services/service_enums.py
@@ -1,0 +1,11 @@
+OPENAI_REASONING_MODELS = [
+    "o1",
+    "o1-mini",
+    "o3",
+    "o3-mini",
+    "o1-pro",
+    "o4-mini",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+]


### PR DESCRIPTION
This PR fixes issues with the new gpt-5 models: 

- I've added a standardized list of reasoning models to be used across the `openai` and `openai_v2` services. This list includes the new gpt-5 class models. We need this list because the `openai` service does some overrides for reasoning models, such as setting the temperature to 1 (the only value accepted by the API)
- OpenAI has deprecated `max_tokens` in favor of `max_completion_tokens`, and `max_tokens` raises an issue every time you try to use it with a reasoning model, so I think it's better we switch over (https://platform.openai.com/docs/api-reference/chat/create#chat_create-max_tokens)

<img width="810" height="584" alt="image" src="https://github.com/user-attachments/assets/05fe8785-31e2-4e0c-a1ec-9dc182c7c11d" />
