### PR TITLE
Add `interview_mode` to humanize schema

### DIFF
--- a/docs/mintlify-migration/en/latest/humanize_schema.mdx
+++ b/docs/mintlify-migration/en/latest/humanize_schema.mdx
@@ -51,6 +51,14 @@ Each `questions[question_name]` value is a `HumanizeQuestionSchema` object.
   </Expandable>
 </ParamField>
 
+<ParamField path="interview_mode" type="string" default="text">
+  **Interview only** (`interview`). Controls the input mode offered to respondents.
+
+  - `"text"` — text-based interview (default).
+  - `"voice"` — voice-based interview.
+  - `"both"` — respondent can choose between text and voice.
+</ParamField>
+
 <ParamField path="comment" type="dict" required={false}>
   Optional comment input shown with the question.
   Submitted comment text appears in survey results under `comment.{question_name}_comment`.

--- a/edsl/coop/coop_humanize_schema.py
+++ b/edsl/coop/coop_humanize_schema.py
@@ -70,6 +70,7 @@ class InterviewHumanizeSchema(HumanizeSchemaBase):
     """Humanize options for the interview question type."""
 
     optional: bool = False
+    interview_mode: Literal["text", "voice", "both"] = "text"
 
 
 class LikertHumanizeSchema(HumanizeSchemaBase):

--- a/tests/coop/test_coop_humanize_schema.py
+++ b/tests/coop/test_coop_humanize_schema.py
@@ -272,6 +272,41 @@ class TestValidateHumanizeSchemaNumerical:
         assert expected_error_snippet in str(exc_info.value)
 
 
+class TestValidateHumanizeSchemaInterview:
+    """Interview-specific validate_humanize_schema behavior."""
+
+    def test_interview_mode_default_passes(self):
+        """interview_mode defaults to 'text' when omitted."""
+        survey = Survey(
+            [
+                QuestionInterview(
+                    question_name="q1",
+                    question_text="Tell me about your experience.",
+                    interview_guide="Ask follow-up questions about details.",
+                ),
+            ]
+        )
+        humanize_schema = {"questions": {"q1": {"optional": False}}}
+        validate_humanize_schema(survey, humanize_schema)
+
+    def test_interview_mode_invalid_value_raises(self):
+        """interview_mode with an unsupported value raises."""
+        survey = Survey(
+            [
+                QuestionInterview(
+                    question_name="q1",
+                    question_text="Tell me about your experience.",
+                    interview_guide="Ask follow-up questions about details.",
+                ),
+            ]
+        )
+        humanize_schema = {
+            "questions": {"q1": {"optional": False, "interview_mode": "video"}}
+        }
+        with pytest.raises(HumanizeSchemaValidationError):
+            validate_humanize_schema(survey, humanize_schema)
+
+
 class TestValidateHumanizeSchemaComments:
     """Comment-related validate_humanize_schema behavior."""
 


### PR DESCRIPTION
This allows users to choose between text, voice, or both (respondent's choice) when creating a `QuestionInterview`.