### PR TITLE
Text interview updates; error report markdown endpoint

### DIFF
--- a/docs/mintlify-migration/en/latest/humanize_schema.mdx
+++ b/docs/mintlify-migration/en/latest/humanize_schema.mdx
@@ -59,6 +59,18 @@ Each `questions[question_name]` value is a `HumanizeQuestionSchema` object.
   - `"both"` — respondent can choose between text and voice.
 </ParamField>
 
+<ParamField path="text_interview_config" type="dict" required={false}>
+  **Interview only** (`interview`). Optional configuration for text-mode interviews. Ignored when `interview_mode` is `"voice"`.
+  <Expandable title="properties">
+    <ParamField path="interviewer_name" type="string" required={false}>
+      Label shown above the interviewer's messages. Must be between 1 and 200 characters. Defaults to `"AI Interviewer"`. Omit or set to `null` to use the default.
+    </ParamField>
+    <ParamField path="end_interview_message" type="string" required={false}>
+      Message shown to respondents when the interview ends. Must be between 1 and 2500 characters. Defaults to `"Thank you for your time. This interview has been ended. Your responses have been recorded and will be valuable for our research."` Omit or set to `null` to use the default.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
 <ParamField path="comment" type="dict" required={false}>
   Optional comment input shown with the question.
   Submitted comment text appears in survey results under `comment.{question_name}_comment`.

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2686,6 +2686,30 @@ class Coop(CoopFunctionsMixin):
 
         return CoopJobsObjects(jobs)
 
+    def get_error_report_markdown(self, job_uuid: Union[str, UUID]) -> str:
+        """
+        Retrieve the markdown-rendered exception report for the most recent error on a job.
+
+        Parameters:
+            job_uuid (Union[str, UUID]): The UUID of the remote inference job.
+
+        Returns:
+            str: The error report rendered as a markdown string.
+
+        Raises:
+            CoopServerResponseError: If the server returns an error (e.g., not found
+                or forbidden).
+
+        Example:
+            >>> print(coop.get_error_report_markdown(job_uuid))
+        """
+        response = self._send_server_request(
+            uri=f"api/v0/remote-inference/job/{job_uuid}/error-report",
+            method="GET",
+        )
+        self._resolve_server_response(response)
+        return response.json()["report"]
+
     def get_running_jobs(self) -> List[str]:
         """
         Get a list of currently running job IDs.

--- a/edsl/coop/coop_humanize_schema.py
+++ b/edsl/coop/coop_humanize_schema.py
@@ -79,11 +79,25 @@ class FileUploadHumanizeSchema(HumanizeSchemaBase):
     optional: bool = False
 
 
+class TextInterviewConfig(HumanizeSchemaBase):
+    """Configuration specific to text-mode interviews."""
+
+    interviewer_name: Annotated[
+        Optional[str],
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=200),
+    ] = None
+    end_interview_message: Annotated[
+        Optional[str],
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=2500),
+    ] = None
+
+
 class InterviewHumanizeSchema(HumanizeSchemaBase):
     """Humanize options for the interview question type."""
 
     optional: bool = False
     interview_mode: Literal["text", "voice", "both"] = "text"
+    text_interview_config: Optional[TextInterviewConfig] = None
 
 
 class LikertHumanizeSchema(HumanizeSchemaBase):


### PR DESCRIPTION
- Allow user to configure AI interviewer name & end of interview message via humanize schema