### PR TITLE
Pipe file upload answers

### DIFF
--- a/docs/mintlify-migration/en/latest/humanize_schema.mdx
+++ b/docs/mintlify-migration/en/latest/humanize_schema.mdx
@@ -65,7 +65,7 @@ Each `questions[question_name]` value is a `HumanizeQuestionSchema` object.
     <ParamField path="language" type="string" default="english">
       The spoken language for the voice interview. A lowercase language id from the supported set below. Case and surrounding whitespace are normalized (e.g. `"  French "` becomes `"french"`); omit or set to `null` to use the default (`"english"`). An unsupported value raises a validation error.
 
-      **Supported languages:** `english`, `french`, `german`, `spanish`, `portuguese`, `chinese`, `japanese`, `hindi`, `italian`, `korean`, `dutch`, `polish`, `russian`, `swedish`, `turkish`, `tagalog`, `bulgarian`, `romanian`, `arabic`, `czech`, `greek`, `finnish`, `croatian`, `malay`, `slovak`, `danish`, `tamil`, `ukrainian`, `hungarian`, `norwegian`, `vietnamese`, `bengali`, `thai`, `hebrew`, `georgian`, `indonesian`, `telugu`, `gujarati`, `kannada`, `malayalam`, `marathi`, `punjabi`, `multilingual`.
+      **Supported languages:** `english`, `french`, `german`, `spanish`, `portuguese`, `chinese`, `japanese`, `hindi`, `italian`, `korean`, `dutch`, `polish`, `russian`, `swedish`, `turkish`, `tagalog`, `bulgarian`, `romanian`, `arabic`, `czech`, `greek`, `finnish`, `croatian`, `malay`, `slovak`, `danish`, `tamil`, `ukrainian`, `hungarian`, `norwegian`, `vietnamese`, `bangla`, `thai`, `hebrew`, `georgian`, `indonesian`, `telugu`, `gujarati`, `kannada`, `malayalam`, `marathi`, `punjabi`, `multilingual`.
     </ParamField>
   </Expandable>
 </ParamField>

--- a/edsl/coop/voice_interview_languages.py
+++ b/edsl/coop/voice_interview_languages.py
@@ -44,7 +44,7 @@ VOICE_INTERVIEW_LANGUAGES: frozenset[str] = frozenset(
         "hungarian",
         "norwegian",
         "vietnamese",
-        "bengali",
+        "bangla",
         "thai",
         "hebrew",
         "georgian",

--- a/edsl/invigilators/prompt_constructor.py
+++ b/edsl/invigilators/prompt_constructor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Dict, Any, Optional, TYPE_CHECKING, Literal
 from functools import cached_property
 import logging
+import re
 import time as _time
 import threading
 
@@ -164,6 +165,42 @@ class PlaceholderComment(BasePlaceholder):
 class PlaceholderGeneratedTokens(BasePlaceholder):
     def __init__(self):
         super().__init__("generated_tokens")
+
+
+class _FileRefPlaceholder(str):
+    """Stands in for a prior file-upload answer in rendered text.
+
+    ``{{ up.answer }}``    -> ``"<see file up>"``      (the whole list)
+    ``{{ up.answer[0] }}`` -> ``"<see file up[0]>"``   (a single file)
+
+    Keeps raw gcs metadata / FileStore reprs out of the prompt while the actual
+    files ride along in ``files_list``.
+    """
+
+    def __new__(cls, name: str):
+        obj = super().__new__(cls, f"<see file {name}>")
+        obj._name = name
+        return obj
+
+    def __getitem__(self, index: Any) -> str:
+        return f"<see file {self._name}[{index}]>"
+
+
+def _referenced_file_indices(question_text: str, name: str) -> tuple[bool, set]:
+    """Which files of prior answer ``name`` does ``question_text`` reference?
+
+    Returns ``(attach_all, indices)``. ``attach_all`` is True for a bare
+    ``{{ name.answer }}`` reference (or when we can't tell, e.g. a dynamic
+    ``{{ name.answer[i] }}`` subscript); ``indices`` is the set of explicit
+    integer ``{{ name.answer[i] }}`` subscripts otherwise.
+    """
+    esc = re.escape(name)
+    indices = {
+        int(m.group(1))
+        for m in re.finditer(rf"\b{esc}\.answer\s*\[\s*(\d+)\s*\]", question_text)
+    }
+    has_whole = bool(re.search(rf"\b{esc}\.answer\b(?!\s*\[)", question_text))
+    return (has_whole or not indices), indices
 
 
 class PromptConstructor:
@@ -550,6 +587,92 @@ class PromptConstructor:
 
         return result
 
+    @staticmethod
+    def _prior_answer_file_stores(value: Any) -> list:
+        """Return the FileStore objects a prior answer represents, or [] if it has none.
+
+        A prior question's answer can carry a file in a few shapes:
+
+        - a ``FileStore`` (e.g. a wrapped local upload) -> a single-element list
+        - a ``FileStoreList`` or a plain list of ``FileStore`` objects
+
+        Anything else (a normal text answer, a placeholder, an empty list) returns [].
+
+        Note: raw ``QuestionFileUpload`` answers (a list of ``gcs_path`` dicts) are
+        realized into FileStores upstream, in the render layer's
+        ``_restore_upload_answers`` (which downloads and caches by gcs_path). Prompt
+        construction deliberately does not fetch from Coop; it only attaches files
+        that have already been materialized.
+        """
+        from ..scenarios import FileStore
+        from ..scenarios.file_store_list import FileStoreList
+
+        if isinstance(value, FileStore):
+            return [value]
+
+        if isinstance(value, FileStoreList):
+            return list(value.data)
+
+        if isinstance(value, (list, tuple)) and len(value) > 0:
+            if all(isinstance(v, FileStore) for v in value):
+                return list(value)
+
+        return []
+
+    @cached_property
+    def prior_answer_files(self) -> list:
+        """Files piped in from prior questions' answers, ready to attach to the model.
+
+        When the current question text references a prior question whose answer is a
+        file — e.g. ``{{ upload_q.answer }}`` where ``upload_q`` is a QuestionFileUpload —
+        the uploaded file(s) are attached to the model the same way scenario files are.
+        The prior answer's text rendering is swapped for a ``<see file ...>`` placeholder
+        so the raw file metadata (or a useless ``FileStore`` repr) doesn't leak into the
+        prompt. Files are only attached when explicitly referenced, mirroring how scenario
+        files behave.
+
+        Note: this reads ``prior_answers_dict()`` and rewrites the referenced answers'
+        ``.answer`` placeholder, so it must run before the question and memory prompts are
+        rendered. ``get_prompts`` calls it up front for exactly this reason.
+        """
+        question_text = getattr(self.question, "question_text", "") or ""
+        # Root variables referenced in the text (e.g. "upload" for {{ upload.answer[0] }}).
+        template_vars = QuestionTemplateReplacementsBuilder.get_jinja2_variables(
+            question_text
+        )
+        if not template_vars:  # no piping at all -> nothing to attach
+            return []
+
+        prior_answers = self.prior_answers_dict()
+        files: list = []
+        for name in template_vars:
+            # A referenced variable may not be a prior question (scenario key, agent
+            # trait, etc.); if it isn't, it can't carry a file answer.
+            question = prior_answers.get(name)
+            if question is None:
+                continue
+            # Only prior answers that are actually file(s) get attached; a normal text
+            # answer (or an unanswered placeholder) returns [] here and is skipped.
+            file_stores = self._prior_answer_file_stores(
+                getattr(question, "answer", None)
+            )
+            if not file_stores:
+                continue
+            # This variable pipes real files -> decide which ones the text asked for:
+            # a bare {{ name.answer }} attaches all, {{ name.answer[i] }} just file i.
+            attach_all, indices = _referenced_file_indices(question_text, name)
+            if attach_all:
+                files.extend(file_stores)
+            else:
+                # Attach only the referenced files; out-of-range indices are skipped.
+                files.extend(
+                    file_stores[i] for i in sorted(indices) if 0 <= i < len(file_stores)
+                )
+            # Render a placeholder in the text; the file itself rides along in files_list.
+            # The placeholder handles both {{ name.answer }} and {{ name.answer[i] }}.
+            question.answer = _FileRefPlaceholder(name)
+        return files
+
     @cached_property
     def question_instructions_prompt(self) -> "Prompt":
         """Get question instructions prompt (cached per PromptConstructor instance).
@@ -746,6 +869,11 @@ class PromptConstructor:
             - Handles file attachments if specified in the question
             - Returns a complete dictionary ready for use with the language model
         """
+        # Resolve any files piped in from prior questions' answers first. This swaps
+        # the referenced answers' text for a placeholder, so it must happen before the
+        # question and memory prompts below are rendered.
+        prior_answer_files = self.prior_answer_files
+
         # Build all the components with timing
         _t0 = _time.time()
         agent_instructions = self.agent_instructions_prompt
@@ -775,6 +903,12 @@ class PromptConstructor:
             files_list = []
             for key in file_keys:
                 files_list.append(self.scenario[key])
+            prompts["files_list"] = files_list
+
+        # Append any files piped in from prior questions' answers.
+        if prior_answer_files:
+            files_list = prompts.get("files_list", [])
+            files_list.extend(prior_answer_files)
             prompts["files_list"] = files_list
         _t6 = _time.time()
 

--- a/edsl/invigilators/prompt_constructor.py
+++ b/edsl/invigilators/prompt_constructor.py
@@ -189,18 +189,25 @@ class _FileRefPlaceholder(str):
 def _referenced_file_indices(question_text: str, name: str) -> tuple[bool, set]:
     """Which files of prior answer ``name`` does ``question_text`` reference?
 
-    Returns ``(attach_all, indices)``. ``attach_all`` is True for a bare
-    ``{{ name.answer }}`` reference (or when we can't tell, e.g. a dynamic
-    ``{{ name.answer[i] }}`` subscript); ``indices`` is the set of explicit
-    integer ``{{ name.answer[i] }}`` subscripts otherwise.
+    Returns ``(attach_all, indices)``:
+
+    - ``(False, set())`` -> ``name`` is referenced but not via ``.answer`` (e.g. a
+      bare ``{{ name }}``); it is not a file reference, so nothing attaches.
+    - ``(True, set())`` -> a bare ``{{ name.answer }}`` (or a subscript we can't
+      resolve statically, e.g. a dynamic ``{{ name.answer[i] }}``) -> attach all.
+    - ``(False, {i, ...})`` -> explicit integer subscripts ``{{ name.answer[i] }}``
+      -> attach just those files.
     """
     esc = re.escape(name)
-    indices = {
-        int(m.group(1))
-        for m in re.finditer(rf"\b{esc}\.answer\s*\[\s*(\d+)\s*\]", question_text)
-    }
-    has_whole = bool(re.search(rf"\b{esc}\.answer\b(?!\s*\[)", question_text))
-    return (has_whole or not indices), indices
+    # Every ``.answer`` reference, capturing an integer subscript when present.
+    # Bare ``.answer`` and a dynamic ``.answer[i]`` both capture "" (-> attach all);
+    # ``.answer[3]`` captures "3". No matches -> not referenced via ``.answer``.
+    refs = re.findall(rf"\b{esc}\.answer\b\s*(?:\[\s*(\d+)\s*\])?", question_text)
+    if not refs:
+        return (False, set())
+    indices = {int(r) for r in refs if r}
+    attach_all = any(r == "" for r in refs)
+    return (attach_all, indices)
 
 
 class PromptConstructor:
@@ -661,6 +668,10 @@ class PromptConstructor:
             # This variable pipes real files -> decide which ones the text asked for:
             # a bare {{ name.answer }} attaches all, {{ name.answer[i] }} just file i.
             attach_all, indices = _referenced_file_indices(question_text, name)
+            if not attach_all and not indices:
+                # Referenced without .answer (e.g. a bare {{ up }}) -> not a file
+                # reference; attach nothing and leave the answer untouched.
+                continue
             if attach_all:
                 files.extend(file_stores)
             else:

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -60,6 +60,11 @@ class RenderService:
         self._interviews = InterviewStore(storage)
         self._tasks = TaskStore(storage)
         self._answers = AnswerStore(storage)
+        # Realized file-upload answers, keyed by gcs_path. A gcs_path is globally
+        # unique and content-addressed, so a file piped into several questions is
+        # downloaded from Coop only once for the lifetime of this render service
+        # (one per job). This mirrors how offloaded scenario FileStores are restored.
+        self._upload_file_cache: dict[str, Any] = {}
 
     def _is_filestore_dict(self, value: Any) -> bool:
         """Check if a dict represents a serialized FileStore."""
@@ -99,6 +104,59 @@ class RenderService:
                     modified[key] = value
             else:
                 modified[key] = value
+        return modified
+
+    @staticmethod
+    def _is_file_upload_answer(value: Any) -> bool:
+        """True if a prior answer is a raw QuestionFileUpload answer.
+
+        The answer is a non-empty list of file-info dicts, each an uploaded-file
+        reference tagged ``type == 'gcs'`` with a non-empty ``gcs_path`` string
+        pointing at the file in Google Cloud Storage. We match on that specific
+        shape — not merely the presence of a ``gcs_path`` key — so an unrelated
+        list-of-dicts answer can't be mistaken for a file upload.
+        """
+        return (
+            isinstance(value, list)
+            and len(value) > 0
+            and all(
+                isinstance(v, dict)
+                and v.get("type") == "gcs"
+                and isinstance(v.get("gcs_path"), str)
+                and bool(v.get("gcs_path"))
+                for v in value
+            )
+        )
+
+    def _restore_upload_answers(self, current_answers: dict) -> dict:
+        """Realize raw file-upload answers into FileStores for piping.
+
+        Downstream questions that pipe a file-upload answer ({{ upload.answer }})
+        need real FileStore objects so the uploaded file can be attached to the
+        model. We realize them here, in the durable render layer, and cache each
+        file by gcs_path so a file referenced by several questions is downloaded
+        from Coop only once per job. The stored answer (in the AnswerStore) is left
+        untouched as the raw gcs reference; only the in-flight copy is enriched.
+        """
+        if not current_answers:
+            return current_answers
+
+        from ..scenarios import FileStore
+        from ..scenarios.file_store_list import FileStoreList
+
+        modified = dict(current_answers)
+        for key, value in current_answers.items():
+            if not self._is_file_upload_answer(value):
+                continue
+            file_stores = []
+            for file_info in value:
+                gcs_path = file_info["gcs_path"]
+                fs = self._upload_file_cache.get(gcs_path)
+                if fs is None:
+                    fs = FileStore.from_file_upload_answer(file_info)
+                    self._upload_file_cache[gcs_path] = fs
+                file_stores.append(fs)
+            modified[key] = FileStoreList(data=file_stores)
         return modified
 
     def _apply_option_permutation(
@@ -239,6 +297,10 @@ class RenderService:
         """Use EDSL's PromptConstructor to render the prompts."""
         import time as _t
 
+        # Realize any file-upload answers into FileStores (cached by gcs_path) so
+        # they can be piped into and attached to this question.
+        current_answers = self._restore_upload_answers(current_answers)
+
         # Reconstruct EDSL objects with timing
         _t0 = _t.time()
         scenario = (
@@ -348,6 +410,10 @@ class RenderService:
     ) -> dict[str, str]:
         """Render prompts using pre-built EDSL objects (avoids redundant from_dict)."""
         import time as _t
+
+        # Realize any file-upload answers into FileStores (cached by gcs_path) so
+        # they can be piped into and attached to this question.
+        current_answers = self._restore_upload_answers(current_answers)
 
         _t0 = _t.time()
         prompt_constructor = PromptConstructor(

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -153,7 +153,14 @@ class RenderService:
                 gcs_path = file_info["gcs_path"]
                 fs = self._upload_file_cache.get(gcs_path)
                 if fs is None:
-                    fs = FileStore.from_file_upload_answer(file_info)
+                    try:
+                        fs = FileStore.from_file_upload_answer(file_info)
+                    except Exception as e:
+                        # Fail loud (and retryable) rather than silently dropping a
+                        # referenced file and rendering a prompt without it.
+                        raise RuntimeError(
+                            f"Failed to fetch file-upload answer for question '{key}'."
+                        ) from e
                     self._upload_file_cache[gcs_path] = fs
                 file_stores.append(fs)
             modified[key] = FileStoreList(data=file_stores)

--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -861,18 +861,24 @@ class FileStore(Scenario):
         cls,
         file_info: dict,
         expected_parrot_url: Optional[str] = None,
+        download_url: Optional[str] = None,
     ) -> "FileStore":
         """
         Create a FileStore from a single entry in a QuestionFileUpload answer.
 
-        Calls the Coop endpoint to obtain a signed download URL, then fetches
-        the file and wraps it in a FileStore.
+        By default this calls the Coop endpoint to obtain a signed download URL,
+        then fetches the file and wraps it in a FileStore. A caller that already
+        has bucket access (e.g. the backend) can pass ``download_url`` to skip the
+        Coop round-trip and fetch the file directly.
 
         Args:
             file_info: A dict with at minimum a 'gcs_path' key, as returned in
                        the answer list for a QuestionFileUpload question.
                        Optionally includes 'name', 'mime_type', and 'extension'.
             expected_parrot_url: Optional override for the Coop server URL.
+            download_url: Optional pre-obtained download URL. When provided, the
+                       Coop signed-URL request is skipped and the file is fetched
+                       from this URL directly.
 
         Returns:
             FileStore: The downloaded file.
@@ -883,21 +889,22 @@ class FileStore(Scenario):
             for file_info in answer:
                 fs = FileStore.from_file_upload_answer(file_info)
         """
-        from ..coop import Coop
+        if download_url is None:
+            from ..coop import Coop
 
-        coop = Coop(url=expected_parrot_url) if expected_parrot_url else Coop()
-        response = coop._send_server_request(
-            uri="api/v0/human-survey-file-uploads/download-url",
-            method="POST",
-            payload={"gcs_path": file_info["gcs_path"]},
-        )
-        response.raise_for_status()
-        response_data = response.json()
-        download_url = response_data.get("url")
-        if not download_url:
-            raise ValueError(
-                f"Server did not return a download URL. Response: {response_data}"
+            coop = Coop(url=expected_parrot_url) if expected_parrot_url else Coop()
+            response = coop._send_server_request(
+                uri="api/v0/human-survey-file-uploads/download-url",
+                method="POST",
+                payload={"gcs_path": file_info["gcs_path"]},
             )
+            response.raise_for_status()
+            response_data = response.json()
+            download_url = response_data.get("url")
+            if not download_url:
+                raise ValueError(
+                    f"Server did not return a download URL. Response: {response_data}"
+                )
 
         # Save under the original filename in a fresh temp dir so the suffix is
         # correct and there's no collision if the same name appears in multiple uploads.

--- a/tests/invigilators/test_prior_answer_files.py
+++ b/tests/invigilators/test_prior_answer_files.py
@@ -1,0 +1,306 @@
+"""Tests for piping prior-answer files into a question's attachments.
+
+Covers the index-aware ``prior_answer_files`` path in the PromptConstructor
+(``{{ up.answer }}`` attaches all files, ``{{ up.answer[i] }}`` attaches one),
+the placeholder that keeps raw file data out of the rendered text, the shape
+detection used to recognize a raw QuestionFileUpload answer, and the
+``download_url`` shortcut on ``FileStore.from_file_upload_answer``.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from edsl.agents import Agent
+from edsl.invigilators.prompt_constructor import (
+    PromptConstructor,
+    _FileRefPlaceholder,
+    _referenced_file_indices,
+)
+from edsl.language_models.model import Model
+from edsl.questions import QuestionFileUpload, QuestionFreeText
+from edsl.scenarios import FileStore, Scenario
+from edsl.scenarios.file_store_list import FileStoreList
+from edsl.surveys import Survey
+from edsl.surveys.memory import MemoryPlan
+
+
+class TestReferencedFileIndices(unittest.TestCase):
+    """The pure regex helper that decides which files a text references."""
+
+    def test_bare_reference_attaches_all(self):
+        self.assertEqual(
+            _referenced_file_indices("Describe {{ up.answer }}", "up"),
+            (True, set()),
+        )
+
+    def test_single_index(self):
+        self.assertEqual(
+            _referenced_file_indices("Look at {{ up.answer[0] }}", "up"),
+            (False, {0}),
+        )
+
+    def test_multiple_indices(self):
+        attach_all, indices = _referenced_file_indices(
+            "{{ up.answer[0] }} and {{ up.answer[2] }}", "up"
+        )
+        self.assertFalse(attach_all)
+        self.assertEqual(indices, {0, 2})
+
+    def test_whole_and_indexed_together_attaches_all(self):
+        attach_all, indices = _referenced_file_indices(
+            "{{ up.answer }} but especially {{ up.answer[1] }}", "up"
+        )
+        self.assertTrue(attach_all)
+        self.assertEqual(indices, {1})
+
+    def test_dynamic_subscript_defaults_to_all(self):
+        # A non-integer subscript can't be resolved statically -> attach all.
+        self.assertEqual(
+            _referenced_file_indices("{{ up.answer[i] }}", "up"),
+            (True, set()),
+        )
+
+    def test_whitespace_inside_subscript(self):
+        self.assertEqual(
+            _referenced_file_indices("{{ up.answer [ 3 ] }}", "up"),
+            (False, {3}),
+        )
+
+    def test_word_boundary_does_not_bleed_across_names(self):
+        # Name "up" must not pick up "upload"'s subscript.
+        attach_all, indices = _referenced_file_indices("{{ upload.answer[3] }}", "up")
+        self.assertEqual(indices, set())
+        # And the longer name resolves its own index.
+        self.assertEqual(
+            _referenced_file_indices("{{ upload.answer[3] }}", "upload"),
+            (False, {3}),
+        )
+
+
+class TestFileRefPlaceholder(unittest.TestCase):
+    """The str subclass that renders <see file ...> for whole and indexed refs."""
+
+    def test_str_is_whole_placeholder(self):
+        self.assertEqual(str(_FileRefPlaceholder("up")), "<see file up>")
+
+    def test_subscript_is_indexed_placeholder(self):
+        self.assertEqual(_FileRefPlaceholder("up")[0], "<see file up[0]>")
+
+    def test_json_serializes_as_string(self):
+        import json
+
+        self.assertEqual(json.dumps(_FileRefPlaceholder("up")), '"<see file up>"')
+
+    def test_renders_through_sandboxed_jinja(self):
+        # The real render path uses a SandboxedEnvironment; confirm it dispatches
+        # __str__ and __getitem__ on the str subclass rather than blocking them.
+        from jinja2.sandbox import SandboxedEnvironment
+
+        env = SandboxedEnvironment()
+        ph = _FileRefPlaceholder("up")
+        self.assertEqual(env.from_string("{{ x }}").render(x=ph), "<see file up>")
+        self.assertEqual(env.from_string("{{ x[0] }}").render(x=ph), "<see file up[0]>")
+
+
+class TestPriorAnswerFileStores(unittest.TestCase):
+    """The helper that turns a prior answer into a list of FileStores (or [])."""
+
+    def setUp(self):
+        self._paths = []
+        self.fs = self._make_filestore(b"contents")
+
+    def tearDown(self):
+        for p in self._paths:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    def _make_filestore(self, content, suffix=".txt"):
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        f.write(content)
+        f.close()
+        self._paths.append(f.name)
+        return FileStore(f.name)
+
+    def test_single_filestore(self):
+        self.assertEqual(
+            PromptConstructor._prior_answer_file_stores(self.fs), [self.fs]
+        )
+
+    def test_file_store_list(self):
+        fsl = FileStoreList(data=[self.fs])
+        self.assertEqual(
+            PromptConstructor._prior_answer_file_stores(fsl), list(fsl.data)
+        )
+
+    def test_plain_list_of_filestores(self):
+        self.assertEqual(
+            PromptConstructor._prior_answer_file_stores([self.fs]), [self.fs]
+        )
+
+    def test_non_file_values_return_empty(self):
+        for value in ("just text", [], None, {"gcs_path": "x"}):
+            self.assertEqual(PromptConstructor._prior_answer_file_stores(value), [])
+
+
+class TestPriorAnswerFiles(unittest.TestCase):
+    """End-to-end: a question that pipes a prior file-upload answer."""
+
+    def setUp(self):
+        self._paths = []
+        self.fs1 = self._make_filestore(b"file one")
+        self.fs2 = self._make_filestore(b"file two")
+
+    def tearDown(self):
+        for p in self._paths:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    def _make_filestore(self, content, suffix=".txt"):
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        f.write(content)
+        f.close()
+        self._paths.append(f.name)
+        return FileStore(f.name)
+
+    def _make_constructor(self, question_text, current_answers):
+        # Fresh objects each call: prior_answer_files mutates the survey's
+        # canonical question objects, so tests must not share a survey.
+        up = QuestionFileUpload(question_name="up", question_text="Upload a file.")
+        q = QuestionFreeText(question_name="q1", question_text=question_text)
+        survey = Survey([up, q])
+        return PromptConstructor(
+            agent=Agent(),
+            question=q,
+            scenario=Scenario(),
+            survey=survey,
+            model=Model(),
+            current_answers=current_answers,
+            memory_plan=MemoryPlan(survey=survey),
+        )
+
+    def test_whole_reference_attaches_all_files(self):
+        fsl = FileStoreList(data=[self.fs1, self.fs2])
+        c = self._make_constructor("Describe {{ up.answer }}", {"up": fsl})
+        self.assertEqual(c.prior_answer_files, list(fsl.data))
+
+    def test_indexed_reference_attaches_only_that_file(self):
+        fsl = FileStoreList(data=[self.fs1, self.fs2])
+        c = self._make_constructor("Look at {{ up.answer[0] }}", {"up": fsl})
+        self.assertEqual(c.prior_answer_files, [list(fsl.data)[0]])
+
+    def test_out_of_range_index_attaches_nothing(self):
+        fsl = FileStoreList(data=[self.fs1, self.fs2])
+        c = self._make_constructor("Look at {{ up.answer[5] }}", {"up": fsl})
+        self.assertEqual(c.prior_answer_files, [])
+
+    def test_text_answer_is_not_attached(self):
+        c = self._make_constructor("You said {{ up.answer }}", {"up": "some text"})
+        self.assertEqual(c.prior_answer_files, [])
+
+    def test_no_reference_attaches_nothing(self):
+        fsl = FileStoreList(data=[self.fs1])
+        c = self._make_constructor("No piping here.", {"up": fsl})
+        self.assertEqual(c.prior_answer_files, [])
+
+    def test_placeholder_replaces_answer_text(self):
+        fsl = FileStoreList(data=[self.fs1])
+        c = self._make_constructor("Describe {{ up.answer }}", {"up": fsl})
+        _ = c.prior_answer_files  # triggers the placeholder swap
+        self.assertEqual(str(c.prior_answers_dict()["up"].answer), "<see file up>")
+
+    def test_get_prompts_attaches_files_and_hides_metadata(self):
+        fsl = FileStoreList(data=[self.fs1, self.fs2])
+        c = self._make_constructor("Describe {{ up.answer }}", {"up": fsl})
+        prompts = c.get_prompts()
+        self.assertEqual(prompts.get("files_list", []), list(fsl.data))
+        # The placeholder is in the text; the raw file value is not.
+        self.assertIn("<see file up>", prompts["user_prompt"].text)
+
+
+class TestIsFileUploadAnswer(unittest.TestCase):
+    """The tightened shape check used to recognize a raw file-upload answer."""
+
+    @staticmethod
+    def _check(value):
+        from edsl.runner.render import RenderService
+
+        return RenderService._is_file_upload_answer(value)
+
+    def test_valid_answer(self):
+        self.assertTrue(self._check([{"type": "gcs", "gcs_path": "users/x/f"}]))
+
+    def test_missing_type_rejected(self):
+        self.assertFalse(self._check([{"gcs_path": "users/x/f"}]))
+
+    def test_missing_gcs_path_rejected(self):
+        self.assertFalse(self._check([{"type": "gcs"}]))
+
+    def test_empty_gcs_path_rejected(self):
+        self.assertFalse(self._check([{"type": "gcs", "gcs_path": ""}]))
+
+    def test_non_list_rejected(self):
+        self.assertFalse(self._check("users/x/f"))
+
+    def test_empty_list_rejected(self):
+        self.assertFalse(self._check([]))
+
+    def test_mixed_list_rejected(self):
+        self.assertFalse(
+            self._check([{"type": "gcs", "gcs_path": "users/x/f"}, "not a dict"])
+        )
+
+
+class TestFromFileUploadAnswerDownloadUrl(unittest.TestCase):
+    """The download_url shortcut that skips the Coop round-trip."""
+
+    def test_download_url_skips_coop(self):
+        file_info = {
+            "type": "gcs",
+            "gcs_path": "users/x/f",
+            "name": "receipt.txt",
+            "mime_type": "text/plain",
+        }
+        sentinel = object()
+        with patch.object(
+            FileStore, "from_url", return_value=sentinel
+        ) as mock_from_url, patch("edsl.coop.Coop") as mock_coop:
+            result = FileStore.from_file_upload_answer(
+                file_info, download_url="http://signed.example/f"
+            )
+
+        self.assertIs(result, sentinel)
+        mock_coop.assert_not_called()
+        # The provided URL is what gets fetched.
+        self.assertEqual(mock_from_url.call_args.args[0], "http://signed.example/f")
+
+
+class TestRestoreUploadAnswersError(unittest.TestCase):
+    """A download failure names the question, not the gcs_path, and stays loud."""
+
+    def test_failure_names_key_not_path(self):
+        from edsl.runner.render import RenderService
+        from edsl.runner.storage import InMemoryStorage
+
+        service = RenderService(InMemoryStorage())
+        current_answers = {
+            "receipt": [{"type": "gcs", "gcs_path": "users/secret/path"}]
+        }
+        with patch.object(
+            FileStore, "from_file_upload_answer", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                service._restore_upload_answers(current_answers)
+
+        message = str(ctx.exception)
+        self.assertIn("receipt", message)
+        self.assertNotIn("users/secret/path", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/invigilators/test_prior_answer_files.py
+++ b/tests/invigilators/test_prior_answer_files.py
@@ -78,6 +78,13 @@ class TestReferencedFileIndices(unittest.TestCase):
             (False, {3}),
         )
 
+    def test_bare_name_without_answer_is_not_a_file_reference(self):
+        # Referencing the question but not its .answer must not attach anything.
+        self.assertEqual(
+            _referenced_file_indices("Describe {{ up }}", "up"),
+            (False, set()),
+        )
+
 
 class TestFileRefPlaceholder(unittest.TestCase):
     """The str subclass that renders <see file ...> for whole and indexed refs."""
@@ -207,6 +214,15 @@ class TestPriorAnswerFiles(unittest.TestCase):
         fsl = FileStoreList(data=[self.fs1])
         c = self._make_constructor("No piping here.", {"up": fsl})
         self.assertEqual(c.prior_answer_files, [])
+
+    def test_bare_reference_without_answer_attaches_nothing(self):
+        # A bare {{ up }} (no .answer) must not attach files or rewrite the answer.
+        fsl = FileStoreList(data=[self.fs1, self.fs2])
+        c = self._make_constructor("Describe {{ up }}", {"up": fsl})
+        self.assertEqual(c.prior_answer_files, [])
+        self.assertNotIsInstance(
+            c.prior_answers_dict()["up"].answer, _FileRefPlaceholder
+        )
 
     def test_placeholder_replaces_answer_text(self):
         fsl = FileStoreList(data=[self.fs1])


### PR DESCRIPTION
This enables piping humanize file uploads into thinking questions, which can then be used to parse the files and ask the respondent further questions.