### PR TITLE
Patches for thinking tokens, newlines in free text questions, and local error report sending

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -215,6 +215,11 @@ class Coop(CoopFunctionsMixin):
     # BASIC METHODS
     ################
     @property
+    def has_api_key(self) -> bool:
+        """True if a non-empty API key is set (constructor arg, class default, or env/config)."""
+        return bool(self.api_key)
+
+    @property
     def headers(self) -> dict:
         """
         Return the headers for the request.
@@ -260,9 +265,9 @@ class Coop(CoopFunctionsMixin):
             if "json_string" in log_payload and log_payload["json_string"]:
                 json_str = log_payload["json_string"]
                 if len(json_str) > 200:
-                    log_payload[
-                        "json_string"
-                    ] = f"{json_str[:200]}... (truncated, total length: {len(json_str)})"
+                    log_payload["json_string"] = (
+                        f"{json_str[:200]}... (truncated, total length: {len(json_str)})"
+                    )
             self._logger.info(f"Request payload: {log_payload}")
 
         try:
@@ -3632,15 +3637,11 @@ class Coop(CoopFunctionsMixin):
             else:
                 for key, value in d.items():
                     if isinstance(value, dict):
-                        _collect_filestores(
-                            value, f"{path}.{key}" if path else key
-                        )
+                        _collect_filestores(value, f"{path}.{key}" if path else key)
                     elif isinstance(value, list):
                         for i, item in enumerate(value):
                             if isinstance(item, dict):
-                                _collect_filestores(
-                                    item, f"{path}.{key}[{i}]"
-                                )
+                                _collect_filestores(item, f"{path}.{key}[{i}]")
 
         _collect_filestores(modified_dict)
 
@@ -3741,11 +3742,7 @@ class Coop(CoopFunctionsMixin):
             if original_object is not None and path:
                 try:
                     clean_path = path.lstrip(".")
-                    keys = (
-                        clean_path.split(".")
-                        if "." in clean_path
-                        else [clean_path]
-                    )
+                    keys = clean_path.split(".") if "." in clean_path else [clean_path]
                     keys = [k for k in keys if k]
                     current_obj = original_object
 
@@ -3765,7 +3762,9 @@ class Coop(CoopFunctionsMixin):
                             idx_val = int(idx_str.rstrip("]"))
                             if key_name:
                                 if hasattr(current_obj, key_name):
-                                    current_obj = getattr(current_obj, key_name)[idx_val]
+                                    current_obj = getattr(current_obj, key_name)[
+                                        idx_val
+                                    ]
                                 else:
                                     current_obj = current_obj[key_name][idx_val]
                             else:
@@ -4012,9 +4011,7 @@ class Coop(CoopFunctionsMixin):
                     value_type = (
                         "inf"
                         if math.isinf(value)
-                        else "nan"
-                        if math.isnan(value)
-                        else "invalid"
+                        else "nan" if math.isnan(value) else "invalid"
                     )
                     error_msg += f"  • {path}: {value} ({value_type})\n"
 
@@ -4462,6 +4459,7 @@ class Coop(CoopFunctionsMixin):
         This method provides a non-blocking way to report errors that occur during
         EDSL operations. It sends error reports to the server for monitoring and
         debugging purposes, while also printing to stderr for immediate feedback.
+        If no API key is configured, returns immediately without contacting the server.
 
         Duplicate errors (same error type and message) are not reported if they
         occurred within the past minute to prevent spam.
@@ -4476,6 +4474,9 @@ class Coop(CoopFunctionsMixin):
             ... except Exception as e:
             ...     await coop.report_error(e)
         """
+        if not self.has_api_key:
+            return
+
         import sys
         import traceback
         import httpx

--- a/edsl/invigilators/invigilator_thinking.py
+++ b/edsl/invigilators/invigilator_thinking.py
@@ -41,6 +41,7 @@ class InvigilatorThinking(InvigilatorBase):
             cache=self.cache,
             iteration=self.iteration,
             invigilator=self,
+            question_type=getattr(self.question, "question_type", None),
         )
 
         self.raw_model_response = agent_response_dict.model_outputs.response

--- a/edsl/invigilators/invigilators.py
+++ b/edsl/invigilators/invigilators.py
@@ -304,6 +304,7 @@ class InvigilatorAI(InvigilatorBase):
 
         params.update({"iteration": self.iteration, "cache": self.cache})
         params.update({"invigilator": self})
+        params["question_type"] = getattr(self.question, "question_type", None)
 
         if self.key_lookup:
             self.model.set_key_lookup(self.key_lookup)

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -709,6 +709,9 @@ class JobsRemoteInferenceHandler:
                     raw_model_response_dict[f"{qname}_output_tokens"] = a.get(
                         "output_tokens"
                     )
+                    raw_model_response_dict[f"{qname}_thinking_tokens"] = a.get(
+                        "thinking_tokens"
+                    )
                     raw_model_response_dict[
                         f"{qname}_input_price_per_million_tokens"
                     ] = a.get("input_price_per_million_tokens")
@@ -716,15 +719,16 @@ class JobsRemoteInferenceHandler:
                         f"{qname}_output_price_per_million_tokens"
                     ] = a.get("output_price_per_million_tokens")
 
-                    # Calculate cost
+                    # Calculate cost (thinking tokens charged at output rate)
                     total_cost = None
                     input_tokens = a.get("input_tokens")
                     output_tokens = a.get("output_tokens")
+                    thinking_tokens = a.get("thinking_tokens") or 0
                     if input_tokens is not None and output_tokens is not None:
                         input_price = a.get("input_price_per_million_tokens") or 0
                         output_price = a.get("output_price_per_million_tokens") or 0
                         total_cost = (input_price / 1_000_000 * input_tokens) + (
-                            output_price / 1_000_000 * output_tokens
+                            output_price / 1_000_000 * (output_tokens + thinking_tokens)
                         )
                     raw_model_response_dict[f"{qname}_cost"] = total_cost
                     one_usd_buys = (

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -485,11 +485,15 @@ class JobsRemoteInferenceHandler:
 
                 output_price_per_million_tokens = output_key[3]
                 output_tokens = raw_response[f"{question_name}_output_tokens"]
+                thinking_tokens = (
+                    raw_response.get(f"{question_name}_thinking_tokens") or 0
+                )
+                total_output_tokens = output_tokens + thinking_tokens
                 output_cost = (
                     output_price_per_million_tokens / 1_000_000
-                ) * output_tokens
+                ) * total_output_tokens
 
-                expenses[output_key]["tokens"] += output_tokens
+                expenses[output_key]["tokens"] += total_output_tokens
                 expenses[output_key]["cost_usd"] += output_cost
 
                 if not cache_used:

--- a/edsl/language_models/language_model.py
+++ b/edsl/language_models/language_model.py
@@ -809,7 +809,12 @@ class LanguageModel(
         return cls.response_handler.get_usage_dict(raw_response)
 
     @classmethod
-    def parse_response(cls, raw_response: dict[str, Any]) -> EDSLOutput:
+    def parse_response(
+        cls,
+        raw_response: dict[str, Any],
+        *,
+        is_free_text: bool = False,
+    ) -> EDSLOutput:
         """Parse the raw API response into a standardized EDSL output format.
 
         This method processes the model's response to extract the generated content
@@ -818,11 +823,15 @@ class LanguageModel(
 
         Args:
             raw_response: The complete response dictionary from the model API
+            is_free_text: If True, the full model text is the answer (no
+                COMMENT:/newline splitting). Used for ``free_text`` questions.
 
         Returns:
             EDSLOutput: Standardized output structure with answer and optional comment
         """
-        return cls.response_handler.parse_response(raw_response)
+        return cls.response_handler.parse_response(
+            raw_response, is_free_text=is_free_text
+        )
 
     async def _async_get_intended_model_call_outcome(
         self,
@@ -1045,7 +1054,9 @@ class LanguageModel(
             cache: The cache object to use for storing/retrieving responses
             iteration: The iteration number (default: 1)
             files_list: Optional list of files to include in the prompt
-            **kwargs: Additional parameters (invigilator, response_schema can be provided here)
+            **kwargs: Additional parameters (invigilator, response_schema,
+                question_type, etc.). For ``question_type="free_text"``,
+                ``parse_response`` is called with ``is_free_text=True``.
 
         Returns:
             AgentResponseDict: Complete response object with inputs, raw outputs, and parsed data
@@ -1077,6 +1088,8 @@ class LanguageModel(
         if "response_schema_name" in kwargs:
             params.update({"response_schema_name": kwargs["response_schema_name"]})
 
+        is_free_text = kwargs.get("question_type") == "free_text"
+
         # Create structured input record
         model_inputs = ModelInputs(user_prompt=user_prompt, system_prompt=system_prompt)
         # Get model response (using cache if available)
@@ -1085,7 +1098,10 @@ class LanguageModel(
         )
 
         # Parse the response into EDSL's standard format
-        edsl_dict: EDSLOutput = self.parse_response(model_outputs.response)
+        edsl_dict: EDSLOutput = self.parse_response(
+            model_outputs.response,
+            is_free_text=is_free_text,
+        )
 
         # Combine everything into a complete response object
         agent_response_dict = AgentResponseDict(

--- a/edsl/language_models/raw_response_handler.py
+++ b/edsl/language_models/raw_response_handler.py
@@ -286,13 +286,21 @@ class RawResponseHandler:
     # can reference the single source of truth.
     COMMENT_DELIMITERS = ["COMMENT:", "CORRECTION:"]
 
-    def parse_response(self, raw_response: dict[str, Any]) -> Any:
+    def parse_response(
+        self,
+        raw_response: dict[str, Any],
+        *,
+        is_free_text: bool = False,
+    ) -> Any:
         """Parses the API response and returns the response text.
 
         The comment is separated from the answer by looking for known
         delimiters (COMMENT:, CORRECTION:) on their own line.  If no
         delimiter is found, falls back to splitting on the last newline
         for backwards compatibility with cached responses.
+
+        When *is_free_text* is True, the full generated string is kept as
+        the answer and no comment is inferred from newlines or delimiters.
         """
 
         from edsl.data_transfer_models import EDSLOutput
@@ -304,9 +312,12 @@ class RawResponseHandler:
 
         reasoning_summary = self.get_reasoning_summary(raw_response)
 
-        answer_text, comment_text = self._split_answer_and_comment(
-            generated_token_string
-        )
+        if is_free_text:
+            answer_text, comment_text = generated_token_string.strip(), None
+        else:
+            answer_text, comment_text = self._split_answer_and_comment(
+                generated_token_string
+            )
 
         edsl_dict = {
             "answer": self.convert_answer(answer_text),
@@ -333,7 +344,7 @@ class RawResponseHandler:
         # Strategy 1: look for known comment delimiters (COMMENT:, CORRECTION:)
         # Match the last line starting with any recognized delimiter.
         delimiter_alts = "|".join(re.escape(d) for d in cls.COMMENT_DELIMITERS)
-        pattern = r'(?m)^[ \t]*(?:' + delimiter_alts + r')[ \t]*(.*)'
+        pattern = r"(?m)^[ \t]*(?:" + delimiter_alts + r")[ \t]*(.*)"
         matches = list(re.finditer(pattern, generated_token_string, re.IGNORECASE))
         if matches:
             last_match = matches[-1]
@@ -341,8 +352,7 @@ class RawResponseHandler:
             # Combine the rest-of-line after the delimiter with any
             # subsequent lines to form the full comment.
             comment_part = (
-                last_match.group(1)
-                + generated_token_string[last_match.end() :]
+                last_match.group(1) + generated_token_string[last_match.end() :]
             ).strip()
             if not answer_part:
                 # Edge case: the entire string started with COMMENT:

--- a/edsl/runner/coordinator.py
+++ b/edsl/runner/coordinator.py
@@ -103,6 +103,7 @@ class ExecutionCoordinator:
             "model_id": rendered.model_id,
             "iteration": rendered.iteration,
             "agent_name": rendered.agent_name,
+            "question_type": rendered.question_type,
         }
 
         service = rendered.service_name or "openai"
@@ -277,6 +278,7 @@ class ExecutionCoordinator:
                     model_id=task.get("model_id"),
                     iteration=task.get("iteration", 0),
                     agent_name=task.get("agent_name"),
+                    question_type=task.get("question_type"),
                 )
 
                 return WorkAssignment(

--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -248,6 +248,7 @@ class ExecutionWorker:
                 files_list=task.files_list,
                 question_name=task.question_name,
                 agent_name=task.agent_name,
+                question_type=task.question_type,
             )
 
             # Extract answer and tokens from the response

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -48,6 +48,7 @@ class RenderedPrompt:
         0  # Which iteration this task belongs to (for cache key differentiation)
     )
     agent_name: str | None = None
+    question_type: str | None = None
 
 
 class RenderService:
@@ -190,6 +191,9 @@ class RenderService:
             service_name=model_data.get("inference_service") if model_data else None,
             iteration=task_def.iteration,
             agent_name=agent_data.get("name") if agent_data else None,
+            question_type=(
+                question_data.get("question_type") if question_data else None
+            ),
         )
 
     def _get_current_answers(
@@ -1030,6 +1034,7 @@ class RenderWorker:
                     else None,
                     iteration=task_def.iteration,
                     agent_name=agent_data.get("name") if agent_data else None,
+                    question_type=getattr(question, "question_type", None),
                 )
             )
             _append_time += _time.time() - _t_ap

--- a/tests/language_models/test_LanguageModel_response_parsing.py
+++ b/tests/language_models/test_LanguageModel_response_parsing.py
@@ -175,3 +175,17 @@ def test_parse_response_legacy_no_delimiter():
         model_response.comment == "These are my comments."
         or model_response.comment is None
     )
+
+
+def test_parse_response_free_text_no_split():
+    """Free-text answers keep newlines; no answer/comment split."""
+    m = LanguageModel.example(
+        test_model=True,
+        canned_response="Line one\nLine two\nCOMMENT: not a delimiter split",
+    )
+    raw_model_response = m.execute_model_call("", "")
+    model_response = m.parse_response(raw_model_response, is_free_text=True)
+    assert model_response.answer == (
+        "Line one\nLine two\nCOMMENT: not a delimiter split"
+    )
+    assert model_response.comment is None


### PR DESCRIPTION
- Add thinking tokens to cost tracking
- Fix issue where free text answers were incorrectly split at newlines (closes #2426)
- Stop sending local error reports when the user's API key is not set (these all silently fail with a 401 error)