### PR TITLE
fix: exclude skipped questions from memory context

### DIFF
--- a/edsl/surveys/memory/memory_plan.py
+++ b/edsl/surveys/memory/memory_plan.py
@@ -72,8 +72,9 @@ class MemoryPlan(UserDict):
             return Prompt("")
 
         q_and_a_pairs = [
-            (self.name_to_text[question_name], answers.get(question_name, None))
+            (self.name_to_text[question_name], answers[question_name])
             for question_name in self[focal_question]
+            if question_name in answers
         ]
 
         base_prompt_text = """


### PR DESCRIPTION
## What does this PR do?

Fixes #1224

When questions are skipped via skip/stop logic, they were still appearing in the memory context of subsequent questions with `Answer: None`. This misled AI agents into thinking they had been asked those questions.

## Root cause

In `memory_plan.py`, `get_memory_prompt_fragment()` used `answers.get(question_name, None)` which includes all questions in the memory plan — even skipped ones that have no entry in the `answers` dict.

## Fix

Changed from:
```python
q_and_a_pairs = [
    (self.name_to_text[question_name], answers.get(question_name, None))
    for question_name in self[focal_question]
]
```

To:
```python
q_and_a_pairs = [
    (self.name_to_text[question_name], answers[question_name])
    for question_name in self[focal_question]
    if question_name in answers
]
```

Only questions with actual answers appear in memory. Skipped questions are excluded entirely.

## Edge cases handled

- **Answer is legitimately `None`**: Still included (key exists in dict)
- **All prior questions skipped**: Returns empty `Prompt("")` — correct
- **Full/lagged/targeted memory modes**: All work the same way