### PR TITLE
Fix IPython HTML object printing to terminal

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -246,16 +246,19 @@ def _display_notebook_login(login_url: str):
     </div>
     """
 
-    # Try IPython display (works in both Jupyter and marimo)
+    # Try IPython display (only in proper notebook environments)
     try:
-        from IPython.display import display, HTML
+        from .utilities.is_notebook import is_notebook
 
-        display(HTML(html_content))
-        return
+        if is_notebook():
+            from IPython.display import display, HTML
+
+            display(HTML(html_content))
+            return
     except ImportError:
         pass
 
-    # Fallback to regular print if neither is available
+    # Fallback to regular print for terminals and non-notebook environments
     print(f"Please visit this URL to log in: {login_url}")
 
 

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -4137,12 +4137,20 @@ class Coop(CoopFunctionsMixin):
             )
             return callout
         else:
-            # Running in an interactive environment (e.g., Jupyter Notebook)
-            try:
-                from IPython.display import HTML, display
+            # Running in an interactive environment — only use HTML display in notebooks
+            from ..utilities.is_notebook import is_notebook
 
-                display(HTML(html_content))
-            except ImportError:
+            if is_notebook():
+                try:
+                    from IPython.display import HTML, display
+
+                    display(HTML(html_content))
+                except ImportError:
+                    if link_description:
+                        print(f"{link_description}\n{url}")
+                    else:
+                        print(url)
+            else:
                 if link_description:
                     print(f"{link_description}\n{url}")
                 else:

--- a/edsl/jobs/html_table_job_logger.py
+++ b/edsl/jobs/html_table_job_logger.py
@@ -10,10 +10,21 @@ from .jobs_status_enums import JobsStatus
 class HTMLTableJobLogger(JobLogger):
     def __init__(self, verbose=True, **kwargs):
         super().__init__(verbose=verbose)
+        import io
+        import contextlib
         from IPython.display import display, HTML
 
         self._HTML = HTML
-        self.display_handle = display(HTML(""), display_id=True)
+        # Suppress stdout during initial display() call to prevent
+        # "<IPython.core.display.HTML object>" leaking in non-notebook environments
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.display_handle = display(HTML(""), display_id=True)
+        if self.display_handle is None:
+            # Running outside notebook — create a no-op stub
+            class _Stub:
+                def update(self, *a, **kw):
+                    pass
+            self.display_handle = _Stub()
         self.current_message = None
         self.log_id = str(uuid.uuid4())
         self.is_expanded = True

--- a/edsl/jobs/jobs_remote_inference_logger.py
+++ b/edsl/jobs/jobs_remote_inference_logger.py
@@ -107,10 +107,20 @@ class JobLogger(ABC):
 
 class HTMLTableJobLogger(JobLogger):
     def __init__(self, verbose=True, **kwargs):
+        import io
+        import contextlib
         from IPython.display import display, HTML
 
         super().__init__(verbose=verbose)
-        self.display_handle = display(HTML(""), display_id=True)
+        # Suppress stdout during initial display() call to prevent
+        # "<IPython.core.display.HTML object>" leaking in non-notebook environments
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.display_handle = display(HTML(""), display_id=True)
+        if self.display_handle is None:
+            class _Stub:
+                def update(self, *a, **kw):
+                    pass
+            self.display_handle = _Stub()
         self.current_message = None
         self.log_id = str(uuid.uuid4())
         self.is_expanded = True
@@ -217,13 +227,23 @@ class StdOutJobLogger(JobLogger):
 
 class JupyterJobLogger(JobLogger):
     def __init__(self, verbose=True, **kwargs):
+        import io
+        import contextlib
         from IPython.display import display, HTML
 
         super().__init__(verbose=verbose)
         self.messages = []
         self.log_id = str(uuid.uuid4())
         self.is_expanded = True
-        self.display_handle = display(HTML(""), display_id=True)
+        # Suppress stdout during initial display() call to prevent
+        # "<IPython.core.display.HTML object>" leaking in non-notebook environments
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.display_handle = display(HTML(""), display_id=True)
+        if self.display_handle is None:
+            class _Stub:
+                def update(self, *a, **kw):
+                    pass
+            self.display_handle = _Stub()
 
     def _linkify(self, text):
         url_pattern = r'(https?://[^\s<>"]+|www\.[^\s<>"]+)'

--- a/edsl/utilities/display_utils.py
+++ b/edsl/utilities/display_utils.py
@@ -15,21 +15,9 @@ except ImportError:
 
 def is_notebook_environment():
     """Check if code is running in a Jupyter notebook or similar interactive environment."""
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True
-        elif shell == "Shell":
-            import sys
-            if "google.colab" in sys.modules:
-                return True
-            return False
-        elif shell == "TerminalInteractiveShell":
-            return False
-        else:
-            return False
-    except (NameError, ImportError):
-        return False
+    from .is_notebook import is_notebook
+
+    return is_notebook()
 
 
 class HTML:
@@ -98,7 +86,14 @@ def smart_truncate(text, max_length, ellipsis="..."):
 
 
 def display_html(html_content, width=None, height=None, as_iframe=False):
-    """Display HTML content, optionally within an iframe."""
+    """Display HTML content, optionally within an iframe.
+
+    In non-notebook environments, prints a plain-text notice instead.
+    """
+    if not is_notebook_environment():
+        print("[HTML content cannot be displayed in this environment]")
+        return
+
     from html import escape
 
     if as_iframe:

--- a/edsl/utilities/is_notebook.py
+++ b/edsl/utilities/is_notebook.py
@@ -11,7 +11,7 @@ def is_notebook() -> bool:
 
             if mo.running_in_notebook():
                 return True
-        except (ImportError, AttributeError, Exception):
+        except (ImportError, AttributeError):
             pass
 
     try:

--- a/edsl/utilities/is_notebook.py
+++ b/edsl/utilities/is_notebook.py
@@ -3,8 +3,16 @@ def is_notebook() -> bool:
     import sys
 
     # Check for marimo first (doesn't use IPython)
+    # Note: just checking sys.modules is not enough — marimo may be imported
+    # without actually running in a marimo notebook.
     if "marimo" in sys.modules:
-        return True
+        try:
+            import marimo as mo
+
+            if mo.running_in_notebook():
+                return True
+        except (ImportError, AttributeError, Exception):
+            pass
 
     try:
         shell = get_ipython().__class__.__name__

--- a/edsl/utilities/spinner.py
+++ b/edsl/utilities/spinner.py
@@ -16,14 +16,12 @@ def is_jupyter():
     """Check if code is running in a Jupyter notebook environment.
 
     Returns:
-        bool: True if running in Jupyter, False otherwise
+        bool: True if running in a Jupyter notebook, Colab, or marimo, False otherwise.
+        Returns False for plain IPython terminals.
     """
-    try:
-        from IPython import get_ipython
+    from .is_notebook import is_notebook
 
-        return get_ipython() is not None
-    except Exception:
-        return False
+    return is_notebook()
 
 
 @contextmanager

--- a/edsl/utilities/utilities.py
+++ b/edsl/utilities/utilities.py
@@ -205,23 +205,10 @@ def dict_to_html(d):
 
 
 def is_notebook() -> bool:
-    """Check if the code is running in a Jupyter notebook or Google Colab."""
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
-        elif shell == "Shell":  # Google Colab's shell class
-            import sys
+    """Check if the code is running in a Jupyter notebook, Google Colab, or marimo."""
+    from .is_notebook import is_notebook as _is_notebook
 
-            if "google.colab" in sys.modules:
-                return True  # Running in Google Colab
-            return False
-        elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
-        else:
-            return False  # Other type
-    except NameError:
-        return False  # Probably standard Python interpreter
+    return _is_notebook()
 
 
 def file_notice(file_name):


### PR DESCRIPTION
## Summary

Fixes #2425

- **Fix `is_notebook.py`**: `"marimo" in sys.modules` was returning `True` even outside marimo notebooks (marimo gets imported at module load by `decorators.py`). Now verifies with `mo.running_in_notebook()`.
- **Fix `spinner.py`**: `is_jupyter()` returned `True` for any IPython environment including terminal. Now delegates to the correct `is_notebook()`.
- **Fix job loggers**: Wrap initial `display(HTML(""))` calls in `contextlib.redirect_stdout` to suppress text output in non-notebook environments.
- **Fix `coop.py` and `__init__.py`**: Add `is_notebook()` guard before `display(HTML(...))` calls.
- **Consolidate notebook detection**: 4 duplicate functions now delegate to the canonical `is_notebook.py`.

## Test plan

- [x] All 1010 non-network tests pass (`pytest tests/ --ignore=tests/coop`)
- [x] All doctests on modified files pass
- [x] Verified `is_notebook()` returns `False` in plain Python and IPython terminals
- [ ] Manual verification: run `q.run()` in IPython terminal — no `<IPython.core.display.HTML object>` output
- [ ] Manual verification: run in Jupyter notebook — HTML display still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)