### PR TITLE
CI: skip voice-agent in coopr compose test so --wait doesn't fail

### DIFF
--- a/.github/workflows/coopr_tests.yml
+++ b/.github/workflows/coopr_tests.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Run Docker Compose
         run: |
           cd /home/stefan/expectedparrot/coopr
-          docker compose up --build --wait
+          # Scale voice-agent to 0: the LiveKit agent has no healthcheck and
+          # exits (0) in CI (no LiveKit backend to attach to), and `--wait`
+          # treats any container stopping mid-wait as a failure -> exit 1,
+          # failing the build before make test-coop even runs. Nothing
+          # depends_on voice-agent, so skipping it is safe.
+          docker compose up --build --wait --scale voice-agent=0
 
       - name: Fetch and checkout last commit in EDSL
         run: |


### PR DESCRIPTION
## Problem
The **Run coopr - edsl tests** workflow fails on every edsl PR — not because of the code under test. Its `Run Docker Compose` step runs:

```
docker compose up --build --wait
```

The `voice-agent` service (LiveKit agent, `command: python -m voice_agent.agent dev`) has **no healthcheck and no restart policy**. In CI it starts, finds no LiveKit backend to attach to, and exits `0`. `docker compose up --wait` treats *any* container that stops while it's waiting — even with exit code 0 — as a failure and returns exit 1. The build then fails before `make test-coop` ever runs.

Log evidence:
```
Container coopr-voice-agent-1  Started
Container coopr-voice-agent-1  Waiting
container coopr-voice-agent-1 exited (0)
##[error]Process completed with exit code 1.
```
Every other container (backend, frontend, all runner services, etc.) reached `Healthy`, and the edsl bump applied cleanly (`68e7a44 → 29cdfde`).

## Fix
`--scale voice-agent=0` so the agent isn't started and `--wait` doesn't watch it. Nothing in the compose stack `depends_on` voice-agent, so skipping it is safe and the rest of the stack still comes up healthy for the tests.

A more general alternative (not taken here) would be to add `profiles: ["voice"]` to the service in coopr's `docker-compose.yml`; this workflow-scoped one-liner keeps the change entirely in the edsl repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)