### PR TITLE
Fix stale async clients causing None on repeated .run()

### DIFF
--- a/edsl/runner/runner.py
+++ b/edsl/runner/runner.py
@@ -500,20 +500,36 @@ class Runner:
     def _clear_async_clients() -> None:
         """Clear cached async HTTP clients that are bound to a now-closed event loop.
 
-        OpenAIService (and subclasses) cache AsyncOpenAI clients at the class
-        level.  Each client holds an aiohttp session tied to the event loop in
-        which it was created.  When ``asyncio.run()`` closes that loop the
-        session becomes unusable, so we must discard the cached clients before
-        starting a new loop.
+        OpenAIService, OpenAIServiceV2, and their subclasses cache AsyncOpenAI
+        clients at the class level.  Each client holds an aiohttp session tied
+        to the event loop in which it was created.  When ``asyncio.run()``
+        closes that loop the session becomes unusable, so we must discard the
+        cached clients before starting a new loop.
         """
+
+        def _all_subclasses(cls):
+            for sub in cls.__subclasses__():
+                yield sub
+                yield from _all_subclasses(sub)
+
+        services_to_clear = []
         try:
             from ..inference_services.services.open_ai_service import OpenAIService
+
+            services_to_clear.append(OpenAIService)
+            services_to_clear.extend(_all_subclasses(OpenAIService))
         except Exception:
-            return
-        OpenAIService._async_client_instances.clear()
-        for subcls in OpenAIService.__subclasses__():
-            if hasattr(subcls, "_async_client_instances"):
-                subcls._async_client_instances.clear()
+            pass
+        try:
+            from ..inference_services.services.open_ai_service_v2 import OpenAIServiceV2
+
+            services_to_clear.append(OpenAIServiceV2)
+            services_to_clear.extend(_all_subclasses(OpenAIServiceV2))
+        except Exception:
+            pass
+        for svc in services_to_clear:
+            if hasattr(svc, "_async_client_instances"):
+                svc._async_client_instances.clear()
 
     def _ensure_queues_for_job(self, job: Any) -> None:
         """Register queues for all models used in this job."""

--- a/edsl/runner/runner.py
+++ b/edsl/runner/runner.py
@@ -496,6 +496,25 @@ class Runner:
 
         return JobHandle(job_id, self)
 
+    @staticmethod
+    def _clear_async_clients() -> None:
+        """Clear cached async HTTP clients that are bound to a now-closed event loop.
+
+        OpenAIService (and subclasses) cache AsyncOpenAI clients at the class
+        level.  Each client holds an aiohttp session tied to the event loop in
+        which it was created.  When ``asyncio.run()`` closes that loop the
+        session becomes unusable, so we must discard the cached clients before
+        starting a new loop.
+        """
+        try:
+            from ..inference_services.services.open_ai_service import OpenAIService
+        except Exception:
+            return
+        OpenAIService._async_client_instances.clear()
+        for subcls in OpenAIService.__subclasses__():
+            if hasattr(subcls, "_async_client_instances"):
+                subcls._async_client_instances.clear()
+
     def _ensure_queues_for_job(self, job: Any) -> None:
         """Register queues for all models used in this job."""
         models = list(job.models) if hasattr(job, "models") else []
@@ -570,6 +589,9 @@ class Runner:
             nest_asyncio.apply()
             loop.run_until_complete(coro)
         else:
+            # Clear cached async clients — they hold aiohttp sessions bound
+            # to the previous event loop which asyncio.run() will have closed.
+            self._clear_async_clients()
             asyncio.run(coro)
 
         return stats


### PR DESCRIPTION
## Summary

- Fixes #2429 — calling `.run()` more than once in the same Python process returns `None` for all answers after the first call
- Root cause: `OpenAIService` caches `AsyncOpenAI` clients (with aiohttp sessions) in class-level dicts. These sessions are bound to the event loop created by `asyncio.run()`. When that loop closes, the cached clients become stale, but `async_client()` keeps returning them.
- Fix: clear the async client cache before each `asyncio.run()` in `Runner._execute_job()`, so fresh clients are created in the new event loop

## Reproduction (before fix)

```python
from edsl.questions import QuestionFreeText, QuestionMultipleChoice
from edsl import Cache

q1 = QuestionFreeText(question_name="ft", question_text="Name a color.")
q2 = QuestionMultipleChoice(
    question_name="mc", question_text="Capital of France?",
    question_options=["London", "Paris", "Berlin"],
)

r1 = q1.run(disable_remote_inference=True, skip_retry=True, cache=Cache())
print(r1.select("answer.ft").to_list()[0])   # => 'Blue.' ✅

r2 = q2.run(disable_remote_inference=True, skip_retry=True, cache=Cache())
print(r2.select("answer.mc").to_list()[0])   # => None ❌ (now returns 'Paris' ✅)
```

## Test plan

- [x] Verified 4 sequential `.run()` calls in one process all return valid answers
- [x] Verified all 11 question types work in sequential `.run()` calls
- [ ] Verify `nest_asyncio` path (Jupyter/marimo) is unaffected — it reuses the same loop so no cache clearing needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)