### PR TITLE
Fix show_flow() diagram rendering and improve visual quality

### DIFF
--- a/edsl/surveys/extras/survey_flow_visualization.py
+++ b/edsl/surveys/extras/survey_flow_visualization.py
@@ -14,32 +14,31 @@ if TYPE_CHECKING:
 
 
 _QUESTION_TYPE_ICONS = {
-    "free_text": "✏️",
-    "multiple_choice": "◉",
-    "checkbox": "☑",
-    "linear_scale": "⟷",
-    "numerical": "#",
-    "yes_no": "Y/N",
-    "likert_five": "★5",
-    "top_k": "🔝",
-    "rank": "↕",
-    "budget": "$",
-    "extract": "⛏",
-    "list": "▤",
-    "dropdown": "▾",
-    "matrix": "▦",
-    "file_upload": "📎",
+    "free_text": "Free Text",
+    "multiple_choice": "Multiple Choice",
+    "checkbox": "Checkbox",
+    "linear_scale": "Linear Scale",
+    "numerical": "Numerical",
+    "yes_no": "Yes/No",
+    "likert_five": "Likert",
+    "top_k": "Top-K",
+    "rank": "Rank",
+    "budget": "Budget",
+    "extract": "Extract",
+    "list": "List",
+    "dropdown": "Dropdown",
+    "matrix": "Matrix",
+    "file_upload": "File Upload",
 }
 
 
-def _question_label(question, max_text_len: int = 40) -> str:
+def _question_label(question) -> str:
     """Build a rich label for a question node."""
-    icon = _QUESTION_TYPE_ICONS.get(getattr(question, "question_type", ""), "?")
+    question_type = getattr(question, "question_type", "")
+    type_label = _QUESTION_TYPE_ICONS.get(question_type, question_type)
     name = question.question_name
     text = getattr(question, "question_text", "") or ""
-    if len(text) > max_text_len:
-        text = text[:max_text_len] + "…"
-    return f"[{icon}] {name}\n<i>{text}</i>"
+    return f"{name}\n<i>{text}</i>\n({type_label})"
 
 
 class SurveyFlowVisualization:
@@ -120,7 +119,7 @@ class SurveyFlowVisualization:
                         param_to_questions.setdefault(param, []).append(index)
                     elif "." in param:
                         source_q, ref_type = param.split(".", 1)
-                        reference_types.setdefault(ref_type, set()).add((source_q, index))
+                        reference_types.setdefault(ref_type, set()).add((source_q, index, param))
                     else:
                         params_and_refs.add(param)
                         param_to_questions.setdefault(param, []).append(index)
@@ -128,7 +127,7 @@ class SurveyFlowVisualization:
         # Add reference edges
         for ref_type, references in reference_types.items():
             color = reference_colors.get(ref_type, reference_colors["default"])
-            for source_q_name, target_q_index in references:
+            for source_q_name, target_q_index, full_param in references:
                 try:
                     source_q_index = next(
                         i for i, q in enumerate(self.survey.questions)
@@ -136,20 +135,24 @@ class SurveyFlowVisualization:
                     )
                 except StopIteration:
                     continue
+                # Skip dashed reference edge when questions are adjacent —
+                # the normal flow arrow already shows the connection.
+                if target_q_index == source_q_index + 1:
+                    continue
                 graph.add_edge(
                     f"Q{source_q_index}", f"Q{target_q_index}",
-                    label=f".{ref_type}", style="dashed", color=color, font_color=color,
+                    label=f"{{{{ {full_param} }}}}", style="dashed", color=color, font_color=color,
                 )
 
         # Add parameter nodes
         for param in params_and_refs:
             node_id = f"param_{param}"
             if param.startswith("agent."):
-                graph.add_node(node_id, label=f"Agent Trait\n{{{{ {param} }}}}", shape="box", fill_color="lightpink")
+                graph.add_node(node_id, label=f"Agent Trait\n{{{{ {param} }}}}", shape="stadium", fill_color="lightpink")
             elif self.scenario and param.startswith("scenario."):
-                graph.add_node(node_id, label=f"Scenario\n{{{{ {param} }}}}", shape="box", fill_color="lightgreen")
+                graph.add_node(node_id, label=f"Scenario\n{{{{ {param} }}}}", shape="stadium", fill_color="lightgreen")
             else:
-                graph.add_node(node_id, label=f"{{{{ {param} }}}}", shape="box", fill_color="lightgrey")
+                graph.add_node(node_id, label=f"{{{{ {param} }}}}", shape="stadium", fill_color="lightgrey")
 
             for q_index in param_to_questions[param]:
                 graph.add_edge(node_id, f"Q{q_index}", style="dotted")
@@ -178,9 +181,14 @@ class SurveyFlowVisualization:
                 if rule.next_q != EndOfSurvey and rule.next_q < num_questions
                 else "EndOfSurvey"
             )
+            if rule.before_rule and rule.current_q > 0:
+                # Skip rule: draw bypass from the question *before* the skipped one
+                source = f"Q{rule.current_q - 1}"
+            else:
+                source = f"Q{rule.current_q}"
             graph.add_edge(
-                f"Q{rule.current_q}", target,
-                label=f"if {rule.expression}", color=color, font_color=color,
+                source, target,
+                label=rule.expression, color=color, font_color=color,
             )
 
         return graph.show(filename=filename)

--- a/edsl/utilities/graph_renderer.py
+++ b/edsl/utilities/graph_renderer.py
@@ -285,6 +285,7 @@ _MERMAID_SHAPES = {
     "box": ("[", "]"),
     "rectangle": ("[", "]"),
     "ellipse": ("([", "])"),
+    "stadium": ("([", "])"),
     "circle": ("((", "))"),
     "diamond": ("{", "}"),
     "hexagon": ("{{", "}}"),
@@ -380,6 +381,11 @@ def _mermaid_styles(nodes: list[NodeDef], subgraphs: list[SubgraphDef]) -> list[
         if sg.fill_color:
             hex_color = _COLOR_HEX.get(sg.fill_color, sg.fill_color)
             lines.append(f"style {sg.id} fill:{hex_color},stroke:#333")
+
+    # Enforce minimum width on question nodes for uniform appearance
+    question_nodes = [n for n in nodes if n.id.startswith("Q") and n.id[1:].isdigit()]
+    for node in question_nodes:
+        lines.append(f"style {node.id} min-width:220px")
 
     return lines
 
@@ -565,7 +571,14 @@ class DiGraph:
             result.save(filename)
             print(f"Graph saved to {filename}")
             return result
+        from edsl.utilities.is_notebook import is_notebook
+        in_notebook = is_notebook()
         result.show()
+        # Return None in notebook environments: the diagram was already sent to
+        # the cell output via IPython.display above, so returning the object
+        # would cause Jupyter to render it a second time as raw mermaid text.
+        if in_notebook:
+            return None
         return result
 
 

--- a/edsl/utilities/graph_renderer.py
+++ b/edsl/utilities/graph_renderer.py
@@ -385,7 +385,7 @@ def _mermaid_styles(nodes: list[NodeDef], subgraphs: list[SubgraphDef]) -> list[
     # Enforce minimum width on question nodes for uniform appearance
     question_nodes = [n for n in nodes if n.id.startswith("Q") and n.id[1:].isdigit()]
     for node in question_nodes:
-        lines.append(f"style {node.id} min-width:220px")
+        lines.append(f"style {node.id} width:220px")
 
     return lines
 
@@ -571,12 +571,17 @@ class DiGraph:
             result.save(filename)
             print(f"Graph saved to {filename}")
             return result
+        import sys
         from edsl.utilities.is_notebook import is_notebook
         in_notebook = is_notebook()
-        result.show()
-        # Return None in notebook environments: the diagram was already sent to
-        # the cell output via IPython.display above, so returning the object
-        # would cause Jupyter to render it a second time as raw mermaid text.
+        returned = result.show()
+        # In marimo, RenderedGraph.show() returns a PIL Image for display;
+        # pass it through so marimo can render it.
+        if in_notebook and "marimo" in sys.modules and returned is not None:
+            return returned
+        # In all other notebook environments the diagram was already sent to
+        # the cell output via IPython.display; returning the object would cause
+        # Jupyter to render it a second time as raw mermaid text.
         if in_notebook:
             return None
         return result


### PR DESCRIPTION
- Fix show_flow() printing raw mermaid source below the rendered diagram in Jupyter notebooks
- Fix marimo PIL Image return value being silently discarded
- Fix skip rule (add_skip_rule) edges drawing from the wrong question — bypass arrows now correctly originate from the question before the skipped one
- Cross-question reference edge labels now show the full {{ question.answer }} placeholder; edges between adjacent questions are suppressed as redundant
- Parameter (scenario/agent) nodes use a pill/stadium shape to distinguish them from question boxes
- Question type labels spell out full names (Multiple Choice, Free Text, etc.) instead of cryptic abbreviations
- Question nodes use width:220px for more uniform layout (SVG-compatible; min-width is not)
- Conditional rule edge labels drop the if prefix for cleaner display