### PR TITLE
Allow EDSL users to specify an alert_on_completion_config

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -45,6 +45,7 @@ from .utils import (
     VisibilityType,
 )
 
+from ..jobs.data_structures import AlertOnCompletionConfig
 from .coop_functions import CoopFunctionsMixin
 from .coop_regular_objects import CoopRegularObjects
 from .coop_jobs_objects import CoopJobsObjects
@@ -1796,6 +1797,7 @@ class Coop(CoopFunctionsMixin):
         initial_results_description: Optional[str] = None,
         iterations: Optional[int] = 1,
         fresh: Optional[bool] = False,
+        alert_on_completion_config: Optional[Any] = None,
     ) -> RemoteInferenceCreationInfo:
         """
         Create a remote inference job for execution in the Expected Parrot cloud.
@@ -1817,6 +1819,8 @@ class Coop(CoopFunctionsMixin):
             initial_results_visibility (VisibilityType): Access level for the job results
             iterations (int): Number of times to run each interview (default: 1)
             fresh (bool): If True, ignore existing cache entries and generate new results
+            alert_on_completion_config (dict, optional): Config for job completion alerts
+                (email and/or webhooks). Dict with "email" (bool) and "webhooks" (list of {"url": str}, max 3).
 
         Returns:
             RemoteInferenceCreationInfo: Information about the created job including:
@@ -1845,19 +1849,25 @@ class Coop(CoopFunctionsMixin):
             f"Creating remote inference job with description: {description}"
         )
 
+        payload = {
+            "json_string": "offloaded",
+            "description": description,
+            "status": status,
+            "iterations": iterations,
+            "visibility": visibility,
+            "version": self._edsl_version,
+            "initial_results_visibility": initial_results_visibility,
+            "fresh": fresh,
+        }
+        if alert_on_completion_config is not None:
+            validated = AlertOnCompletionConfig.model_validate(
+                alert_on_completion_config
+            )
+            payload["alert_on_completion_config"] = validated.model_dump()
         response = self._send_server_request(
             uri="api/v0/new-remote-inference",
             method="POST",
-            payload={
-                "json_string": "offloaded",
-                "description": description,
-                "status": status,
-                "iterations": iterations,
-                "visibility": visibility,
-                "version": self._edsl_version,
-                "initial_results_visibility": initial_results_visibility,
-                "fresh": fresh,
-            },
+            payload=payload,
         )
         self._resolve_server_response(response)
         response_json = response.json()

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -1921,6 +1921,27 @@ class Coop(CoopFunctionsMixin):
             }
         )
 
+    def cancel_remote_inference_job(self, job_uuid: str) -> None:
+        """
+        Request cancellation of a queued or running remote inference job.
+
+        Calls the server to mark the job as cancelling. The job may not stop
+        immediately; poll with new_remote_inference_get(job_uuid) to see status.
+
+        Parameters:
+            job_uuid (str): The UUID of the remote job to cancel.
+
+        Raises:
+            CoopServerResponseError: If the server returns an error (e.g. not found, forbidden).
+        """
+        response = self._send_server_request(
+            uri="api/v0/remote-inference/update-status",
+            method="POST",
+            payload={"job_uuid": str(job_uuid), "status": "cancelling"},
+        )
+        self._resolve_server_response(response)
+        return response.json()
+
     def old_remote_inference_create(
         self,
         job: "Jobs",

--- a/edsl/jobs/__init__.py
+++ b/edsl/jobs/__init__.py
@@ -7,6 +7,10 @@ and management of concurrent language model API calls.
 
 from .jobs import Jobs
 from .jobs import RunConfig, RunParameters, RunEnvironment  # noqa: F401
+from .data_structures import (  # noqa: F401
+    WebhookConfig,
+    AlertOnCompletionConfig,
+)
 from .remote_inference import JobsRemoteInferenceHandler  # noqa: F401
 from .jobs_runner_status import JobsRunnerStatusBase  # noqa: F401
 from .exceptions import (
@@ -41,4 +45,6 @@ __all__ = [
     "RunConfig",
     "RunParameters",
     "RunEnvironment",
+    "WebhookConfig",
+    "AlertOnCompletionConfig",
 ]

--- a/edsl/jobs/data_structures.py
+++ b/edsl/jobs/data_structures.py
@@ -1,6 +1,8 @@
-from typing import Optional, Literal, TYPE_CHECKING, Any
+from typing import Optional, Literal, TYPE_CHECKING, Any, List
 from dataclasses import dataclass, asdict
 from collections import UserDict
+
+from pydantic import BaseModel, Field
 
 from ..data_transfer_models import EDSLResultObjectInput
 from ..base import Base
@@ -15,6 +17,19 @@ if TYPE_CHECKING:
     from ..caching import Cache
 
 VisibilityType = Literal["private", "public", "unlisted"]
+
+
+class WebhookConfig(BaseModel):
+    """Config for a single completion webhook."""
+
+    url: str
+
+
+class AlertOnCompletionConfig(BaseModel):
+    """Config for job completion alerts (email and/or webhooks)."""
+
+    email: bool = False
+    webhooks: List[WebhookConfig] = Field(default_factory=list, max_length=3)
 
 
 @dataclass
@@ -72,6 +87,7 @@ class RunParameters(Base):
         job_uuid (str, optional): UUID for the job, used for tracking
         fresh (bool): If True, ignore cache and generate new results, default is False
         new_format (bool): If True, uses remote_inference_create method, if False uses old_remote_inference_create method, default is True
+        alert_on_completion_config (dict, optional): Config for job completion alerts (email and/or webhooks). Dict with "email" (bool) and "webhooks" (list of {"url": str}, max 3).
     """
 
     n: int = 1
@@ -106,6 +122,7 @@ class RunParameters(Base):
     expected_parrot_api_key: Optional[str] = (
         None  # Custom EXPECTED_PARROT_API_KEY to use for this job run
     )
+    alert_on_completion_config: Optional[dict] = None
 
     def to_dict(self, add_edsl_version=False) -> dict:
         d = asdict(self)

--- a/edsl/jobs/jobs.py
+++ b/edsl/jobs/jobs.py
@@ -1000,6 +1000,7 @@ class Jobs(Base):
             remote_inference_results_visibility=self.run_config.parameters.remote_inference_results_visibility,
             fresh=self.run_config.parameters.fresh,
             new_format=self.run_config.parameters.new_format,
+            alert_on_completion_config=self.run_config.parameters.alert_on_completion_config,
         )
         return job_info
 
@@ -1765,6 +1766,9 @@ class Jobs(Base):
             If True, uses remote_inference_create method, if False uses old_remote_inference_create method (default: True)
         expected_parrot_api_key : str, optional
             Custom EXPECTED_PARROT_API_KEY to use for this job run
+        alert_on_completion_config : dict or AlertOnCompletionConfig, optional
+            Config for job completion alerts (email and/or webhooks). Pass a dict with
+            "email" (bool) and "webhooks" (list of {"url": str}, max 3 items).
 
         Returns
         -------

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -138,6 +138,7 @@ class JobsRemoteInferenceHandler:
         remote_inference_results_visibility: Optional["VisibilityType"] = "private",
         fresh: Optional[bool] = False,
         new_format: Optional[bool] = True,
+        alert_on_completion_config: Optional[Any] = None,
     ) -> RemoteJobInfo:
         """
         Create a remote inference job and return job information.
@@ -148,6 +149,7 @@ class JobsRemoteInferenceHandler:
             remote_inference_results_visibility: Visibility setting for results
             fresh: If True, ignore existing cache entries and generate new results
             new_format: If True, use pull method for result retrieval; if False, use legacy get method
+            alert_on_completion_config: Optional config for job completion alerts (email and/or webhooks)
 
         Returns:
             RemoteJobInfo: Information about the created job including UUID and logger
@@ -175,6 +177,7 @@ class JobsRemoteInferenceHandler:
                 iterations=iterations,
                 initial_results_visibility=remote_inference_results_visibility,
                 fresh=fresh,
+                alert_on_completion_config=alert_on_completion_config,
             )
         else:
             remote_job_creation_data = coop.old_remote_inference_create(


### PR DESCRIPTION
This allows for notification via email or HTTP request when a job has finished.

Also in this PR: Allow users to cancel a remote job from EDSL.