### PR TITLE
update notebook import

### DIFF
--- a/edsl/notebooks/__init__.py
+++ b/edsl/notebooks/__init__.py
@@ -6,7 +6,8 @@ to other formats such as LaTeX.
 """
 
 from .notebook import Notebook
-from .notebook_to_latex import NotebookToLaTeX
+
+# from .notebook_to_latex import NotebookToLaTeX
 from .exceptions import (
     NotebookError,
     NotebookValueError,
@@ -17,7 +18,7 @@ from .exceptions import (
 
 __all__ = [
     "Notebook",
-    "NotebookToLaTeX",
+    # "NotebookToLaTeX",
     "NotebookError",
     "NotebookValueError",
     "NotebookFormatError",


### PR DESCRIPTION
This pull request makes a minor change to the `edsl/notebooks` package by commenting out the import and export of the `NotebookToLaTeX` class. This means `NotebookToLaTeX` is no longer available for import from the package's top-level API.

- Commented out the import of `NotebookToLaTeX` in `edsl/notebooks/__init__.py`, removing it from the public API. [[1]](diffhunk://#diff-2bf4833d898c7c491b9190f9fd7034590a8593b97845fe6f81a48bae4d555aebL9-R10) [[2]](diffhunk://#diff-2bf4833d898c7c491b9190f9fd7034590a8593b97845fe6f81a48bae4d555aebL20-R21)