### PR TITLE
Fix URL truncation in Scenario and ScenarioList rich display

### DIFF
--- a/edsl/display/utils.py
+++ b/edsl/display/utils.py
@@ -26,6 +26,47 @@ def file_notice(file_name, link_text="Download file"):
         print(f"File created: {file_name}")
 
 
+def smart_truncate(text, max_length, ellipsis="..."):
+    """
+    Truncate a string at whitespace boundaries to avoid breaking URLs or important strings.
+    URLs are never truncated as they need to remain functional.
+
+    Args:
+        text (str): The text to truncate
+        max_length (int): Maximum length of the truncated string (including ellipsis)
+        ellipsis (str): The ellipsis string to append when truncating
+
+    Returns:
+        str: The truncated string, or original string if it's a URL
+    """
+    if len(text) <= max_length:
+        return text
+
+    # Check if this looks like a URL - if so, don't truncate it
+    # URLs should remain functional
+    if text.startswith(('http://', 'https://', 'ftp://', 'ftps://')) or '://' in text:
+        return text
+
+    # If the text needs to be truncated
+    target_length = max_length - len(ellipsis)
+
+    # If target length is too small, just do simple truncation
+    if target_length < 10:
+        return text[:target_length] + ellipsis
+
+    # Try to find a good breaking point (whitespace)
+    # Look for the last whitespace character within a reasonable range
+    # We'll search backwards up to 20% of the target length to find whitespace
+    search_start = max(target_length - int(target_length * 0.2), target_length // 2)
+
+    for i in range(target_length - 1, search_start - 1, -1):
+        if text[i].isspace():
+            return text[:i] + ellipsis
+
+    # If no good break point found, fall back to simple truncation
+    return text[:target_length] + ellipsis
+
+
 def display_html(html_content, width=None, height=None, as_iframe=False):
     """
     Display HTML content, optionally within an iframe.

--- a/edsl/display/utils.py
+++ b/edsl/display/utils.py
@@ -44,7 +44,7 @@ def smart_truncate(text, max_length, ellipsis="..."):
 
     # Check if this looks like a URL - if so, don't truncate it
     # URLs should remain functional
-    if text.startswith(('http://', 'https://', 'ftp://', 'ftps://')) or '://' in text:
+    if text.startswith(("http://", "https://", "ftp://", "ftps://")) or "://" in text:
         return text
 
     # If the text needs to be truncated

--- a/edsl/scenarios/scenario.py
+++ b/edsl/scenarios/scenario.py
@@ -24,6 +24,7 @@ from typing import Union, List, Optional, TYPE_CHECKING, Dict, Any, Iterable, Ma
 
 from ..base import Base
 from .exceptions import ScenarioError
+from ..display.utils import smart_truncate
 
 if TYPE_CHECKING:
     from .scenario_list import ScenarioList
@@ -727,10 +728,10 @@ class Scenario(Base, UserDict):
             output.append("    data={\n", style=RICH_STYLES["default"])
 
             for i, (key, value) in enumerate(list(self.data.items())[:max_items]):
-                # Format the value with truncation if needed
+                # Format the value with smart truncation if needed
                 value_repr = repr(value)
                 if len(value_repr) > max_value_length:
-                    value_repr = value_repr[: max_value_length - 3] + "..."
+                    value_repr = smart_truncate(value_repr, max_value_length)
 
                 output.append("        ", style=RICH_STYLES["default"])
                 output.append(f"'{key}'", style=RICH_STYLES["secondary"])

--- a/edsl/scenarios/scenario_list.py
+++ b/edsl/scenarios/scenario_list.py
@@ -91,6 +91,7 @@ from ..utilities import (
     memory_profile,
     list_split,
 )
+from ..display.utils import smart_truncate
 from ..dataset import ScenarioListOperationsMixin
 
 from ..db_list.sqlite_list import SQLiteList
@@ -1243,11 +1244,11 @@ class ScenarioList(MutableSequence, Base, ScenarioListOperationsMixin):
 
             # Show fields
             for key, value in scenario_data.items():
-                # Format the value with truncation if needed
+                # Format the value with smart truncation if needed
                 max_value_length = max(terminal_width - 30, 50)
                 value_repr = repr(value)
                 if len(value_repr) > max_value_length:
-                    value_repr = value_repr[: max_value_length - 3] + "..."
+                    value_repr = smart_truncate(value_repr, max_value_length)
 
                 output.append("                ", style=RICH_STYLES["default"])
                 output.append(f"'{key}'", style=RICH_STYLES["key"])


### PR DESCRIPTION
## Summary

Fixes issue where URLs in Scenario and ScenarioList rich display were being truncated mid-string, making them non-functional.

## Problem

Previously, URLs were truncated like this:
```
'admin_url': 'https://expectedparrot.com/home/projects/748feafb-...,
'respondent_url': 'https://expectedparrot.com/respond/projects/748fea...,
```

This broke the URLs and made them unusable.

## Solution

- Added `smart_truncate()` function that detects URLs and preserves them entirely
- Updated both `Scenario._summary_repr()` and `ScenarioList._summary_repr()` to use smart truncation
- URLs are now displayed in full while other text is still truncated at whitespace boundaries

## After Fix

URLs are now displayed completely:
```
'admin_url': 'https://expectedparrot.com/home/projects/748feafb-c573-48ff-992d-06a3680cbf34',
'respondent_url': 'https://expectedparrot.com/respond/projects/748feafb-c573-48ff-992d-06a3680cbf34',
```

## Test Plan

- [x] URLs are preserved in full in Scenario display
- [x] URLs are preserved in full in ScenarioList display  
- [x] Non-URL text is still properly truncated at whitespace
- [x] Basic functionality tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)