### PR TITLE
Retrieve humanize comments when pulling responses into EDSL

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2682,6 +2682,7 @@ class Coop(CoopFunctionsMixin):
                         "One of your responses is missing a unique identifier."
                     )
 
+                # Dict mapping question names to {"answer": ..., "comment": ...} dicts
                 response_dict = json.loads(response.get("response_json_string"))
                 agent_traits_json_string = response.get("agent_traits_json_string")
                 scenario_json_string = response.get("scenario_json_string")

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -83,11 +83,22 @@ class DirectAnswerRegistry:
         Execute agent-level direct answering.
 
         The agent has an `answer_question_directly(question, scenario)` method
-        that returns the answer directly without LLM involvement.
+        that returns either the answer directly or a dict with "answer" and
+        optional "comment" keys.
         """
-        answer = entry.agent.answer_question_directly(entry.question, entry.scenario)
+        result = entry.agent.answer_question_directly(entry.question, entry.scenario)
+        # Handle dicts with answer and comment keys - this is used for humanize
+        # to turn responses into results
+        if isinstance(result, dict) and "answer" in result:
+            return {
+                "answer": result["answer"],
+                "comment": result.get("comment", None),
+                "cached": False,
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
         return {
-            "answer": answer,
+            "answer": result,
             "comment": "Direct answer from agent method",
             "cached": False,
             "input_tokens": 0,

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -92,7 +92,7 @@ class DirectAnswerRegistry:
         if isinstance(result, dict) and "answer" in result:
             return {
                 "answer": result["answer"],
-                "comment": result.get("comment", None),
+            "comment": result.get("comment"),
                 "cached": False,
                 "input_tokens": 0,
                 "output_tokens": 0,

--- a/tests/agents/test_Agent.py
+++ b/tests/agents/test_Agent.py
@@ -97,6 +97,27 @@ def test_adding_direct_question_answering_method():
         agent.add_direct_question_answering_method(bad_answer_question_directly)
 
 
+def test_direct_question_answering_method_with_comment():
+    """Returning {"answer": ..., "comment": ...} is backwards-compatible and surfaces the comment in results."""
+    from edsl.questions import QuestionFreeText
+    from edsl.surveys import Survey
+    from edsl.language_models import LanguageModel
+
+    m = LanguageModel.example(test_model=True)
+    a = Agent()
+
+    def f(self, question, scenario):
+        return {"answer": "blue", "comment": "my reasoning here"}
+
+    a.add_direct_question_answering_method(f)
+
+    q = QuestionFreeText(question_name="q1", question_text="What is your favorite color?")
+    results = Survey([q]).by(a).by(m).run(disable_remote_inference=True)
+
+    assert results.select("answer.q1").first() == "blue"
+    assert results.select("answer.q1_comment").first() == "my reasoning here"
+
+
 # Invigilator creation tests moved to test_AgentInvigilator.py
 
 

--- a/tests/agents/test_Agent.py
+++ b/tests/agents/test_Agent.py
@@ -111,11 +111,13 @@ def test_direct_question_answering_method_with_comment():
 
     a.add_direct_question_answering_method(f)
 
-    q = QuestionFreeText(question_name="q1", question_text="What is your favorite color?")
+    q = QuestionFreeText(
+        question_name="q1", question_text="What is your favorite color?"
+    )
     results = Survey([q]).by(a).by(m).run(disable_remote_inference=True)
 
     assert results.select("answer.q1").first() == "blue"
-    assert results.select("answer.q1_comment").first() == "my reasoning here"
+    assert results.select("comment.q1_comment").first() == "my reasoning here"
 
 
 # Invigilator creation tests moved to test_AgentInvigilator.py
@@ -155,5 +157,13 @@ def test_agent_dynamic_traits_answering():
 
     q = QuestionFreeText(question_name="age", question_text="How old are you?")
     m = Model("test")
-    results = q.by(m).by(a).run(disable_remote_inference=True, disable_remote_cache=True, stop_on_exception=True)
+    results = (
+        q.by(m)
+        .by(a)
+        .run(
+            disable_remote_inference=True,
+            disable_remote_cache=True,
+            stop_on_exception=True,
+        )
+    )
     assert results.select("answer.age").to_list()


### PR DESCRIPTION
This PR updates `_execute_agent_direct` to handle dict return values from `answer_question_directly`. If `result` dicts have an "answer" key, then we will use that key (`result["answer"]`) as the value instead of the whole `result`.

This allows us to put other useful information in the `result` dicts, such as comments (to support the new humanize comments feature). 