### PR TITLE
Add enumeration parameter for multiple choice option labeling

### DIFF
--- a/edsl/invigilators/question_template_replacements_builder.py
+++ b/edsl/invigilators/question_template_replacements_builder.py
@@ -342,9 +342,12 @@ class QuestionTemplateReplacementsBuilder:
         {'use_code': False, 'include_comment': True, 'question_name': 'q0', 'question_text': 'Do you like school?', 'question_options': ['yes', 'no']}
 
         """
+        enumeration = getattr(question, "_enumeration", None)
+        enumeration_value = enumeration.value if enumeration is not None else "none"
         question_settings = {
             "use_code": getattr(question, "_use_code", True),
             "include_comment": getattr(question, "_include_comment", False),
+            "enumeration": enumeration_value,
         }
         return {**question_settings, **question_data}
 

--- a/edsl/questions/question_base.py
+++ b/edsl/questions/question_base.py
@@ -434,7 +434,7 @@ class QuestionBase(
         ]
         only_if_not_na_list = ["_answering_instructions", "_question_presentation"]
 
-        only_if_not_default_list = {"_include_comment": True, "_use_code": False}
+        only_if_not_default_list = {"_include_comment": True, "_use_code": False, "_enumeration": "none"}
 
         def ok(key, value):
             if not key.startswith("_"):

--- a/edsl/questions/question_base_prompts_mixin.py
+++ b/edsl/questions/question_base_prompts_mixin.py
@@ -180,11 +180,14 @@ class QuestionBasePromptsMixin:
         self._question_presentation = value
 
     def prompt_preview(self, scenario=None, agent=None):
+        enumeration = getattr(self, "_enumeration", None)
+        enumeration_value = enumeration.value if enumeration is not None else "none"
         return self.new_default_instructions.render(
             self.data
             | {
                 "include_comment": getattr(self, "_include_comment", True),
                 "use_code": getattr(self, "_use_code", True),
+                "enumeration": enumeration_value,
             }
             | ({"scenario": scenario} or {})
             | ({"agent": agent} or {})

--- a/edsl/questions/question_multiple_choice.py
+++ b/edsl/questions/question_multiple_choice.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from enum import Enum
 from typing import Union, Literal, Optional, List, Any
 
 from jinja2 import Template
@@ -8,6 +9,44 @@ from .question_base import QuestionBase
 from .descriptors import QuestionOptionsDescriptor
 from .decorators import inject_exception
 from .response_validator_abc import ResponseValidatorABC
+
+
+class AnswerEnumeration(str, Enum):
+    """Enumeration styles for multiple choice option labeling."""
+    NONE = "none"
+    NUMERIC_STARTS_WITH_0 = "numeric_starts_with_0"
+    NUMERIC_STARTS_WITH_1 = "numeric_starts_with_1"
+    LETTERS = "letters"
+    LETTERS_LOWER = "letters_lower"
+
+    def codes_for(self, n: int) -> list:
+        """Return the list of valid answer codes for n options."""
+        if self == AnswerEnumeration.NONE:
+            return None
+        elif self == AnswerEnumeration.NUMERIC_STARTS_WITH_0:
+            return list(range(n))
+        elif self == AnswerEnumeration.NUMERIC_STARTS_WITH_1:
+            return list(range(1, n + 1))
+        elif self == AnswerEnumeration.LETTERS:
+            return [chr(65 + i) for i in range(n)]
+        elif self == AnswerEnumeration.LETTERS_LOWER:
+            return [chr(97 + i) for i in range(n)]
+
+    def translate_to_index(self, code) -> int:
+        """Convert an answer code back to a 0-based index."""
+        if self == AnswerEnumeration.NUMERIC_STARTS_WITH_0:
+            return int(code)
+        elif self == AnswerEnumeration.NUMERIC_STARTS_WITH_1:
+            return int(code) - 1
+        elif self == AnswerEnumeration.LETTERS:
+            return ord(str(code).upper()) - 65
+        elif self == AnswerEnumeration.LETTERS_LOWER:
+            return ord(str(code).lower()) - 97
+        return None
+
+    @property
+    def is_enumerated(self) -> bool:
+        return self != AnswerEnumeration.NONE
 
 
 class BaseMultipleChoiceResponse(BaseModel):
@@ -132,7 +171,7 @@ class MultipleChoiceResponseValidator(ResponseValidatorABC):
         'Good'
     """
 
-    required_params = ["question_options", "use_code"]
+    required_params = ["question_options", "use_code", "enumeration"]
 
     def fix(self, response, verbose=False):
         """
@@ -169,20 +208,38 @@ class MultipleChoiceResponseValidator(ResponseValidatorABC):
                 print("Not attempting to fix None answer value")
             return response
 
-        # When use_code=True, try to extract the numeric code from responses
-        # like "0: Yes", "0 - Yes", "0. Yes", etc.
-        if self.use_code:
+        # When using any enumeration style, try to extract the code from
+        # responses like "0: Yes", "B: Blue", "b", "2 - Option", etc.
+        enumeration = getattr(self, "enumeration", AnswerEnumeration.NONE)
+        if enumeration.is_enumerated:
             answer = str(response.get("answer", ""))
             import re
-            code_match = re.match(r"^\s*(\d+)\s*[:.\-)\]]\s*", answer)
-            if code_match:
-                code = int(code_match.group(1))
-                if 0 <= code < len(self.question_options):
-                    return {
-                        "answer": code,
-                        "comment": response.get("comment"),
-                        "generated_tokens": response.get("generated_tokens"),
-                    }
+            valid_codes = enumeration.codes_for(len(self.question_options))
+
+            if enumeration in (AnswerEnumeration.LETTERS, AnswerEnumeration.LETTERS_LOWER):
+                # Extract letter code: "B: Blue" -> "B", or bare "b" -> "B"/"b"
+                letter_match = re.match(r"^\s*([A-Za-z])\s*[:.\-)\]]\s*", answer)
+                if letter_match:
+                    letter = letter_match.group(1)
+                    if enumeration == AnswerEnumeration.LETTERS:
+                        letter = letter.upper()
+                    else:
+                        letter = letter.lower()
+                    if letter in valid_codes:
+                        return {"answer": letter, "comment": response.get("comment"), "generated_tokens": response.get("generated_tokens")}
+                # Bare single letter
+                stripped = answer.strip()
+                if len(stripped) == 1 and stripped.isalpha():
+                    letter = stripped.upper() if enumeration == AnswerEnumeration.LETTERS else stripped.lower()
+                    if letter in valid_codes:
+                        return {"answer": letter, "comment": response.get("comment"), "generated_tokens": response.get("generated_tokens")}
+            else:
+                # Numeric: "0: Yes", "1 - Option", etc.
+                code_match = re.match(r"^\s*(\d+)\s*[:.\-)\]]\s*", answer)
+                if code_match:
+                    code = int(code_match.group(1))
+                    if code in valid_codes:
+                        return {"answer": code, "comment": response.get("comment"), "generated_tokens": response.get("generated_tokens")}
 
         # Get the raw text to analyze
         response_text = str(response.get("answer", ""))
@@ -402,6 +459,7 @@ class QuestionMultipleChoice(QuestionBase):
         question_options: Union[list[str], list[list], list[float], list[int]],
         include_comment: bool = True,
         use_code: bool = False,
+        enumeration: Optional[str] = None,
         answering_instructions: Optional[str] = None,
         question_presentation: Optional[str] = None,
         permissive: bool = False,
@@ -470,12 +528,39 @@ class QuestionMultipleChoice(QuestionBase):
           while still suggesting options
         - Dynamic options can reference variables in a scenario using Jinja2 template syntax
         """
+        # Resolve enumeration from use_code (backward compat) and enumeration param
+        if use_code and enumeration is not None:
+            raise ValueError(
+                "Cannot set both use_code=True and enumeration. "
+                "use_code=True is equivalent to enumeration='numeric_starts_with_0'."
+            )
+        if enumeration is not None:
+            try:
+                self._enumeration = AnswerEnumeration(enumeration)
+            except ValueError:
+                valid = [e.value for e in AnswerEnumeration if e != AnswerEnumeration.NONE]
+                raise ValueError(
+                    f"Invalid enumeration '{enumeration}'. Valid values: {valid}"
+                )
+        elif use_code:
+            self._enumeration = AnswerEnumeration.NUMERIC_STARTS_WITH_0
+        else:
+            self._enumeration = AnswerEnumeration.NONE
+
+        # Validate letter enumeration limit
+        if self._enumeration in (AnswerEnumeration.LETTERS, AnswerEnumeration.LETTERS_LOWER):
+            if isinstance(question_options, list) and len(question_options) > 26:
+                raise ValueError(
+                    f"Letter enumeration supports at most 26 options (A-Z), got {len(question_options)}."
+                )
+
         self.question_name = question_name
         self.question_text = question_text
         self.question_options = self._clean_nan_from_options(question_options)
 
         self._include_comment = include_comment
-        self.use_code = use_code
+        # use_code property is derived from _enumeration for backward compat
+        self._use_code = self._enumeration == AnswerEnumeration.NUMERIC_STARTS_WITH_0
         self.answering_instructions = answering_instructions
         self.question_presentation = question_presentation
         self.permissive = permissive
@@ -507,15 +592,17 @@ class QuestionMultipleChoice(QuestionBase):
                 cleaned_options.append(option)
         return cleaned_options
 
+    @property
+    def enumeration(self) -> AnswerEnumeration:
+        return self._enumeration
+
     def create_response_model(self, replacement_dict: dict = None):
         if replacement_dict is None:
             replacement_dict = {}
-            # The replacement dict that could be from scenario, current answers, etc. to populate the response model
 
-        if self.use_code:
-            return create_response_model(
-                list(range(len(self.question_options))), self.permissive
-            )
+        codes = self._enumeration.codes_for(len(self.question_options))
+        if codes is not None:
+            return create_response_model(codes, self.permissive)
         else:
             return create_response_model(self.question_options, self.permissive)
 
@@ -603,24 +690,18 @@ class QuestionMultipleChoice(QuestionBase):
             self.question_options, replacements_dict
         )
 
-        if self._use_code:
+        if self._enumeration.is_enumerated:
             try:
-                return translated_options[int(answer_code)]
-            except IndexError:
+                idx = self._enumeration.translate_to_index(answer_code)
+                return translated_options[idx]
+            except (IndexError, TypeError, ValueError):
                 from .exceptions import QuestionValueError
 
                 raise QuestionValueError(
-                    f"Answer code is out of range. The answer code index was: {int(answer_code)}. The options were: {translated_options}."
-                )
-            except TypeError:
-                from .exceptions import QuestionValueError
-
-                raise QuestionValueError(
-                    f"The answer code was: '{answer_code}.'",
-                    f"The options were: '{translated_options}'.",
+                    f"Answer code '{answer_code}' could not be translated. "
+                    f"The options were: {translated_options}."
                 )
         else:
-            # return translated_options[answer_code]
             return answer_code
 
     @property

--- a/edsl/questions/templates/multiple_choice/answering_instructions.jinja
+++ b/edsl/questions/templates/multiple_choice/answering_instructions.jinja
@@ -1,5 +1,7 @@
 {# Answering Instructions #}
-{% if use_code %}
+{% if enumeration == "letters" or enumeration == "letters_lower" %}
+Respond only with the letter corresponding to one of the options (e.g., A, B, C, D).
+{% elif enumeration == "numeric_starts_with_0" or enumeration == "numeric_starts_with_1" or use_code %}
 Respond only with the code corresponding to one of the options.
 {% else %}
 Respond only with a string corresponding to one of the options.

--- a/edsl/questions/templates/multiple_choice/question_presentation.jinja
+++ b/edsl/questions/templates/multiple_choice/question_presentation.jinja
@@ -1,6 +1,18 @@
 {# Question Presention #}
 {{question_text}}
-{% if use_code %}
+{% if enumeration == "numeric_starts_with_1" %}
+    {%- for option in question_options %}
+{{ loop.index }}: {{option}}
+    {% endfor %}
+{% elif enumeration == "letters" %}
+    {%- for option in question_options %}
+{{ "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[loop.index0] }}: {{option}}
+    {% endfor %}
+{% elif enumeration == "letters_lower" %}
+    {%- for option in question_options %}
+{{ "abcdefghijklmnopqrstuvwxyz"[loop.index0] }}: {{option}}
+    {% endfor %}
+{% elif use_code or enumeration == "numeric_starts_with_0" %}
     {%- for option in question_options %}
 {{ loop.index0 }}: {{option}}
     {% endfor %}

--- a/tests/test_letter_enumeration.py
+++ b/tests/test_letter_enumeration.py
@@ -1,0 +1,270 @@
+"""Tests for enumeration styles (letters, numeric, etc.) in QuestionMultipleChoice."""
+
+import pytest
+from edsl.questions import QuestionMultipleChoice
+from edsl.questions.question_multiple_choice import AnswerEnumeration
+
+
+class TestAnswerEnumeration:
+    """Test the AnswerEnumeration enum."""
+
+    def test_enum_values(self):
+        assert AnswerEnumeration.NONE is not None
+        assert AnswerEnumeration.NUMERIC_STARTS_WITH_0 is not None
+        assert AnswerEnumeration.NUMERIC_STARTS_WITH_1 is not None
+        assert AnswerEnumeration.LETTERS is not None
+        assert AnswerEnumeration.LETTERS_LOWER is not None
+
+    def test_from_string(self):
+        assert AnswerEnumeration("numeric_starts_with_0") == AnswerEnumeration.NUMERIC_STARTS_WITH_0
+        assert AnswerEnumeration("letters") == AnswerEnumeration.LETTERS
+
+
+class TestEnumerationCreation:
+    """Test creating questions with different enumeration styles."""
+
+    def test_default_no_enumeration(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.", question_options=["A", "B"],
+        )
+        assert q.enumeration == AnswerEnumeration.NONE
+
+    def test_enumeration_letters(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.", question_options=["Red", "Blue"],
+            enumeration="letters",
+        )
+        assert q.enumeration == AnswerEnumeration.LETTERS
+
+    def test_enumeration_numeric_starts_with_0(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.", question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_0",
+        )
+        assert q.enumeration == AnswerEnumeration.NUMERIC_STARTS_WITH_0
+
+    def test_use_code_backward_compat(self):
+        """use_code=True should map to enumeration=NUMERIC_STARTS_WITH_0."""
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.", question_options=["Red", "Blue"],
+            use_code=True,
+        )
+        assert q.enumeration == AnswerEnumeration.NUMERIC_STARTS_WITH_0
+
+    def test_invalid_enumeration_raises(self):
+        with pytest.raises(ValueError):
+            QuestionMultipleChoice(
+                question_name="q1", question_text="Pick.", question_options=["A", "B"],
+                enumeration="roman_numerals",
+            )
+
+    def test_letters_max_26(self):
+        with pytest.raises(ValueError):
+            QuestionMultipleChoice(
+                question_name="q1", question_text="Pick.",
+                question_options=[f"Opt {i}" for i in range(27)],
+                enumeration="letters",
+            )
+
+    def test_use_code_and_enumeration_raises(self):
+        with pytest.raises(ValueError):
+            QuestionMultipleChoice(
+                question_name="q1", question_text="Pick.", question_options=["A", "B"],
+                use_code=True, enumeration="letters",
+            )
+
+
+class TestEnumerationValidation:
+    """Test answer validation with different enumeration styles."""
+
+    def test_letters_accepts_valid(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="letters",
+        )
+        result = q.response_validator.validate({"answer": "B"})
+        assert result["answer"] == "B"
+
+    def test_letters_rejects_out_of_range(self):
+        from edsl.questions.exceptions import QuestionAnswerValidationError
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="letters",
+        )
+        with pytest.raises(QuestionAnswerValidationError):
+            q.response_validator.validate({"answer": "C"})
+
+    def test_letters_lower_accepts_lowercase(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="letters_lower",
+        )
+        result = q.response_validator.validate({"answer": "b"})
+        assert result["answer"] == "b"
+
+    def test_numeric_starts_with_1_accepts(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="numeric_starts_with_1",
+        )
+        result = q.response_validator.validate({"answer": 2})
+        assert result["answer"] == 2
+
+    def test_numeric_starts_with_1_rejects_zero(self):
+        from edsl.questions.exceptions import QuestionAnswerValidationError
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_1",
+        )
+        with pytest.raises(QuestionAnswerValidationError):
+            q.response_validator.validate({"answer": 0})
+
+
+class TestEnumerationTranslation:
+    """Test translating enumerated answers back to option text."""
+
+    def test_letters_translate(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="letters",
+        )
+        assert q._translate_answer_code_to_answer("A", {}) == "Red"
+        assert q._translate_answer_code_to_answer("B", {}) == "Blue"
+        assert q._translate_answer_code_to_answer("C", {}) == "Green"
+
+    def test_letters_lower_translate(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="letters_lower",
+        )
+        assert q._translate_answer_code_to_answer("a", {}) == "Red"
+        assert q._translate_answer_code_to_answer("b", {}) == "Blue"
+
+    def test_numeric_starts_with_1_translate(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="numeric_starts_with_1",
+        )
+        assert q._translate_answer_code_to_answer(1, {}) == "Red"
+        assert q._translate_answer_code_to_answer(3, {}) == "Green"
+
+    def test_numeric_starts_with_0_translate(self):
+        """Numeric 0-based should work same as old use_code."""
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_0",
+        )
+        assert q._translate_answer_code_to_answer(0, {}) == "Red"
+        assert q._translate_answer_code_to_answer(1, {}) == "Blue"
+
+
+class TestEnumerationFix:
+    """Test fix() method with enumerated responses."""
+
+    def test_fix_letter_with_label(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="letters",
+        )
+        fixed = q.response_validator.fix({"answer": "B: Blue"})
+        assert fixed["answer"] == "B"
+
+    def test_fix_lowercase_to_uppercase(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="letters",
+        )
+        fixed = q.response_validator.fix({"answer": "b"})
+        assert fixed["answer"] == "B"
+
+    def test_fix_numeric_starts_with_1_with_label(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_1",
+        )
+        fixed = q.response_validator.fix({"answer": "1: Red"})
+        assert fixed["answer"] == 1
+
+
+class TestEnumerationPrompt:
+    """Test prompt generation with different enumeration styles."""
+
+    def test_letters_in_prompt(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick a color.",
+            question_options=["Red", "Blue", "Green"],
+            enumeration="letters",
+        )
+        from edsl import Survey, Model
+        prompts = Survey([q]).by(Model("test")).prompts()
+        user_prompt = prompts.select("user_prompt").to_list()[0]
+        assert "A:" in user_prompt or "A: " in user_prompt
+        assert "B:" in user_prompt or "B: " in user_prompt
+
+    def test_letters_instruction_in_prompt(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick a color.",
+            question_options=["Red", "Blue"],
+            enumeration="letters",
+        )
+        from edsl import Survey, Model
+        prompts = Survey([q]).by(Model("test")).prompts()
+        user_prompt = prompts.select("user_prompt").to_list()[0]
+        assert "letter" in user_prompt.lower()
+
+    def test_numeric_starts_with_1_in_prompt(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_1",
+        )
+        from edsl import Survey, Model
+        prompts = Survey([q]).by(Model("test")).prompts()
+        user_prompt = prompts.select("user_prompt").to_list()[0]
+        assert "1:" in user_prompt or "1: " in user_prompt
+        assert "2:" in user_prompt or "2: " in user_prompt
+
+
+class TestEnumerationSerialization:
+    """Test serialization roundtrip."""
+
+    def test_roundtrip_letters(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="letters",
+        )
+        d = q.to_dict()
+        q2 = QuestionMultipleChoice.from_dict(d)
+        assert q2.enumeration == AnswerEnumeration.LETTERS
+
+    def test_roundtrip_numeric_starts_with_1(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+            enumeration="numeric_starts_with_1",
+        )
+        d = q.to_dict()
+        q2 = QuestionMultipleChoice.from_dict(d)
+        assert q2.enumeration == AnswerEnumeration.NUMERIC_STARTS_WITH_1
+
+    def test_roundtrip_none(self):
+        q = QuestionMultipleChoice(
+            question_name="q1", question_text="Pick.",
+            question_options=["Red", "Blue"],
+        )
+        d = q.to_dict()
+        q2 = QuestionMultipleChoice.from_dict(d)
+        assert q2.enumeration == AnswerEnumeration.NONE


### PR DESCRIPTION
## Summary
- Adds `AnswerEnumeration` enum with five option labeling styles: `none`, `numeric_starts_with_0`, `numeric_starts_with_1`, `letters`, `letters_lower`
- `use_code=True` preserved as backward compat for `numeric_starts_with_0`
- Includes prompt template updates, fix() method support, answer translation, and serialization roundtrip

## Example usage
```python
q = QuestionMultipleChoice(
    question_name="capital",
    question_text="What is the capital of France?",
    question_options=["Berlin", "Paris", "London", "Madrid"],
    enumeration="letters",
)
# Prompt shows: A: Berlin, B: Paris, C: London, D: Madrid
# LLM responds "B", translated to "Paris"
```

## Test plan
- [x] 27 new tests in `tests/test_letter_enumeration.py`
- [x] All 355 question/survey tests pass
- [x] Serialization roundtrip verified
- [x] Backward compat with `use_code=True` verified

Fixes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)