### PR TITLE
feat: add wildcard support to Results.filter() expressions

### DIFF
--- a/edsl/results/results_filter.py
+++ b/edsl/results/results_filter.py
@@ -4,6 +4,7 @@ This module provides the ResultsFilter class which handles filtering operations
 on Results objects, including expression validation and evaluation.
 """
 
+import re
 import warnings
 from typing import TYPE_CHECKING
 
@@ -99,6 +100,61 @@ class ResultsFilter:
 
         return ""
 
+    def _expand_wildcards(self, expression: str) -> str:
+        """Expand wildcard patterns in filter expressions to OR'd conditions.
+
+        Finds patterns like ``question_text.*`` in the expression and replaces
+        them with all matching column names joined by ``or``.
+
+        For example, if columns are ``['question_text.q1', 'question_text.q2']``:
+            ``question_text.* == 'Hello'``
+        becomes:
+            ``(question_text.q1 == 'Hello' or question_text.q2 == 'Hello')``
+
+        Args:
+            expression: The filter expression potentially containing wildcards.
+
+        Returns:
+            The expression with wildcards expanded, or the original if none found.
+        """
+        columns = self.results.columns
+
+        # Match wildcard references like data_type.* or data_type.*suffix
+        wildcard_pattern = re.compile(r'(\w+\.\*[\w]*)')
+        wildcards = wildcard_pattern.findall(expression)
+
+        if not wildcards:
+            return expression
+
+        from fnmatch import fnmatch
+
+        for wc in set(wildcards):
+            matching_cols = [c for c in columns if fnmatch(c, wc)]
+            if not matching_cols:
+                continue
+
+            # Build the rest of the expression around the wildcard
+            # Find the full comparison containing this wildcard
+            # e.g. "question_text.* == 'Hello'" or "question_text.* in ['a', 'b']"
+            escaped_wc = re.escape(wc)
+            comparison_pattern = re.compile(
+                rf'{escaped_wc}\s*(==|!=|>=|<=|>|<|in\b|not\s+in\b)\s*(.+?)(?:\s+(?:and|or)\s+|$)'
+            )
+            match = comparison_pattern.search(expression)
+            if not match:
+                continue
+
+            operator = match.group(1)
+            value = match.group(2).strip()
+            full_match = match.group(0).strip()
+
+            expanded_parts = [f"{col} {operator} {value}" for col in matching_cols]
+            expanded = "(" + " or ".join(expanded_parts) + ")"
+
+            expression = expression.replace(full_match, expanded)
+
+        return expression
+
     @staticmethod
     def has_single_equals(expression: str) -> bool:
         """Check if an expression contains a single equals sign not part of ==, >=, or <=.
@@ -191,6 +247,9 @@ class ResultsFilter:
             raise ResultsFilterError(
                 "You must use '==' instead of '=' in the filter expression."
             )
+
+        # Expand wildcard patterns (e.g. question_text.* == 'Hello')
+        normalized_expression = self._expand_wildcards(normalized_expression)
 
         try:
             # Create new Results object with same class as original but empty data

--- a/edsl/results/results_filter.py
+++ b/edsl/results/results_filter.py
@@ -111,6 +111,11 @@ class ResultsFilter:
         becomes:
             ``(question_text.q1 == 'Hello' or question_text.q2 == 'Hello')``
 
+        Compound expressions are preserved:
+            ``question_text.* == 'Hello' and answer.* == 'Yes'``
+        becomes:
+            ``(question_text.q1 == 'Hello' or question_text.q2 == 'Hello') and (answer.q1 == 'Yes' or answer.q2 == 'Yes')``
+
         Args:
             expression: The filter expression potentially containing wildcards.
 
@@ -120,7 +125,7 @@ class ResultsFilter:
         columns = self.results.columns
 
         # Match wildcard references like data_type.* or data_type.*suffix
-        wildcard_pattern = re.compile(r'(\w+\.\*[\w]*)')
+        wildcard_pattern = re.compile(r'\w+\.\*[\w]*')
         wildcards = wildcard_pattern.findall(expression)
 
         if not wildcards:
@@ -133,25 +138,34 @@ class ResultsFilter:
             if not matching_cols:
                 continue
 
-            # Build the rest of the expression around the wildcard
-            # Find the full comparison containing this wildcard
-            # e.g. "question_text.* == 'Hello'" or "question_text.* in ['a', 'b']"
             escaped_wc = re.escape(wc)
+            # Capture the operator and the value (which may contain brackets, quotes, etc.)
+            # Use a lookahead for and/or boundaries so we don't consume the connective.
+            # The value group uses a greedy match but stops before an unquoted and/or keyword.
             comparison_pattern = re.compile(
-                rf'{escaped_wc}\s*(==|!=|>=|<=|>|<|in\b|not\s+in\b)\s*(.+?)(?=\s+(?:and|or)\s+|$)'
+                rf"""({escaped_wc}"""
+                rf"""\s*(?:==|!=|>=|<=|>|<|not\s+in\b|in\b)"""
+                rf"""\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|\S+))"""
             )
             match = comparison_pattern.search(expression)
             if not match:
                 continue
 
-            operator = match.group(1)
-            value = match.group(2).strip()
-            full_match = match.group(0)
+            full_match = match.group(1)
+            # Extract operator and value by removing the wildcard prefix
+            remainder = full_match[len(wc):].strip()
+            # Split on first space after operator
+            op_match = re.match(r'(==|!=|>=|<=|>|<|not\s+in|in)\s*(.*)', remainder)
+            if not op_match:
+                continue
+
+            operator = op_match.group(1)
+            value = op_match.group(2).strip()
 
             expanded_parts = [f"{col} {operator} {value}" for col in matching_cols]
             expanded = "(" + " or ".join(expanded_parts) + ")"
 
-            expression = expression.replace(full_match, expanded)
+            expression = expression.replace(full_match, expanded, 1)
 
         return expression
 

--- a/edsl/results/results_filter.py
+++ b/edsl/results/results_filter.py
@@ -138,7 +138,7 @@ class ResultsFilter:
             # e.g. "question_text.* == 'Hello'" or "question_text.* in ['a', 'b']"
             escaped_wc = re.escape(wc)
             comparison_pattern = re.compile(
-                rf'{escaped_wc}\s*(==|!=|>=|<=|>|<|in\b|not\s+in\b)\s*(.+?)(?:\s+(?:and|or)\s+|$)'
+                rf'{escaped_wc}\s*(==|!=|>=|<=|>|<|in\b|not\s+in\b)\s*(.+?)(?=\s+(?:and|or)\s+|$)'
             )
             match = comparison_pattern.search(expression)
             if not match:
@@ -146,7 +146,7 @@ class ResultsFilter:
 
             operator = match.group(1)
             value = match.group(2).strip()
-            full_match = match.group(0).strip()
+            full_match = match.group(0)
 
             expanded_parts = [f"{col} {operator} {value}" for col in matching_cols]
             expanded = "(" + " or ".join(expanded_parts) + ")"


### PR DESCRIPTION
## What does this PR do?

Fixes #1981

Extends `Results.filter()` to support wildcard `*` patterns in filter expressions, matching the wildcard behavior already available in `Results.select()`.

## Example

```python
# Before — had to specify exact question name
results.filter("question_text.example_question == 'Hello'")

# After — wildcard matches all question_text columns
results.filter("question_text.* == 'Hello'")
```

The wildcard `question_text.*` is expanded to an OR'd expression across all matching columns:
```python
(question_text.q1 == 'Hello' or question_text.q2 == 'Hello' or ...)
```

## How it works

1. `_expand_wildcards()` scans the expression for patterns like `data_type.*`
2. Uses `fnmatch` to find all matching column names from `self.results.columns`
3. Extracts the comparison operator and value
4. Builds an OR'd expression with each matching column
5. Replaces the wildcard expression before `simpleeval` evaluates it

## Changes

- `edsl/results/results_filter.py` — added `_expand_wildcards()` method, called before expression evaluation in `filter()`