### PR TITLE
Skip JSON coercion for free text responses

### DIFF
--- a/edsl/language_models/raw_response_handler.py
+++ b/edsl/language_models/raw_response_handler.py
@@ -319,8 +319,13 @@ class RawResponseHandler:
                 generated_token_string
             )
 
+        # Free-text answers should remain literal text; do not JSON-coerce.
+        parsed_answer = (
+            answer_text if is_free_text else self.convert_answer(answer_text)
+        )
+
         edsl_dict = {
-            "answer": self.convert_answer(answer_text),
+            "answer": parsed_answer,
             "generated_tokens": generated_token_string,
             "comment": comment_text,
             "reasoning_summary": reasoning_summary,

--- a/tests/language_models/test_LanguageModel_response_parsing.py
+++ b/tests/language_models/test_LanguageModel_response_parsing.py
@@ -144,7 +144,7 @@ class TestSplitAnswerAndComment:
 
     def test_list_answer_with_comment_delimiter(self):
         """List answer followed by a COMMENT: delimiter."""
-        text = '[1, 2, 3]\nCOMMENT: These are my choices.'
+        text = "[1, 2, 3]\nCOMMENT: These are my choices."
         answer, comment = RawResponseHandler._split_answer_and_comment(text)
         assert answer == "[1, 2, 3]"
         assert comment == "These are my choices."
@@ -188,4 +188,18 @@ def test_parse_response_free_text_no_split():
     assert model_response.answer == (
         "Line one\nLine two\nCOMMENT: not a delimiter split"
     )
+    assert model_response.comment is None
+
+
+def test_parse_response_free_text_does_not_json_coerce():
+    """Free-text parsing should preserve literal text and not run JSON coercion."""
+    expected_text = "Consider a magma with the set {a, b} and a binary operation * defined as follows: a * a = a, a * b = b, b * a = b, b * b = b."
+    m = LanguageModel.example(
+        test_model=True,
+        canned_response=expected_text,
+    )
+    raw_model_response = m.execute_model_call("", "")
+    model_response = m.parse_response(raw_model_response, is_free_text=True)
+    assert model_response.answer == expected_text
+    assert model_response.generated_tokens == expected_text
     assert model_response.comment is None


### PR DESCRIPTION
This fixes an issue where some free text responses, particularly those with math notation, are incorrectly parsed as JSON. This leads to an answer that is very inconsistent with the generated tokens. For example, this string

```
"Consider a magma with the set {a, b} and a binary operation * defined as follows: a * a = a, a * b = b, b * a = b, b * b = b."
```

was parsed as the following JSON structure:

```
{'follows': 'a * a = a'}
```

