### PR TITLE
Fix Dashboard button link to point to homepage

### DIFF
--- a/docs/mintlify-migration/mint.json
+++ b/docs/mintlify-migration/mint.json
@@ -23,7 +23,7 @@
   ],
   "topbarCtaButton": {
     "name": "Dashboard",
-    "url": "https://www.expectedparrot.com/login"
+    "url": "https://www.expectedparrot.com"
   },
   "tabs": [
     {


### PR DESCRIPTION
## Summary

Changes the "Dashboard" button link in the docs topbar from `https://www.expectedparrot.com/login` to `https://www.expectedparrot.com`

This allows a user who is already logged in to skip the login page

**File changed:** `docs/mintlify-migration/mint.json` — `topbarCtaButton.url`