### PR TITLE
Humanize updates

### DIFF
--- a/docs/mintlify-migration/en/latest/custom_css.mdx
+++ b/docs/mintlify-migration/en/latest/custom_css.mdx
@@ -6,11 +6,82 @@ sidebarTitle: "Custom CSS"
 
 Every question component supported by humanize has `edsl-*` CSS classes so you can customise the survey appearance.
 
+## Applying custom CSS
+
+### When creating a human survey
+
+Pass your CSS string in the `humanize_schema` under `survey.custom_css`.
+
+```python
+from edsl import Survey, QuestionFreeText, QuestionMultipleChoice
+
+survey = Survey([
+    QuestionMultipleChoice(
+        question_name="rating",
+        question_text="Rate your experience.",
+        question_options=["Good", "OK", "Bad"],
+    ),
+    QuestionFreeText(
+        question_name="feedback",
+        question_text="Any additional feedback you'd like to share?",
+    ),
+])
+
+custom_css = """
+.edsl-survey-container { background-color: #f9f9f9; }
+.edsl-question-text { font-weight: bold; color: #333; }
+"""
+
+humanize_schema = {
+    "questions": {
+        "rating": {"format": {"type": "dropdown"}},
+        "feedback": {"optional": True},
+    },
+    "survey": {"custom_css": custom_css},
+}
+
+survey.humanize(humanize_schema=humanize_schema)
+```
+
+Pass `"survey": {"custom_css": None}` (or omit `custom_css`) to create the survey without any custom CSS.
+
+### Updating CSS on an existing human survey
+
+Use `Coop.patch_human_survey_css` to set or clear the CSS on a human survey that already exists.
+
+```python
+from edsl import Coop
+
+coop = Coop()
+
+# Set or replace CSS
+coop.patch_human_survey_css(
+    human_survey_uuid="your-human-survey-uuid",
+    css=".edsl-survey-container { background-color: #fff; }",
+)
+
+# Clear existing CSS
+coop.patch_human_survey_css(
+    human_survey_uuid="your-human-survey-uuid",
+    css=None,
+)
+```
+
 ## Survey-level classes
 
 | Class | Element | Notes |
 |---|---|---|
 | `edsl-survey-container` | Outermost container of the entire survey | Use to set background color for the whole survey |
+
+## Common question classes
+
+These classes are present on every question regardless of type.
+
+| Class | Element | Notes |
+|---|---|---|
+| `edsl-question` | Outermost `<div>` of every question | Always present |
+| `edsl-question-text` | Question prompt `<div>` | Rendered from `question_text` |
+| `edsl-question-image` | `<img>` embedded in a question | Image blocks in question text |
 
 ## Question-specific HTML
 

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -3729,6 +3729,31 @@ class Coop(CoopFunctionsMixin):
 
         validate_humanize_schema(survey, humanize_schema)
 
+    def patch_human_survey_css(
+        self,
+        human_survey_uuid: Union[str, UUID],
+        css: Optional[str],
+    ) -> dict:
+        """
+        Set or clear the custom CSS in a human survey's humanize schema.
+
+        Pass ``css=None`` to remove any existing custom CSS.
+
+        Parameters:
+            human_survey_uuid: UUID of the human survey.
+            css: CSS string to apply, or ``None`` to clear it.
+
+        Returns:
+            dict: ``{"message": str}``
+        """
+        response = self._send_server_request(
+            uri=f"api/v0/human-surveys/{human_survey_uuid}/humanize-schema/css",
+            method="PATCH",
+            payload={"css": css},
+        )
+        self._resolve_server_response(response)
+        return response.json()
+
     def _turn_human_responses_into_results(
         self,
         human_responses: List[dict],

--- a/edsl/inference_services/services/service_enums.py
+++ b/edsl/inference_services/services/service_enums.py
@@ -9,4 +9,5 @@ OPENAI_REASONING_MODELS = [
     "gpt-5-mini",
     "gpt-5-nano",
     "gpt-5.1",
+    "gpt-5.5",
 ]


### PR DESCRIPTION
- Add endpoint for patching humanize CSS (after a survey is deployed)
- Update humanize docs with 1) new endpoint for patching CSS and 2) new CSS class for updating image CSS
- Mark gpt-5.5 as reasoning model (This is needed to apply reasoning model overrides, such as `temperature = 1`, at the OpenAI service level. This should make gpt-5.5 work with the Daily Model Test (which it currently does not - it is not in the list of available models). 