### PR TITLE
Guard skip_question_before_running against undefined variables

### DIFF
--- a/.github/workflows/coopr_tests.yml
+++ b/.github/workflows/coopr_tests.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Run Docker Compose
         run: |
           cd /home/stefan/expectedparrot/coopr
-          docker compose up --build --wait
+          # Scale voice-agent to 0: the LiveKit agent has no healthcheck and
+          # exits (0) in CI (no LiveKit backend to attach to), and `--wait`
+          # treats any container stopping mid-wait as a failure -> exit 1,
+          # failing the build before make test-coop even runs. Nothing
+          # depends_on voice-agent, so skipping it is safe.
+          docker compose up --build --wait --scale voice-agent=0
 
       - name: Fetch and checkout last commit in EDSL
         run: |

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -283,9 +283,9 @@ class RenderService:
                     current_answers[other_task.question_name] = answer.answer
                     # Include comment for piping ({{ qname.comment }})
                     if answer.comment:
-                        current_answers[f"{other_task.question_name}_comment"] = (
-                            answer.comment
-                        )
+                        current_answers[
+                            f"{other_task.question_name}_comment"
+                        ] = answer.comment
 
         return current_answers
 
@@ -770,16 +770,45 @@ class RenderWorker:
                 ops_counter["skip_task_calls"] += 1
 
                 _t_skip = _time.time()
-                should_skip, skip_reason = self._job_service.should_skip_task(
-                    job_id,
-                    interview_id,
-                    task_id,
-                    debug=False,  # Reduce noise
-                    cached_survey=cached_survey,
-                    cached_question_index_map=cached_question_index_map,
-                    cached_answers=cached_answers,
-                    cached_task_def=task_def,
-                )
+                try:
+                    should_skip, skip_reason = self._job_service.should_skip_task(
+                        job_id,
+                        interview_id,
+                        task_id,
+                        debug=False,  # Reduce noise
+                        cached_survey=cached_survey,
+                        cached_question_index_map=cached_question_index_map,
+                        cached_answers=cached_answers,
+                        cached_task_def=task_def,
+                    )
+                except Exception as skip_exc:
+                    # Defense-in-depth: skip-rule evaluation must never take down
+                    # the whole render batch. Without this guard an exception here
+                    # (e.g. a survey rule referencing an undefined variable) unwinds
+                    # the entire task loop — no task is marked FAILED and the job
+                    # freezes until the stall watchdog force-fails it with no usable
+                    # error. Instead, fail *this* task permanently with the real
+                    # error and keep rendering the rest of the batch. The failure is
+                    # deterministic (same inputs render the same crash), so retrying
+                    # is pointless -> force_permanent=True.
+                    import traceback
+
+                    print(
+                        f"  [render] should_skip_task raised for task {task_id} "
+                        f"(interview {interview_id}); failing this task and "
+                        f"continuing render: {type(skip_exc).__name__}: {skip_exc}"
+                    )
+                    traceback.print_exc()
+                    self._job_service.on_task_failed(
+                        job_id,
+                        interview_id,
+                        task_id,
+                        error_type=type(skip_exc).__name__,
+                        error_message=f"Skip-rule evaluation failed: {skip_exc}",
+                        force_permanent=True,
+                    )
+                    _skip_logic_time += _time.time() - _t_skip
+                    continue
                 _skip_logic_time += _time.time() - _t_skip
                 if should_skip:
                     self._job_service.on_task_skipped(
@@ -869,14 +898,14 @@ class RenderWorker:
         # Instead of checking ALL interview tasks, only fetch answers for actual dependencies
         # This reduces O(n) to O(d) where d = number of dependencies (usually small)
         _t0 = _time.time()
-        answers_cache: dict[str, dict[str, Any]] = (
-            {}
-        )  # interview_id -> {question_name -> answer}
+        answers_cache: dict[
+            str, dict[str, Any]
+        ] = {}  # interview_id -> {question_name -> answer}
 
         # Collect all dependency task IDs from tasks being rendered
-        dep_task_ids_by_interview: dict[str, set[str]] = (
-            {}
-        )  # interview_id -> set of dependency task_ids
+        dep_task_ids_by_interview: dict[
+            str, set[str]
+        ] = {}  # interview_id -> set of dependency task_ids
         for task_id in tasks_to_render:
             task_def = all_task_defs.get(task_id)
             if task_def and task_def.depends_on:
@@ -980,9 +1009,9 @@ class RenderWorker:
         # Caches for objects that depend on per-task context
         _permuted_questions: dict[tuple, "QuestionBase"] = {}
         _survey_cache: dict[tuple, tuple] = {}
-        _prompt_cache: dict[tuple, dict] = (
-            {}
-        )  # Cache rendered prompts by input combination
+        _prompt_cache: dict[
+            tuple, dict
+        ] = {}  # Cache rendered prompts by input combination
 
         from ..questions import QuestionFreeText as _QuestionFreeText
 

--- a/edsl/surveys/rules/rule_collection.py
+++ b/edsl/surveys/rules/rule_collection.py
@@ -210,10 +210,33 @@ class RuleCollection(UserList):
         >>> rule_collection.add_rule(r)
         >>> rule_collection.skip_question_before_running(1, {})
         False
+
+        A before-rule that references a variable from a question that was
+        itself skipped (and therefore has no answer) cannot be evaluated. Rather
+        than crash the interview, the rule is treated as not applicable, matching
+        the behavior of next_question() and should_stop_survey().
+
+        >>> rule_collection = RuleCollection()
+        >>> r = Rule(current_q=1, expression="{{ q_skipped.answer }} == 'Yes'", next_q=2, priority=1, question_name_to_index={'q_skipped': 0}, before_rule = True)
+        >>> rule_collection.add_rule(r)
+        >>> rule_collection.skip_question_before_running(1, {})
+        False
         """
         for rule in self.applicable_rules(q_now, before_rule=True):
-            if rule.evaluate(answers):
-                return True
+            try:
+                if rule.evaluate(answers):
+                    return True
+            except SurveyRuleCannotEvaluateError as e:
+                # Handle undefined variable errors gracefully, consistent with
+                # next_question() and should_stop_survey(). A before-rule (skip
+                # rule) can reference a variable from a question that was itself
+                # skipped, leaving its answer undefined. Rather than crashing the
+                # whole interview, treat this rule as not applicable (i.e. it does
+                # not force a skip).
+                if "is undefined" in str(e):
+                    continue
+                # Re-raise genuine evaluation errors (syntax/type errors, etc.)
+                raise
         return False
 
     def applicable_rules(self, q_now: int, before_rule: bool = False) -> list:


### PR DESCRIPTION
## Problem

A **before-rule** (skip rule) can reference a variable from a question that was itself conditionally skipped, so its answer is undefined. When the expression accesses `{{ q.answer }}`, Jinja's `Undefined.__getattr__` raises, surfacing as `SurveyRuleCannotEvaluateError: '<q>' is undefined`.

`RuleCollection.skip_question_before_running()` evaluated its rules **bare** — with no exception guard — so the error propagated out of survey navigation and **froze the interview**. On coopr the frozen job then stalled until the runner's 10-minute watchdog force-failed every task with no usable error ("Unknown error", 0 results).

This reproduced on chick (`1.0.8.dev1`) with a 5-agent / 88-question survey whose skip rule on q73 (`g2a_business_bank`) references `g2_business_account` — itself a conditionally-skipped question:

```
{{ d3_employment.answer }} != 'Self-employed / ...' or {{ g2_business_account.answer }} != 'Yes - a dedicated business account'
```

Because Jinja renders the whole template before Python evaluates `or`, the undefined right-hand side crashes even when the left side would short-circuit.

## Fix

`next_question()` and `should_stop_survey()` in the same file **already** catch `SurveyRuleCannotEvaluateError` and treat an unevaluable rule as not applicable. This mirrors that established guard in `skip_question_before_running()`: on an "is undefined" error, skip the offending before-rule (it does not force a skip) and continue; genuine syntax/type errors are still re-raised.

Adds doctests covering the undefined-variable case. All 41 doctests in the module pass.

## Deployment note

coopr bakes edsl at a pinned git SHA (`backend/pyproject.toml`). chick will keep freezing on this survey until that pin is bumped to a commit containing this fix and chick is redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)