### PR TITLE
Fix Results.to_agent_list() generating duplicate agents

### DIFF
--- a/edsl/dataset/dataset_operations_mixin.py
+++ b/edsl/dataset/dataset_operations_mixin.py
@@ -636,7 +636,7 @@ class DataOperationsBase:
             if "name" in d:
                 d["agent_name"] = d.pop("name")
                 agents.append(Agent(d, name=d["agent_name"]))
-            if "agent_parameters" in d:
+            elif "agent_parameters" in d:
                 agent_parameters = d.pop("agent_parameters")
                 agent_name = agent_parameters.get("name", None)
                 instruction = agent_parameters.get("instruction", None)


### PR DESCRIPTION
## Summary
- Fixed bug where `Results.to_agent_list()` was creating duplicate agents when a "name" field was present
- Changed conditional logic from `if "agent_parameters"` to `elif "agent_parameters"` in `to_agent_list()` method
- Added comprehensive regression tests to prevent future occurrences

## Root Cause
The issue was in the conditional logic in `dataset_operations_mixin.py:639`. When a "name" field was present:

1. First `if "name" in d:` condition was satisfied and created an Agent
2. The `else` clause only paired with `if "agent_parameters" in d:`, not both conditions  
3. Since no "agent_parameters" existed, it fell through to create a second Agent

## Changes
- **Fixed**: `edsl/dataset/dataset_operations_mixin.py` - Changed `if "agent_parameters"` to `elif "agent_parameters"`
- **Added**: `tests/dataset/test_DatasetOperationsMixin.py` - 3 new regression tests covering all code paths

## Test Plan
- [x] Reproduced original bug (was creating 2 agents instead of 1)
- [x] Verified fix works (now creates exactly 1 agent)
- [x] Added tests for all three conditional paths:
  - `test_to_agent_list_no_duplicate_agents()` - Tests main bug fix
  - `test_to_agent_list_agent_parameters_path()` - Tests agent_parameters handling
  - `test_to_agent_list_traits_only_path()` - Tests default traits-only path
- [x] All new tests pass
- [x] Code passes linting

Fixes #2191

🤖 Generated with [Claude Code](https://claude.ai/code)