### PR TITLE
Fix login function export in lazy loading system

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -53,6 +53,13 @@ _module_cache = {}
 
 def __getattr__(name):
     """Lazy loading of EDSL modules and their exports."""
+    # First check if the attribute exists in the current module's globals
+    # This handles functions/classes defined directly in __init__.py
+    import sys
+    current_module = sys.modules[__name__]
+    if hasattr(current_module, name):
+        return getattr(current_module, name)
+    
     # Check if it's a module we should lazy-load
     for module_name in _LAZY_MODULES:
         try:


### PR DESCRIPTION
## Summary
- Fix login function export issue where the function defined in `edsl/__init__.py` was not accessible via lazy loading
- The `__getattr__` method now checks the current module's globals before attempting lazy loading from other modules
- Both `from edsl import login` and `edsl.login` syntax now work correctly

## Test plan
- [x] Test `from edsl import login` - imports successfully
- [x] Test `edsl.login` attribute access - works correctly
- [x] Verify login function is callable and maintains original functionality

🤖 Generated with [Claude Code](https://claude.ai/code)