### PR TITLE
Fix OpenAI v2 issues

### DIFF
--- a/edsl/inference_services/services/open_ai_service.py
+++ b/edsl/inference_services/services/open_ai_service.py
@@ -32,13 +32,16 @@ class OpenAIParameterBuilder:
 
         default_max_tokens = model_params.get("max_tokens", 1000)
         default_temperature = model_params.get("temperature", 0.5)
+        default_reasoning_effort = model_params.get("reasoning_effort", "medium")
         if model in OPENAI_REASONING_MODELS:
             # For reasoning models, use much higher completion tokens to allow for reasoning + response
             max_tokens = max(default_max_tokens, 5000)
             temperature = 1
+            reasoning_effort = default_reasoning_effort
         else:
             max_tokens = default_max_tokens
             temperature = default_temperature
+            reasoning_effort = None
 
         # Base parameters
         params = {
@@ -56,6 +59,9 @@ class OpenAIParameterBuilder:
                 else None
             ),
         }
+
+        if model in OPENAI_REASONING_MODELS:
+            params["reasoning_effort"] = reasoning_effort
 
         return params
 
@@ -168,6 +174,7 @@ class OpenAIService(InferenceServiceABC):
                 "presence_penalty": 0,
                 "logprobs": False,
                 "top_logprobs": 3,
+                "reasoning_effort": None,
             }
 
             def sync_client(self):
@@ -320,6 +327,7 @@ class OpenAIService(InferenceServiceABC):
                     presence_penalty=self.presence_penalty,
                     logprobs=self.logprobs,
                     top_logprobs=self.top_logprobs,
+                    reasoning_effort=self.reasoning_effort,
                 )
 
                 # Add structured output support if response_schema is provided

--- a/edsl/inference_services/services/open_ai_service.py
+++ b/edsl/inference_services/services/open_ai_service.py
@@ -37,7 +37,9 @@ class OpenAIParameterBuilder:
             # For reasoning models, use much higher completion tokens to allow for reasoning + response
             max_tokens = max(default_max_tokens, 5000)
             temperature = 1
-            reasoning_effort = default_reasoning_effort
+            # If no reasoning effort is provided, use "medium" as the default
+            # Some models (e.g. gpt-5) do not support null values for reasoning_effort
+            reasoning_effort = default_reasoning_effort or "medium"
         else:
             max_tokens = default_max_tokens
             temperature = default_temperature

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -43,8 +43,8 @@ class OpenAIServiceV2(InferenceServiceABC):
     usage_sequence = ["usage"]
     # sequence to extract reasoning summary from response.output
     reasoning_sequence = ["output", 0, "summary"]
-    input_token_name = "prompt_tokens"
-    output_token_name = "completion_tokens"
+    input_token_name = "input_tokens"
+    output_token_name = "output_tokens"
 
     available_models_url = "https://platform.openai.com/docs/models/gp"
 

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -140,6 +140,7 @@ class OpenAIServiceV2(InferenceServiceABC):
                 "presence_penalty": 0,
                 "logprobs": False,
                 "top_logprobs": 3,
+                "reasoning": None,
             }
 
             def sync_client(self) -> openai.OpenAI:
@@ -322,7 +323,10 @@ class OpenAIServiceV2(InferenceServiceABC):
 
                 # Only add reasoning parameter for reasoning models
                 if is_reasoning_model:
-                    params["reasoning"] = {"summary": "auto"}
+                    reasoning_params = {"summary": "auto"}
+                    if isinstance(self.reasoning, dict):
+                        reasoning_params.update(self.reasoning)
+                    params["reasoning"] = reasoning_params
 
                 # For all models using the responses API, use max_output_tokens
                 # instead of max_tokens (which is for the completions API)

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -286,7 +286,7 @@ class OpenAIServiceV2(InferenceServiceABC):
                                     )
                 # build input sequence
                 messages: Any
-                if system_prompt and not self.omit_system_prompt_if_empty:
+                if system_prompt:
                     # For Responses API, system content should also be properly formatted
                     system_content = (
                         system_prompt
@@ -298,7 +298,13 @@ class OpenAIServiceV2(InferenceServiceABC):
                         {"role": "user", "content": content},
                     ]
                 else:
-                    messages = [{"role": "user", "content": content}]
+                    if self.omit_system_prompt_if_empty:
+                        messages = [{"role": "user", "content": content}]
+                    else:
+                        messages = [
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": content},
+                        ]
 
                 # All OpenAI models with the responses API use these base parameters
                 params = {

--- a/edsl/inference_services/services/service_enums.py
+++ b/edsl/inference_services/services/service_enums.py
@@ -8,4 +8,5 @@ OPENAI_REASONING_MODELS = [
     "gpt-5",
     "gpt-5-mini",
     "gpt-5-nano",
+    "gpt-5.1",
 ]

--- a/edsl/interviews/interview.py
+++ b/edsl/interviews/interview.py
@@ -9,7 +9,7 @@ a survey with a specific language model and scenario. It handles the complete wo
 4. Handling exceptions and retry logic
 5. Managing the asynchronous execution of question answering tasks
 
-The Interview class serves as the execution layer between high-level Jobs objects and 
+The Interview class serves as the execution layer between high-level Jobs objects and
 the individual API calls to language models, with support for caching and distributed execution.
 """
 
@@ -289,7 +289,7 @@ class Interview:
         Examples:
             >>> i = Interview.example()
             >>> hash(i)
-            697272427402946620
+            134932146855371893
         """
         # Create the base dictionary with core components
         d = {

--- a/edsl/language_models/language_model.py
+++ b/edsl/language_models/language_model.py
@@ -571,7 +571,7 @@ class LanguageModel(
         Examples:
             >>> m = LanguageModel.example()
             >>> hash(m)  # Actual value may vary
-            325654563661254408
+            1865859436931396641
         """
         return dict_hash(self.to_dict(add_edsl_version=False))
 


### PR DESCRIPTION
- Fixes an issue where the system prompt (and agent traits) are not taken into account for OpenAI v2 models.
- Fixes OpenAI v2 token names (incorrect token names resulted in the model input / output tokens not being correctly recorded in the results).
- Adds support for the `reasoning_effort` param for `openai` and the `reasoning` param for `openai_v2`.