### PR TITLE
add _position_index attribute to fix duplicate hashes

### DIFF
--- a/edsl/jobs/jobs_interview_constructor.py
+++ b/edsl/jobs/jobs_interview_constructor.py
@@ -43,39 +43,25 @@ class InterviewsConstructor:
         _create_interviews_timing["call_count"] += 1
 
         t0 = time.time()
-        agent_index = {
-            hash(agent): index for index, agent in enumerate(self.jobs.agents)
-        }
+        for index, agent in enumerate(self.jobs.agents):
+            agent._position_index = index
         _create_interviews_timing["hash_agents"] += time.time() - t0
 
         t1 = time.time()
-        model_index = {
-            hash(model): index for index, model in enumerate(self.jobs.models)
-        }
+        for index, model in enumerate(self.jobs.models):
+            model._position_index = index
         _create_interviews_timing["hash_models"] += time.time() - t1
 
         t2 = time.time()
-        scenario_index = {}
         for index, scenario in enumerate(self.jobs.scenarios):
+            scenario._position_index = index
             scenario.my_hash = hash(scenario)
-            scenario_index[scenario.my_hash] = index
         _create_interviews_timing["hash_scenarios"] += time.time() - t2
 
         t3 = time.time()
         for agent, scenario, model in product(
             self.jobs.agents, self.jobs.scenarios, self.jobs.models
         ):
-            t4 = time.time()
-            agent_hash = hash(agent)
-            model_hash = hash(model)
-
-            if hasattr(scenario, "my_hash"):
-                scenario_hash = scenario.my_hash
-            else:
-                scenario_hash = hash(scenario)
-                scenario.my_hash = scenario_hash
-            _create_interviews_timing["hash_lookups"] += time.time() - t4
-
             t5 = time.time()
             drawn_survey = (
                 self.jobs.survey.draw()
@@ -92,9 +78,9 @@ class InterviewsConstructor:
                 skip_retry=self.jobs.run_config.parameters.skip_retry,
                 raise_validation_errors=self.jobs.run_config.parameters.raise_validation_errors,
                 indices={
-                    "agent": agent_index[agent_hash],
-                    "model": model_index[model_hash],
-                    "scenario": scenario_index[scenario_hash],
+                    "agent": agent._position_index,
+                    "model": model._position_index,
+                    "scenario": scenario._position_index,
                 },
             )
             _create_interviews_timing["interview_creation"] += time.time() - t6


### PR DESCRIPTION
This pull request refactors how indices for `agent`, `model`, and `scenario` objects are tracked and accessed within the `create_interviews` method in `jobs_interview_constructor.py`. Instead of using separate hash-based dictionaries to map objects to their indices, the code now assigns a `_position_index` attribute directly to each object. This simplifies the code and potentially improves performance by removing the need for repeated hash lookups.

Key changes:

**Refactoring index tracking:**
* Assigns a `_position_index` attribute to each `agent`, `model`, and `scenario` object during enumeration, replacing the previous use of hash-based index dictionaries.

**Simplifying index access:**
* Updates the construction of the `indices` dictionary to use the new `_position_index` attributes instead of dictionary lookups based on object hashes.