### PR TITLE
Update error service logs access

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -748,9 +748,8 @@ class Coop(CoopFunctionsMixin):
             # This allows other parts of the code to check these settings efficiently
             if "remote_logging" in settings:
                 os.environ["EDSL_REMOTE_LOGGING"] = (
-                    "1" if settings["remote_logging"] else "0"
+                    "1" if settings["remote_logging"] == True else "0"
                 )
-
             return settings
         except Timeout:
             return {}

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -731,16 +731,27 @@ class Coop(CoopFunctionsMixin):
     def edsl_settings(self) -> dict:
         """
         Retrieve and return the EDSL settings stored on Coop.
+        Also caches important settings in environment variables for efficient access.
         If no response is received within 5 seconds, return an empty dict.
         """
         from requests.exceptions import Timeout
+        import os
 
         try:
             response = self._send_server_request(
                 uri="api/v0/edsl-settings", method="GET", timeout=20
             )
             self._resolve_server_response(response, check_api_key=False)
-            return response.json()
+            settings = response.json()
+
+            # Cache important settings in environment variables
+            # This allows other parts of the code to check these settings efficiently
+            if "remote_logging" in settings:
+                os.environ["EDSL_REMOTE_LOGGING"] = (
+                    "1" if settings["remote_logging"] else "0"
+                )
+
+            return settings
         except Timeout:
             return {}
 

--- a/edsl/inference_services/decorators.py
+++ b/edsl/inference_services/decorators.py
@@ -44,21 +44,19 @@ def report_errors_async(func: Callable) -> Callable:
             # Check if remote_logging is enabled
             # First check if we've already fetched and cached the setting
             remote_logging_str = os.environ.get("EDSL_REMOTE_LOGGING")
-
             if remote_logging_str is None:
                 # First time - fetch from /edsl-settings and cache in env var
                 try:
                     from ..coop import Coop
 
                     c = Coop()
-                    settings = c.edsl_settings()
+                    settings = c.edsl_settings
                     remote_logging = settings.get("remote_logging", True)
                     # Cache the setting in env var for future use
                     os.environ["EDSL_REMOTE_LOGGING"] = "1" if remote_logging else "0"
-                except Exception:
+                except Exception as e:
                     # If we can't get settings, default to enabled and cache it
-                    os.environ["EDSL_REMOTE_LOGGING"] = "1"
-                    remote_logging = True
+                    pass
             else:
                 # Use cached value from env var
                 remote_logging = remote_logging_str == "1"

--- a/edsl/inference_services/decorators.py
+++ b/edsl/inference_services/decorators.py
@@ -11,59 +11,98 @@ from typing import Callable, Any
 
 def report_errors_async(func: Callable) -> Callable:
     """
-    Decorator that automatically reports errors using Coop.report_error() 
+    Decorator that automatically reports errors using Coop.report_error()
     before re-raising them. For use with async methods.
-    
+
     This decorator wraps async methods to catch any exceptions, report them
-    to the Coop error reporting system, and then re-raise the original exception.
-    
+    to the Coop error reporting system (if remote_logging is enabled),
+    and then re-raise the original exception.
+
+    The remote_logging setting is fetched from /edsl-settings on first use
+    and cached in an environment variable to avoid repeated API calls.
+
     Args:
         func: The async function to wrap
-        
+
     Returns:
         The wrapped async function
-        
+
     Example:
         @report_errors_async
         async def my_async_method(self):
             # method implementation
             pass
     """
+
     @wraps(func)
     async def wrapper(*args, **kwargs) -> Any:
+        import os
+
         try:
             return await func(*args, **kwargs)
         except Exception as e:
-            from ..coop import Coop
-            c = Coop()
-            await c.report_error(e)
+            # Check if remote_logging is enabled
+            # First check if we've already fetched and cached the setting
+            remote_logging_str = os.environ.get("EDSL_REMOTE_LOGGING")
+
+            if remote_logging_str is None:
+                # First time - fetch from /edsl-settings and cache in env var
+                try:
+                    from ..coop import Coop
+
+                    c = Coop()
+                    settings = c.edsl_settings()
+                    remote_logging = settings.get("remote_logging", True)
+                    # Cache the setting in env var for future use
+                    os.environ["EDSL_REMOTE_LOGGING"] = "1" if remote_logging else "0"
+                except Exception:
+                    # If we can't get settings, default to enabled and cache it
+                    os.environ["EDSL_REMOTE_LOGGING"] = "1"
+                    remote_logging = True
+            else:
+                # Use cached value from env var
+                remote_logging = remote_logging_str == "1"
+
+            # Report error if enabled
+            if remote_logging:
+                try:
+                    from ..coop import Coop
+
+                    c = Coop()
+                    await c.report_error(e)
+                except Exception:
+                    # If reporting fails, just continue
+                    pass
+
             raise e
+
     return wrapper
 
 
 def report_errors_sync(func: Callable) -> Callable:
     """
-    Decorator that automatically reports errors using Coop.report_error() 
+    Decorator that automatically reports errors using Coop.report_error()
     before re-raising them. For use with synchronous methods.
-    
+
     This decorator wraps sync methods to catch any exceptions, report them
     to the Coop error reporting system, and then re-raise the original exception.
-    
+
     Note: This creates a Coop instance synchronously but the report_error method
     is async, so this decorator will need to handle that appropriately.
-    
+
     Args:
         func: The sync function to wrap
-        
+
     Returns:
         The wrapped sync function
-        
+
     Example:
         @report_errors_sync
         def my_sync_method(self):
             # method implementation
             pass
     """
+
     @wraps(func)
     def wrapper(*args, **kwargs) -> Any:
         try:
@@ -73,10 +112,14 @@ def report_errors_sync(func: Callable) -> Callable:
             # since we can't await the async report_error method
             import sys
             import traceback
-            
-            print(f"EDSL Error Report (sync): {type(e).__name__}: {str(e)}", file=sys.stderr)
+
+            print(
+                f"EDSL Error Report (sync): {type(e).__name__}: {str(e)}",
+                file=sys.stderr,
+            )
             print("Traceback:", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
             print("-" * 50, file=sys.stderr)
             raise e
+
     return wrapper


### PR DESCRIPTION
This pull request improves how error reporting is managed in the EDSL Coop system, focusing on making remote error logging more efficient by caching configuration settings. The main change is to cache the `remote_logging` setting in an environment variable, so that it is only fetched once from the server and reused throughout the application. This reduces unnecessary API calls and ensures consistent behavior for error reporting in both async and sync contexts.

**Remote logging configuration and error reporting:**
- The `edsl_settings` method in `Coop` now caches the `remote_logging` setting in the `EDSL_REMOTE_LOGGING` environment variable after fetching it from the server, making it available for quick checks elsewhere in the codebase.
- The `report_errors_async` decorator now checks the cached `EDSL_REMOTE_LOGGING` environment variable to determine if remote error logging is enabled, fetching and caching the setting from the server only if it hasn't already been set. This avoids repeated API calls and ensures that error reporting is only attempted if enabled. [[1]](diffhunk://#diff-eef37a5c8dba653f39b033318279747efe81ffe11d10367e3c662883d32a1d0fL18-R22) [[2]](diffhunk://#diff-eef37a5c8dba653f39b033318279747efe81ffe11d10367e3c662883d32a1d0fR36-R76)
- The docstring for `report_errors_async` has been updated to reflect the new behavior of caching the `remote_logging` setting in an environment variable.

**Code style and formatting:**
- Minor formatting improvements were made to the sync error reporting decorator for better readability.