### PR TITLE
use pull endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ Choose whether to run surveys on your own computer or at the Expected Parrot ser
 Easily share workflows and projects privately or publicly at Coop: an integrated platform for AI-based research. Your account comes with free credits for running surveys, and lets you securely share keys, track expenses and usage for your team.
 
 **Built-in tools for analyis**: 
-Analyze results as specified datasets from your account or workspace. Easily import data to use with your surveys and export results..
+Analyze results as specified datasets from your account or workspace. Easily import data to use with your surveys and export results.

--- a/edsl/results/results_remote_fetcher.py
+++ b/edsl/results/results_remote_fetcher.py
@@ -76,7 +76,7 @@ class ResultsRemoteFetcher:
 
             # Fetch the remote Results object
             coop = Coop()
-            remote_results = coop.get(results_uuid, expected_object_type="results")
+            remote_results = coop.pull(results_uuid, expected_object_type="results")
 
             # Update this instance with remote data
             self.results.data = remote_results.data


### PR DESCRIPTION
This pull request makes a small update to the `fetch_remote` method in `edsl/results/results_remote_fetcher.py`, changing the way remote results are retrieved to use a more appropriate method. This improves clarity and may better reflect the intended operation.

- Replaced the use of `coop.get` with `coop.pull` when fetching remote results in the `fetch_remote` method to clarify intent and possibly improve data retrieval semantics.