### PR TITLE
Fix issue 2220

### DIFF
--- a/edsl/surveys/rules/rule.py
+++ b/edsl/surveys/rules/rule.py
@@ -288,19 +288,34 @@ class Rule:
             """
             jinja_dict = defaultdict(dict)
 
+            def format_value_for_python(value):
+                """Format a value for safe use in Python expressions."""
+                if isinstance(value, str):
+                    # Use JSON dumps to properly escape strings for Python
+                    import json
+
+                    return json.dumps(value)
+                else:
+                    # For non-strings, return as-is (numbers, booleans, etc.)
+                    return value
+
             for key, value in dictionary.items():
                 # print("Now processing key: ", key)
                 # print(f"key: {key}, value: {value}")
+
+                # Format value for safe Python evaluation
+                formatted_value = format_value_for_python(value)
+
                 # Handle special keys
                 if "agent." in key:
                     # print("Agent key found")
-                    jinja_dict["agent"][key.split(".")[1]] = value
+                    jinja_dict["agent"][key.split(".")[1]] = formatted_value
                     # print("jinja dict: ", jinja_dict)
                     continue
 
                 if "scenario." in key:
                     # print("Scenario key found")
-                    jinja_dict["scenario"][key.split(".")[1]] = value
+                    jinja_dict["scenario"][key.split(".")[1]] = formatted_value
                     # print("jinja dict: ", jinja_dict)
                     continue
 
@@ -310,7 +325,7 @@ class Rule:
                     if question_name in key:
                         if question_name == key:
                             # print("question name is key; it's an answer")
-                            jinja_dict[question_name]["answer"] = value
+                            jinja_dict[question_name]["answer"] = formatted_value
                             # print("jinja dict: ", jinja_dict)
                             continue
                         else:
@@ -321,7 +336,9 @@ class Rule:
                                 # print("value_type: ", value_type)
                                 if passed_name == question_name:
                                     # print("passed name is question name; it's a sub-type")
-                                    jinja_dict[question_name][value_type] = value
+                                    jinja_dict[question_name][
+                                        value_type
+                                    ] = formatted_value
                                     # print("jinja dict: ", jinja_dict)
                                     continue
 

--- a/edsl/surveys/rules/rule.py
+++ b/edsl/surveys/rules/rule.py
@@ -348,7 +348,7 @@ class Rule:
         try:
             to_evaluate = substitute_in_answers(self.expression, current_info_env)
         except Exception as e:
-            msg = f"""Exception in evaluation: {e}. The expression is: {self.expression}. The current info env trying to substitute in is: {current_info_env}. After the substition, the expression was: {to_evaluate}."""
+            msg = f"""Exception in evaluation: {e}. The expression is: {self.expression}. The current info env trying to substitute in is: {current_info_env}. Template rendering failed before substitution could complete."""
             raise SurveyRuleCannotEvaluateError(msg)
 
         random_functions = {


### PR DESCRIPTION
This pull request improves the safety and reliability of survey rule evaluation, especially around string handling and survey navigation logic. The main updates ensure that values are safely formatted for Python evaluation, error messages are clearer, and the survey stop logic is more robust and testable.

**Improvements to value formatting and safety:**

* Added a helper function `format_value_for_python` in `jinja_ize_dictionary` to ensure string values are properly escaped using `json.dumps` before being used in Python expressions, reducing the risk of injection or evaluation errors.
* Updated all assignments in `jinja_ize_dictionary` to use the formatted value, ensuring consistency and safety across agent, scenario, and question keys. [[1]](diffhunk://#diff-a61f7c3cbb9be33e163ee5e4b12070e6fc99b685b8bebf01eee1067fd10dad4dL313-R328) [[2]](diffhunk://#diff-a61f7c3cbb9be33e163ee5e4b12070e6fc99b685b8bebf01eee1067fd10dad4dL324-R341)

**Error handling and messaging:**

* Improved the error message in `substitute_in_answers` to clarify when template rendering fails before substitution, making debugging easier.

**Survey navigation and stopping logic:**

* Modified the `next_question` method to skip stop rules that can't be evaluated due to missing answers, instead of raising errors, which prevents premature failures during navigation planning. Also removed premature evaluation of "before" rules for the next question, deferring their evaluation until the appropriate context is available.
* Added a new `should_stop_survey` method to `RuleCollection` that checks, after a question is answered, whether any stop rule applies. This method is robust to missing variables and includes a docstring with usage examples.