### PR TITLE
reload dot env after login is completed

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -304,7 +304,8 @@ def login(timeout: int = 120) -> None:
     from edsl.coop import Coop
     import secrets
     from edsl.config import CONFIG
-    
+    from dotenv import load_dotenv
+
     # If we're in a notebook, handle the UI specially
     if _is_notebook_environment():
         # Generate auth token and URL (mirroring Coop._display_login_url logic)
@@ -325,6 +326,8 @@ def login(timeout: int = 120) -> None:
             if api_key:
                 # Store the key
                 coop.ep_key_handler.store_ep_api_key(api_key)
+                load_dotenv()
+
                 _update_notebook_status("✅ Successfully logged in and stored API key!", is_success=True)
             else:
                 _update_notebook_status("❌ Login timed out. Please try again.")


### PR DESCRIPTION
This pull request introduces an update to the `login` function in `edsl/__init__.py` to improve environment variable handling after storing the API key. The main change is the addition of loading environment variables from a `.env` file immediately after a successful API key storage.

Enhancements to environment variable management:

* Added an import for `load_dotenv` from the `dotenv` package to the top of `edsl/__init__.py`.
* Called `load_dotenv()` right after storing the API key in the `login` function, ensuring that any new environment variables in the `.env` file are loaded into the environment.