### PR TITLE
use os.environ to load the key

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -326,7 +326,7 @@ def login(timeout: int = 120) -> None:
             if api_key:
                 # Store the key
                 coop.ep_key_handler.store_ep_api_key(api_key)
-                load_dotenv()
+                os.environ["EXPECTED_PARROT_API_KEY"] = api_key
 
                 _update_notebook_status("✅ Successfully logged in and stored API key!", is_success=True)
             else:


### PR DESCRIPTION
This pull request makes a small change to the login logic by setting the `EXPECTED_PARROT_API_KEY` environment variable directly in the `login` function instead of reloading environment variables from a file. This ensures the API key is immediately available in the current process after login.