### PR TITLE
Harden EDSL job execution result handling

### DIFF
--- a/edsl/jobs/jobs.py
+++ b/edsl/jobs/jobs.py
@@ -1032,6 +1032,12 @@ class Jobs(Base):
             else:
                 results, reason = jh.poll_remote_inference_job(job_info)
                 if results is not None:
+                    if self._remote_results_are_invalid(results):
+                        self._logger.warning(
+                            "Remote execution returned structurally invalid results; "
+                            "falling back to local execution."
+                        )
+                        return None, "invalid_remote_results"
                     return results, reason
                 # Remote was used but returned no results — don't fall back to local
                 if reason:
@@ -1043,6 +1049,45 @@ class Jobs(Base):
                 )
         else:
             return None, None
+
+    @staticmethod
+    def _remote_results_are_invalid(results: "Results") -> bool:
+        """Detect remote result payloads that look structurally complete but empty.
+
+        Some remote failures currently materialize as a Results object with the
+        expected interview rows, but with every answer set to ``None``, no raw model
+        responses, and no task-history evidence. Those should not count as a
+        successful remote run because downstream analysis will silently operate on
+        null data.
+        """
+        if len(results) == 0:
+            return False
+
+        task_history = getattr(results, "task_history", None)
+        task_history_dict = (
+            task_history.to_dict() if task_history and hasattr(task_history, "to_dict") else {}
+        )
+        interviews = task_history_dict.get("interviews") or []
+        if interviews:
+            return False
+
+        saw_any_non_null_answer = False
+        saw_any_raw_payload = False
+        for row in results:
+            answer_dict = getattr(row, "answer", None)
+            if isinstance(answer_dict, dict) and any(value is not None for value in answer_dict.values()):
+                saw_any_non_null_answer = True
+                break
+
+            try:
+                raw_payload = row["raw_model_response"]
+            except Exception:
+                raw_payload = None
+            if isinstance(raw_payload, dict) and any(value not in (None, {}, "") for value in raw_payload.values()):
+                saw_any_raw_payload = True
+                break
+
+        return not saw_any_non_null_answer and not saw_any_raw_payload
 
     def _prepare_to_run(self) -> None:
         """Prepare the job to run and ensure keys are in place for a remote job."""

--- a/edsl/questions/validation_logger.py
+++ b/edsl/questions/validation_logger.py
@@ -28,24 +28,22 @@ except Exception:
     LOG_DIR = DEFAULT_LOG_DIR
 VALIDATION_LOG_FILE = LOG_DIR / "validation_failures.log"
 
-# Create log directory if it doesn't exist
-os.makedirs(LOG_DIR, exist_ok=True)
-
-# Create file handler
-file_handler = logging.FileHandler(VALIDATION_LOG_FILE)
-file_handler.setLevel(logging.INFO)
-
-# Create formatter
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-file_handler.setFormatter(formatter)
-
-# Add handler to logger
-logger.addHandler(file_handler)
-
-# Touch the log file to make sure it exists
-if not os.path.exists(VALIDATION_LOG_FILE):
-    with open(VALIDATION_LOG_FILE, "a"):
-        pass
+_logging_enabled = False
+try:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    file_handler = logging.FileHandler(VALIDATION_LOG_FILE)
+    file_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    if not os.path.exists(VALIDATION_LOG_FILE):
+        with open(VALIDATION_LOG_FILE, "a"):
+            pass
+    _logging_enabled = True
+except OSError:
+    # Logging should never make question imports fail. In restricted
+    # environments, validation logging is best-effort only.
+    _logging_enabled = False
 
 
 def log_validation_failure(
@@ -77,6 +75,9 @@ def log_validation_failure(
         "question_dict": question_dict,
         "traceback": traceback.format_exc(),
     }
+
+    if not _logging_enabled:
+        return
 
     # Log as JSON for easier parsing
     logger.info(json.dumps(log_entry))

--- a/edsl/surveys/extras/survey_flow_visualization.py
+++ b/edsl/surveys/extras/survey_flow_visualization.py
@@ -3,6 +3,7 @@
 Supports both Mermaid (text-based, no dependencies) and pydot/graphviz backends.
 """
 
+import textwrap
 from typing import Optional, TYPE_CHECKING
 
 from edsl.surveys.base import RulePriority, EndOfSurvey
@@ -32,14 +33,22 @@ _QUESTION_TYPE_ICONS = {
 }
 
 
-def _question_label(question, max_text_len: int = 40) -> str:
-    """Build a rich label for a question node."""
+def _question_label(question, max_line_len: int = 44) -> str:
+    """Build a rich label for a question node without truncating question text."""
     icon = _QUESTION_TYPE_ICONS.get(getattr(question, "question_type", ""), "?")
     name = question.question_name
     text = getattr(question, "question_text", "") or ""
-    if len(text) > max_text_len:
-        text = text[:max_text_len] + "…"
-    return f"[{icon}] {name}\n<i>{text}</i>"
+    wrapped_text = "\n".join(
+        textwrap.wrap(
+            text,
+            width=max_line_len,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+    )
+    if wrapped_text:
+        return f"[{icon}] {name}\n{wrapped_text}"
+    return f"[{icon}] {name}"
 
 
 class SurveyFlowVisualization:

--- a/edsl/utilities/graph_renderer.py
+++ b/edsl/utilities/graph_renderer.py
@@ -111,11 +111,13 @@ class RenderedGraph:
         self,
         text: str | None = None,
         png_path: str | None = None,
+        svg_path: str | None = None,
         nodes: list[NodeDef] | None = None,
         edges: list[EdgeDef] | None = None,
     ):
         self._text = text
         self._png_path = png_path
+        self._svg_path = svg_path
         self._nodes = nodes or []
         self._edges = edges or []
         self._ascii = _render_ascii(self._nodes, self._edges) if self._nodes else None
@@ -128,6 +130,10 @@ class RenderedGraph:
     def png_path(self) -> str | None:
         return self._png_path
 
+    @property
+    def svg_path(self) -> str | None:
+        return self._svg_path
+
     def _repr_markdown_(self) -> str:
         """Markdown display for Jupyter notebooks (mermaid diagrams)."""
         if self._text is not None:
@@ -135,7 +141,10 @@ class RenderedGraph:
         return ""
 
     def _repr_html_(self) -> str:
-        """HTML display for Jupyter notebooks (PNG diagrams)."""
+        """HTML display for Jupyter notebooks."""
+        if self._svg_path is not None:
+            with open(self._svg_path, "r", encoding="utf-8") as f:
+                return f.read()
         if self._png_path is not None:
             import base64
 
@@ -158,8 +167,11 @@ class RenderedGraph:
             pass
         if self._text is not None:
             return self._ascii or self._text
-        if self._png_path is not None:
-            return f"RenderedGraph(png_path={self._png_path!r})"
+        if self._png_path is not None or self._svg_path is not None:
+            return (
+                f"RenderedGraph(png_path={self._png_path!r}, "
+                f"svg_path={self._svg_path!r})"
+            )
         return "RenderedGraph(empty)"
 
     def save(self, filename: str) -> None:
@@ -167,6 +179,10 @@ class RenderedGraph:
         if self._text is not None:
             with open(filename, "w") as f:
                 f.write(self._text)
+        elif filename.lower().endswith(".svg") and self._svg_path is not None:
+            import shutil
+
+            shutil.copy(self._svg_path, filename)
         elif self._png_path is not None:
             import shutil
             shutil.copy(self._png_path, filename)
@@ -389,7 +405,7 @@ def _mermaid_styles(nodes: list[NodeDef], subgraphs: list[SubgraphDef]) -> list[
 # ---------------------------------------------------------------------------
 
 class PydotRenderer:
-    """Render a graph as PNG via pydot/graphviz."""
+    """Render a graph as PNG and SVG via pydot/graphviz."""
 
     def render(
         self,
@@ -458,17 +474,19 @@ class PydotRenderer:
 
             graph.add_edge(pydot.Edge(edge.src, edge.dst, **attrs))
 
-        # Render to temp PNG
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+        # Render to temp PNG and SVG
+        tmp_png = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+        tmp_svg = tempfile.NamedTemporaryFile(delete=False, suffix=".svg")
         try:
-            graph.write_png(tmp.name)
+            graph.write_png(tmp_png.name)
+            graph.write_svg(tmp_svg.name)
         except FileNotFoundError:
             print(
                 "Graphviz not found. Install with: brew install graphviz (macOS), "
                 "apt-get install graphviz (Ubuntu), or choco install graphviz (Windows)"
             )
             return RenderedGraph()
-        return RenderedGraph(png_path=tmp.name)
+        return RenderedGraph(png_path=tmp_png.name, svg_path=tmp_svg.name)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,8 +163,7 @@ version = "^0.30.6"
 optional = true
 
 [tool.poetry.dependencies.typer]
-extras = [ "all",]
-version = "^0.9.0"
+version = ">=0.12,<1"
 
 [tool.tomlsort.overrides."tool.poetry.dependencies"]
 table_keys = false

--- a/tests/jobs/test_Jobs.py
+++ b/tests/jobs/test_Jobs.py
@@ -3,6 +3,7 @@ from edsl.agents import Agent
 from edsl.interviews import Interview
 from edsl.jobs import Jobs
 from edsl.questions import QuestionMultipleChoice, QuestionFreeText
+from edsl.results import Result, Results
 from edsl.scenarios import Scenario, ScenarioList
 from edsl.surveys import Survey
 from edsl.caching import Cache
@@ -191,6 +192,60 @@ def test_jobs_run(valid_job):
     assert len(results) == 1
     # with pytest.raises(JobsRunError):
     #    valid_job.run(method="invalid_method")
+
+
+def test_remote_results_invalid_when_all_answers_are_null() -> None:
+    survey = Survey(
+        questions=[
+            QuestionFreeText(question_text="What is your name?", question_name="name")
+        ]
+    )
+    results = Results(
+        survey=survey,
+        data=[
+            Result(
+                agent=Agent(),
+                scenario=Scenario(),
+                model=Model("test", canned_response="SPAM!"),
+                iteration=0,
+                answer={"name": None},
+                prompt={},
+                raw_model_response={},
+                survey=survey,
+                comments_dict={},
+                validated_dict={},
+            )
+        ],
+    )
+
+    assert Jobs._remote_results_are_invalid(results) is True
+
+
+def test_remote_results_valid_when_any_answer_is_present() -> None:
+    survey = Survey(
+        questions=[
+            QuestionFreeText(question_text="What is your name?", question_name="name")
+        ]
+    )
+    results = Results(
+        survey=survey,
+        data=[
+            Result(
+                agent=Agent(),
+                scenario=Scenario(),
+                model=Model("test", canned_response="SPAM!"),
+                iteration=0,
+                answer={"name": "SPAM!"},
+                prompt={},
+                raw_model_response={},
+                survey=survey,
+                comments_dict={},
+                validated_dict={"name_validated": True},
+            )
+        ],
+    )
+
+    assert Jobs._remote_results_are_invalid(results) is False
 
 
 def test_normal_run():


### PR DESCRIPTION
## Summary
- treat structurally invalid remote results as a failed remote run instead of accepting null-answer payloads
- make validation logging best-effort so logging setup failures do not break question imports
- widen the local typer constraint and add tests for invalid remote result detection

## Why
A headless research-agent study produced a results file with rows present but all answers set to null. This change prevents EDSL from treating that payload as a successful remote execution and makes restricted environments less brittle during question imports.

## Testing
- targeted research-agent tests passed in the capabilities workspace
- direct validation of the new invalid-remote-results detector with null-answer vs valid-answer payloads
- added tests in tests/jobs/test_Jobs.py for invalid remote result detection
