### PR TITLE
Add support + docs for QuestionFileUpload with humanize

### DIFF
--- a/docs/mintlify-migration/en/latest/custom_css.mdx
+++ b/docs/mintlify-migration/en/latest/custom_css.mdx
@@ -159,51 +159,109 @@ These classes are present on every question regardless of type.
 
 ### File upload
 
-<Tabs>
-  <Tab title="Multiple files">
 ```html
 <div class="edsl-question edsl-file-upload-question">
   <div class="edsl-question-text">Upload supporting documents.</div>
-  <div>
-    <input type="file" multiple />
-    <div>
-      <span>2 files chosen</span>
-      <button type="button">Choose Files</button>
+
+  <!-- edsl-file-upload-dragging is added to this element while a drag is in progress -->
+  <div class="edsl-file-upload-dropzone [edsl-file-upload-dragging]">
+
+    <!-- clickable / drag-and-drop target -->
+    <div role="button" class="edsl-file-upload-target">
+      <input type="file" multiple class="sr-only" />
+      <div class="edsl-file-upload-icon-wrapper">
+        <!-- upload icon -->
+        <svg class="edsl-file-upload-icon">…</svg>
+      </div>
+      <p class="edsl-file-upload-title">Upload files</p>
+      <p class="edsl-file-upload-subtitle">Drag & drop or click to browse</p>
+      <!-- shown when file-type / size constraints are set -->
+      <p class="edsl-file-upload-hints">All file types · Max 10 files · Up to 1 GB per file</p>
     </div>
-  </div>
-  <div class="edsl-file-list">
-    <div>
-      <p>Selected files (2):</p>
-      <button type="button">Clear all</button>
+
+    <!-- shown only when there are file-level errors -->
+    <div class="edsl-file-upload-errors">
+      <!-- error messages -->
+      <button type="button"><!-- dismiss --></button>
     </div>
-    <div class="edsl-file-item">
-      <p>doc1.pdf <span>(24 KB)</span></p>
-      <button type="button">Remove</button>
+
+    <!-- shown only when files have been added -->
+    <div class="edsl-file-list">
+      <div class="edsl-file-list-header">
+        <span>Files (2)</span>
+        <button type="button" class="edsl-file-remove-all">Remove all</button>
+      </div>
+
+      <!-- card layout (small screens) -->
+      <div class="edsl-file-cards">
+        <div class="edsl-file-item">
+          <div class="edsl-file-item-icon-wrapper">
+            <svg class="edsl-file-item-icon">…</svg>
+          </div>
+          <div>
+            <p class="edsl-file-item-name">doc1.pdf</p>
+            <div>
+              <p class="edsl-file-item-size">24 KB</p>
+              <span class="edsl-file-item-status">
+                <!-- while uploading: -->
+                <span class="edsl-file-status-uploading">
+                  <div class="edsl-file-progress-track">
+                    <div class="edsl-file-progress-fill" style="width: 60%"></div>
+                  </div>
+                  Uploading…
+                </span>
+                <!-- on success: -->
+                <span class="edsl-file-status-done">Done</span>
+                <!-- on failure: -->
+                <span class="edsl-file-status-error">Failed</span>
+              </span>
+            </div>
+          </div>
+          <button type="button" class="edsl-file-item-remove"><!-- trash icon --></button>
+        </div>
+      </div>
+
+      <!-- table layout (medium+ screens) -->
+      <div class="edsl-file-table-wrapper">
+        <table class="edsl-file-table">
+          <thead class="edsl-file-table-header">
+            <tr class="edsl-file-table-header-row">
+              <th class="edsl-file-table-header-cell">Name</th>
+              <th class="edsl-file-table-header-cell">Size</th>
+              <th class="edsl-file-table-header-cell">Upload Status</th>
+              <th class="edsl-file-table-header-cell">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="edsl-file-table-row">
+              <td>
+                <svg class="edsl-file-item-icon">…</svg>
+                <span>doc1.pdf</span>
+              </td>
+              <td>24 KB</td>
+              <td>
+                <!-- one of: -->
+                <span class="edsl-file-status-uploading">
+                  <div class="edsl-file-progress-track">
+                    <div class="edsl-file-progress-fill" style="width: 60%"></div>
+                  </div>
+                </span>
+                <span class="edsl-file-status-done">Done</span>
+                <span class="edsl-file-status-error">Failed</span>
+              </td>
+              <td>
+                <button type="button" class="edsl-file-item-remove"><!-- trash icon --></button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
-    <div class="edsl-file-item">
-      <p>doc2.pdf <span>(18 KB)</span></p>
-      <button type="button">Remove</button>
-    </div>
+
   </div>
   <p class="edsl-error">…</p>
 </div>
 ```
-  </Tab>
-  <Tab title="Single file">
-```html
-<div class="edsl-question edsl-file-upload-question">
-  <div class="edsl-question-text">Upload your CV.</div>
-  <input type="file" />
-  <!-- shown after a file is selected -->
-  <div>
-    <p>Selected: resume.pdf (142 KB)</p>
-    <button type="button">Clear</button>
-  </div>
-  <p class="edsl-error">…</p>
-</div>
-```
-  </Tab>
-</Tabs>
 
 ### Free text
 

--- a/docs/mintlify-migration/en/latest/humanize.mdx
+++ b/docs/mintlify-migration/en/latest/humanize.mdx
@@ -199,6 +199,30 @@ status = coop.get_human_survey("your-human-survey-uuid")
 print(f"Responses received: {status['n_responses']}")
 ```
 
+### Working with file upload responses
+
+If your survey includes a `QuestionFileUpload` question, each response's answer for that question is a list of file-info dicts. Use `FileStore.from_file_upload_answer` (single file) or `FileStoreList.from_file_upload_answers` (all files at once) to download and wrap them:
+
+```python
+from edsl import Coop
+from edsl.scenarios import FileStore, FileStoreList
+
+coop = Coop()
+
+results = coop.get_human_survey_responses("your-human-survey-uuid")
+
+# Each answer is a list of uploaded file dicts
+uploaded_files = results[0]["answer"]["my_upload_question"]
+
+# Download all files as a FileStoreList
+fsl = FileStoreList.from_file_upload_answers(uploaded_files)
+
+# Or download a single file
+fs = FileStore.from_file_upload_answer(uploaded_files[0])
+```
+
+The returned `FileStore` and `FileStoreList` objects behave like any other — you can inspect, filter, or pass them into further EDSL workflows.
+
 ---
 
 ## QR code

--- a/docs/mintlify-migration/en/latest/humanize_schema.mdx
+++ b/docs/mintlify-migration/en/latest/humanize_schema.mdx
@@ -28,7 +28,7 @@ Each `questions[question_name]` value is a `HumanizeQuestionSchema` object.
 <ParamField path="optional" type="boolean" default={false}>
   Whether the question is optional. Default is `false` when omitted.
 
-  **Supported question types:** `free_text`, `budget`, `checkbox`, `interview`, `likert_five`, `linear_scale`, `list`, `matrix`, `multiple_choice`, `multiple_choice_with_other`, `numerical`, `rank`, `top_k`, `yes_no`.
+  **Supported question types:** `free_text`, `budget`, `checkbox`, `file_upload`, `interview`, `likert_five`, `linear_scale`, `list`, `matrix`, `multiple_choice`, `multiple_choice_with_other`, `numerical`, `rank`, `top_k`, `yes_no`.
 
   Note: `optional` currently has no effect for `interview` and `rank`.
 </ParamField>

--- a/edsl/coop/coop_humanize_schema.py
+++ b/edsl/coop/coop_humanize_schema.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Literal, Optional, Type, Union
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    model_validator,
+)
 
 from ..questions import QuestionBase
 
@@ -36,7 +43,7 @@ class SurveyHumanizeSchema(HumanizeSchemaBase):
 class CommentConfig(HumanizeSchemaBase):
     """Configuration for the optional comment field on a question."""
 
-    label: str
+    label: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class FreeTextHumanizeSchema(HumanizeSchemaBase):
@@ -64,6 +71,12 @@ class ComputeHumanizeSchema(HumanizeSchemaBase):
     """Humanize options for the compute question type (no optionality)."""
 
     pass
+
+
+class FileUploadHumanizeSchema(HumanizeSchemaBase):
+    """Humanize options for the file upload question type."""
+
+    optional: bool = False
 
 
 class InterviewHumanizeSchema(HumanizeSchemaBase):
@@ -191,6 +204,7 @@ HumanizeQuestionSchema = Union[
     BudgetHumanizeSchema,
     CheckboxHumanizeSchema,
     ComputeHumanizeSchema,
+    FileUploadHumanizeSchema,
     InterviewHumanizeSchema,
     LikertHumanizeSchema,
     LinearScaleHumanizeSchema,
@@ -220,6 +234,7 @@ QUESTION_TYPE_TO_HUMANIZE_CLASS: Dict[str, Type[BaseModel]] = {
     "budget": BudgetHumanizeSchema,
     "checkbox": CheckboxHumanizeSchema,
     "compute": ComputeHumanizeSchema,
+    "file_upload": FileUploadHumanizeSchema,
     "interview": InterviewHumanizeSchema,
     "likert_five": LikertHumanizeSchema,
     "linear_scale": LinearScaleHumanizeSchema,

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -129,7 +129,9 @@ class FileStore(Scenario):
             or (mimetypes.guess_type(path)[0] if path else None)
             or "application/octet-stream"
         )
-        self.base64_string = base64_string or self.encode_file_to_base64_string(path or "")
+        self.base64_string = base64_string or self.encode_file_to_base64_string(
+            path or ""
+        )
         self.external_locations = external_locations or {}
 
         self.extracted_text = (
@@ -296,7 +298,9 @@ class FileStore(Scenario):
     ) -> "FileStore":
         """Async version of screenshot functionality"""
         try:
-            from playwright.async_api import async_playwright  # ty: ignore[unresolved-import]
+            from playwright.async_api import (
+                async_playwright,
+            )  # ty: ignore[unresolved-import]
         except ImportError:
             raise ImportError(
                 "Screenshot functionality requires additional dependencies.\n"
@@ -798,7 +802,9 @@ class FileStore(Scenario):
                 file_store_dict["base64_string"] = "offloaded"
             return self.__class__.from_dict(file_store_dict)
 
-    def save_to_gcs_bucket(self, signed_url_or_dict: Union[str, Dict[str, str]]) -> dict:
+    def save_to_gcs_bucket(
+        self, signed_url_or_dict: Union[str, Dict[str, str]]
+    ) -> dict:
         """
         Saves the FileStore's file content to a Google Cloud Storage bucket using a signed URL.
 
@@ -834,7 +840,11 @@ class FileStore(Scenario):
         }
 
         # Upload to GCS using the signed URL
-        signed_url = signed_url_or_dict if isinstance(signed_url_or_dict, str) else signed_url_or_dict.get("url", "")
+        signed_url = (
+            signed_url_or_dict
+            if isinstance(signed_url_or_dict, str)
+            else signed_url_or_dict.get("url", "")
+        )
         response = requests.put(signed_url, data=file_content, headers=headers)
         response.raise_for_status()
 
@@ -890,7 +900,6 @@ class FileStore(Scenario):
 
         # Save under the original filename in a fresh temp dir so the suffix is
         # correct and there's no collision if the same name appears in multiple uploads.
-        import tempfile
 
         name = file_info.get("name") or ""
         if not name:
@@ -966,24 +975,33 @@ class FileStore(Scenario):
         try:
             from edsl.utilities.display_utils import HTML
         except ImportError:
+
             class HTML:
                 def __init__(self, content):
                     self.content = content
+
                 def _repr_html_(self):
                     return self.content
+
         return HTML(self._html_download_link(custom_filename or self.path, style))
 
     def _html_download_link(self, custom_filename=None, style=None):
         """Generate an HTML download link string for this FileStore."""
         import os as _os
+
         filename = _os.path.basename(custom_filename or self.path)
         b64_data = self.base64_string
         mime_type = self.mime_type
         default_style = {
-            "background-color": "#4CAF50", "color": "white",
-            "padding": "10px 20px", "text-decoration": "none",
-            "border-radius": "4px", "display": "inline-block",
-            "margin": "10px 0", "font-family": "sans-serif", "cursor": "pointer",
+            "background-color": "#4CAF50",
+            "color": "white",
+            "padding": "10px 20px",
+            "text-decoration": "none",
+            "border-radius": "4px",
+            "display": "inline-block",
+            "margin": "10px 0",
+            "font-family": "sans-serif",
+            "cursor": "pointer",
         }
         button_style = style or default_style
         style_str = "; ".join(f"{k}: {v}" for k, v in button_style.items())

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -891,6 +891,7 @@ class FileStore(Scenario):
             method="POST",
             payload={"gcs_path": file_info["gcs_path"]},
         )
+        response.raise_for_status()
         response_data = response.json()
         download_url = response_data.get("url")
         if not download_url:

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -901,7 +901,7 @@ class FileStore(Scenario):
         # Save under the original filename in a fresh temp dir so the suffix is
         # correct and there's no collision if the same name appears in multiple uploads.
 
-        name = file_info.get("name") or ""
+        name = os.path.basename(file_info.get("name") or "")
         if not name:
             extension = file_info.get("extension", "")
             name = f"file.{extension}" if extension else "file"

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -847,6 +847,64 @@ class FileStore(Scenario):
         }
 
     @classmethod
+    def from_file_upload_answer(
+        cls,
+        file_info: dict,
+        expected_parrot_url: Optional[str] = None,
+    ) -> "FileStore":
+        """
+        Create a FileStore from a single entry in a QuestionFileUpload answer.
+
+        Calls the Coop endpoint to obtain a signed download URL, then fetches
+        the file and wraps it in a FileStore.
+
+        Args:
+            file_info: A dict with at minimum a 'gcs_path' key, as returned in
+                       the answer list for a QuestionFileUpload question.
+                       Optionally includes 'name', 'mime_type', and 'extension'.
+            expected_parrot_url: Optional override for the Coop server URL.
+
+        Returns:
+            FileStore: The downloaded file.
+
+        Example::
+
+            answer = results[0]['answer']['my_upload_question']
+            for file_info in answer:
+                fs = FileStore.from_file_upload_answer(file_info)
+        """
+        from ..coop import Coop
+
+        coop = Coop(url=expected_parrot_url) if expected_parrot_url else Coop()
+        response = coop._send_server_request(
+            uri="api/v0/human-survey-file-uploads/download-url",
+            method="POST",
+            payload={"gcs_path": file_info["gcs_path"]},
+        )
+        response_data = response.json()
+        download_url = response_data.get("url")
+        if not download_url:
+            raise ValueError(
+                f"Server did not return a download URL. Response: {response_data}"
+            )
+
+        # Save under the original filename in a fresh temp dir so the suffix is
+        # correct and there's no collision if the same name appears in multiple uploads.
+        import tempfile
+
+        name = file_info.get("name") or ""
+        if not name:
+            extension = file_info.get("extension", "")
+            name = f"file.{extension}" if extension else "file"
+        download_path = os.path.join(tempfile.mkdtemp(), name)
+
+        return cls.from_url(
+            download_url,
+            download_path=download_path,
+            mime_type=file_info.get("mime_type"),
+        )
+
+    @classmethod
     def pull(
         cls,
         url_or_uuid: Optional[Union[str, UUID]] = None,

--- a/edsl/scenarios/file_store_list.py
+++ b/edsl/scenarios/file_store_list.py
@@ -5,6 +5,7 @@ import tempfile
 
 from .scenario_list import ScenarioList
 from .file_store import FileStore
+
 if TYPE_CHECKING:
     pass
 
@@ -247,7 +248,7 @@ class FileStoreList(ScenarioList):
     def from_file_upload_answers(
         cls,
         files: list,
-        expected_parrot_url: str = None,
+        expected_parrot_url: Optional[str] = None,
     ) -> "FileStoreList":
         """
         Create a FileStoreList from the answer list of a QuestionFileUpload question.
@@ -266,7 +267,9 @@ class FileStoreList(ScenarioList):
             fsl = FileStoreList.from_file_upload_answers(answer)
         """
         file_stores = [
-            FileStore.from_file_upload_answer(f, expected_parrot_url=expected_parrot_url)
+            FileStore.from_file_upload_answer(
+                f, expected_parrot_url=expected_parrot_url
+            )
             for f in files
         ]
         return cls(data=file_stores)

--- a/edsl/scenarios/file_store_list.py
+++ b/edsl/scenarios/file_store_list.py
@@ -244,6 +244,34 @@ class FileStoreList(ScenarioList):
         return self.__class__(data=video_files, codebook=self.codebook)
 
     @classmethod
+    def from_file_upload_answers(
+        cls,
+        files: list,
+        expected_parrot_url: str = None,
+    ) -> "FileStoreList":
+        """
+        Create a FileStoreList from the answer list of a QuestionFileUpload question.
+
+        Args:
+            files: List of file-info dicts, each containing at minimum 'gcs_path',
+                   as returned in the answer for a QuestionFileUpload question.
+            expected_parrot_url: Optional override for the Coop server URL.
+
+        Returns:
+            FileStoreList: One FileStore per uploaded file.
+
+        Example::
+
+            answer = results[0]['answer']['my_upload_question']
+            fsl = FileStoreList.from_file_upload_answers(answer)
+        """
+        file_stores = [
+            FileStore.from_file_upload_answer(f, expected_parrot_url=expected_parrot_url)
+            for f in files
+        ]
+        return cls(data=file_stores)
+
+    @classmethod
     def example(cls) -> "FileStoreList":
         """Create an example FileStoreList for testing and demonstration.
 


### PR DESCRIPTION
- Add humanize schema for QuestionFileUpload, with `optional` (bool) parameter
- Add helper methods `FileStore.from_file_upload_answer`, `FileStoreList.from_file_upload_answers` that allow users to work with humanize file upload responses
- Update docs with QuestionFileUpload changes