### PR TITLE
Normalize multiple choice responses like "0: Yes" to code-only format

### DIFF
--- a/edsl/questions/question_multiple_choice.py
+++ b/edsl/questions/question_multiple_choice.py
@@ -168,6 +168,13 @@ class MultipleChoiceResponseValidator(ResponseValidatorABC):
             if verbose:
                 print("Not attempting to fix None answer value")
             return response
+        
+        answer = response.get("answer")
+        # Normalize responses like "0: Yes" to "0" if use_code=True
+        if isinstance(answer, str) and ":" in answer and getattr(self, "use_code", False):
+            if verbose:
+                print(f"Normalizing answer from '{answer}' to code only")
+            response["answer"] = answer.split(":")[0].strip()
 
         # Get the raw text to analyze
         response_text = str(response.get("answer", ""))


### PR DESCRIPTION
This PR addresses issue #2356.

Problem:
- When `use_code=True` for multiple choice questions, the LLM sometimes returns responses like "0: Yes" instead of just "0".
- This causes `QuestionAnswerValidationError` because the strict literal validation expects only the numeric code.

Solution:
- Added normalization in `MultipleChoiceResponseValidator.fix()` to split responses containing ":" and keep only the numeric code.
- Applied only for string responses when `use_code=True`.
- Existing validation and matching strategies (exact, case-insensitive, prefix matching) remain unchanged.

This ensures that the validator accepts responses like "0: Yes" while keeping the validation strict for other cases.
