### PR TITLE
Fix PDF text ordering in ScenarioList.from_pdf

### DIFF
--- a/edsl/scenarios/scenario_list_pdf_tools.py
+++ b/edsl/scenarios/scenario_list_pdf_tools.py
@@ -205,7 +205,15 @@ class PdfTools:
         # Iterate through each page and extract text
         for page_num in range(len(document)):
             page = document.load_page(page_num)
-            text = page.get_text()
+            blocks = page.get_text("blocks")  # Extract text blocks
+
+            # Sort blocks by their vertical position (y0) to maintain reading order
+            blocks.sort(key=lambda b: (b[1], b[0]))  # Sort by y0 first, then x0
+
+            # Combine the text blocks in order
+            text = ""
+            for block in blocks:
+                text += block[4] + "\n"
 
             # Create a dictionary for the current page
             page_info = {"filename": filename, "page": page_num + 1, "text": text}


### PR DESCRIPTION
## Summary
- Fixes #957
- `ScenarioList.from_pdf()` now extracts text in proper reading order, matching `Scenario.from_pdf()` behavior

## Reasoning
`PdfTools.extract_text_from_pdf()` was using `page.get_text()` which returns text blocks in arbitrary order determined by the PDF's internal structure. This caused content to appear misordered (e.g., question texts out of order with options).

`Scenario.from_pdf()` uses `PdfExtractor` which extracts text blocks via `get_text("blocks")` and sorts them by vertical position (y0) then horizontal position (x0) to maintain proper reading order.

Updated `PdfTools.extract_text_from_pdf()` to use the same block-based extraction and sorting approach.