### PR TITLE
use sandboxed jinja templtes

### DIFF
--- a/edsl/prompts/prompt.py
+++ b/edsl/prompts/prompt.py
@@ -6,6 +6,7 @@ import time
 from functools import lru_cache
 
 from jinja2 import Environment, meta, Undefined
+from jinja2.sandbox import SandboxedEnvironment
 
 from .exceptions import TemplateRenderError, PromptValueError, PromptImplementationError
 from ..base import PersistenceMixin, RepresentationMixin
@@ -42,11 +43,14 @@ class TemplateVars:
         return self.data
 
 
-def make_env() -> Environment:
-    """Create a fresh Jinja environment each time,
-    so we don't mix captured variables across multiple renders.
+def make_env() -> SandboxedEnvironment:
+    """Create a fresh sandboxed Jinja environment each time.
+
+    Uses SandboxedEnvironment to prevent Server-Side Template Injection (SSTI)
+    attacks by blocking access to dangerous attributes like __class__, __mro__,
+    __globals__, etc.
     """
-    return Environment(undefined=PreserveUndefined)
+    return SandboxedEnvironment(undefined=PreserveUndefined)
 
 
 @lru_cache(maxsize=100000)


### PR DESCRIPTION
This pull request updates the Jinja2 environment used for rendering prompts to improve security. The key change is switching from the standard `Environment` to `SandboxedEnvironment`, which helps prevent Server-Side Template Injection (SSTI) attacks.

**Security improvements:**

* Replaced the use of `jinja2.Environment` with `jinja2.sandbox.SandboxedEnvironment` in the `make_env` function in `prompt.py`, ensuring that template rendering is isolated and dangerous Python attributes are blocked. [[1]](diffhunk://#diff-637bead5057bc27b528b30b40be5954da41a63f1e98923b1feacddbdbb9ded6bR9) [[2]](diffhunk://#diff-637bead5057bc27b528b30b40be5954da41a63f1e98923b1feacddbdbb9ded6bL45-R53)