### PR TITLE
Fix terminal HTML object output when running Question.run()

### DIFF
--- a/edsl/utilities/is_notebook.py
+++ b/edsl/utilities/is_notebook.py
@@ -7,8 +7,19 @@ def is_notebook() -> bool:
         return True
 
     try:
-        shell = get_ipython().__class__.__name__
+        from IPython import get_ipython
+
+        ipy = get_ipython()
+        if ipy is None:
+            return False
+
+        shell = ipy.__class__.__name__
         if shell == "ZMQInteractiveShell":
+            # Jupyter console can use ZMQInteractiveShell but behaves like a terminal.
+            # If stdout is a TTY, avoid notebook-only HTML displays.
+            stdout = getattr(sys, "stdout", None)
+            if stdout is not None and hasattr(stdout, "isatty") and stdout.isatty():
+                return False
             return True  # Jupyter notebook or qtconsole
         elif shell == "Shell":  # Google Colab's shell class
             if "google.colab" in sys.modules:
@@ -18,5 +29,5 @@ def is_notebook() -> bool:
             return False  # Terminal running IPython
         else:
             return False  # Other type
-    except NameError:
+    except (ImportError, NameError):
         return False  # Probably standard Python interpreter

--- a/tests/utilities/test_is_notebook.py
+++ b/tests/utilities/test_is_notebook.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+from edsl.utilities.is_notebook import is_notebook
+
+
+class _FakeStdout:
+    def __init__(self, is_tty: bool):
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+def _install_fake_ipython(monkeypatch, shell_name: str):
+    shell = type(shell_name, (), {})()
+    fake_ipython = types.ModuleType("IPython")
+    fake_ipython.get_ipython = lambda: shell
+    monkeypatch.setitem(sys.modules, "IPython", fake_ipython)
+
+
+def test_zmq_shell_with_tty_is_not_notebook(monkeypatch):
+    _install_fake_ipython(monkeypatch, "ZMQInteractiveShell")
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(True))
+    assert is_notebook() is False
+
+
+def test_zmq_shell_without_tty_is_notebook(monkeypatch):
+    _install_fake_ipython(monkeypatch, "ZMQInteractiveShell")
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(False))
+    assert is_notebook() is True
+
+
+def test_terminal_ipython_is_not_notebook(monkeypatch):
+    _install_fake_ipython(monkeypatch, "TerminalInteractiveShell")
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(True))
+    assert is_notebook() is False


### PR DESCRIPTION
## Summary
- fix notebook detection so `ZMQInteractiveShell` is only treated as notebook when stdout is not a TTY
- keep terminal-based ZMQ shells (e.g. console sessions) on terminal loggers instead of HTML logger output
- add regression tests for ZMQ TTY/non-TTY handling and terminal IPython handling

## Why
Fixes #2425.

Issue #2425 reports `<IPython.core.display.HTML object>` printing in terminal runs. This happened because terminal ZMQ shells were misdetected as notebook environments.

## Testing
- `pytest -q tests/utilities/test_is_notebook.py`
- `pytest -q tests/jobs/test_JobsChecks.py`