### PR TITLE
Omit temperature for Anthropic models that reject it (Fable 5, Opus 4.7+, Sonnet 5)

### DIFF
--- a/edsl/inference_services/services/anthropic_service.py
+++ b/edsl/inference_services/services/anthropic_service.py
@@ -72,6 +72,29 @@ class AnthropicService(InferenceServiceABC):
         return version == cls._temperature_deprecation_version and family != "opus"
 
     @classmethod
+    def _temperature_unsupported(cls, model_name: str) -> bool:
+        """Return whether this Anthropic model rejects the ``temperature`` parameter.
+
+        Claude Fable 5 / Mythos 5 and the Claude 4.7+/5 generation removed sampling
+        parameters: sending ``temperature`` at all (any value, including 1.0) returns
+        ``400 invalid_request_error``. It must be omitted from the request, not set.
+        """
+        name = model_name.lower()
+        if re.search(r"claude-(fable|mythos)", name):
+            return True
+        version_match = re.search(
+            r"claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)", name
+        )
+        if version_match:
+            version = (int(version_match.group(1)), int(version_match.group(2)))
+            return version >= (4, 7)
+        # Single-number generation ids (e.g. claude-sonnet-5) also reject it.
+        single_version = re.search(r"claude-(?:opus|sonnet|haiku)-(\d+)(?!-?\d)", name)
+        if single_version:
+            return int(single_version.group(1)) >= 5
+        return False
+
+    @classmethod
     def _api_temperature(cls, model_name: str, temperature: float) -> float:
         if cls._requires_temperature_one(model_name):
             return 1.0
@@ -193,10 +216,14 @@ class AnthropicService(InferenceServiceABC):
                 create_kwargs = dict(
                     model=model_name,
                     max_tokens=self.max_tokens,
-                    temperature=cls._api_temperature(model_name, self.temperature),
                     system=system_prompt,  # note that the Anthropic API uses "system" parameter rather than put it in the message
                     messages=messages,
                 )
+                # Fable 5 / Opus 4.7+ / Sonnet 5 reject `temperature` entirely; omit it.
+                if not cls._temperature_unsupported(model_name):
+                    create_kwargs["temperature"] = cls._api_temperature(
+                        model_name, self.temperature
+                    )
                 if self.thinking is not None:
                     create_kwargs["thinking"] = self.thinking
                 if self.output_config is not None:

--- a/tests/inference_services/test_anthropic_service.py
+++ b/tests/inference_services/test_anthropic_service.py
@@ -49,6 +49,56 @@ def test_anthropic_request_uses_temperature_one_for_affected_models(monkeypatch)
     assert model.parameters["temperature"] == 0.2
 
 
+def test_temperature_unsupported_for_fable_and_47_plus():
+    for name in [
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-mythos-preview",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+    ]:
+        assert AnthropicService._temperature_unsupported(name), name
+    for name in [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-opus-4-5-20251124",
+        "claude-haiku-4-5",
+    ]:
+        assert not AnthropicService._temperature_unsupported(name), name
+
+
+def test_anthropic_request_omits_temperature_for_fable(monkeypatch):
+    captured_kwargs = {}
+
+    class DummyResponse:
+        def model_dump(self):
+            return {"content": [{"type": "text", "text": "ok"}]}
+
+    class DummyMessages:
+        async def create(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return DummyResponse()
+
+    class DummyAnthropicClient:
+        def __init__(self, api_key):
+            self.messages = DummyMessages()
+
+    monkeypatch.setattr(
+        "edsl.inference_services.services.anthropic_service.AsyncAnthropic",
+        DummyAnthropicClient,
+    )
+
+    model_class = AnthropicService.create_model("claude-fable-5")
+    model = model_class(temperature=0.2, skip_api_key_check=True)
+
+    asyncio.run(model.async_execute_model_call("hello"))
+
+    # Fable 5 rejects `temperature`; it must be omitted entirely, not set to a value.
+    assert "temperature" not in captured_kwargs
+    assert model.parameters["temperature"] == 0.2  # local parameter is untouched
+
+
 def test_anthropic_request_preserves_temperature_for_legacy_models(monkeypatch):
     captured_kwargs = {}
 


### PR DESCRIPTION
## Problem

Claude **Fable 5** / Mythos 5 and the Claude **4.7+/5** generation removed sampling parameters — sending `temperature` at all (any value, **including `1.0`**) returns:

```
400 invalid_request_error: `temperature` is deprecated for this model.
```

The Anthropic service always put `temperature` in the `messages.create()` call. Its `_requires_temperature_one` guard had two gaps:

1. Its regex only matched `claude-(opus|sonnet|haiku)-N-N`, so **`claude-fable-5` didn't match at all** — Fable got the default `temperature=0.5` and 400'd on every call.
2. Even where it matched (4.7+), it set `temperature=1.0` — but those models reject `temperature` at **any** value; it must be **omitted**, not set.

Net effect: every `claude-fable-5` call (and 4.7+/5 calls) failed with an empty result.

## Fix

Add `_temperature_unsupported(model_name)` and omit `temperature` from the request kwargs for the models that reject it (Fable 5 / Mythos 5 / Opus 4.7+ / Sonnet 5). **Backward compatible** — models that still accept `temperature` are unchanged:

| Model | Before | After |
|---|---|---|
| `claude-fable-5` | `temperature=0.5` → **400** | omitted → ✅ |
| `claude-opus-4-8` / `4-7`, `claude-sonnet-5` | `1.0` (rejected) | omitted → ✅ |
| `claude-sonnet-4-6` | `1.0` | `1.0` (unchanged) |
| `claude-opus-4-5` | passthrough | passthrough (unchanged) |

## Verification

- Unit-level: `_temperature_unsupported` returns the expected classification across Fable/Mythos/4.6/4.7/4.8/5/legacy ids.
- Request-build (mocked client): `temperature` is omitted for `claude-fable-5` and `claude-opus-4-8`, still `1.0` for `claude-sonnet-4-6`, still `0.2` for `claude-opus-4-5`.
- **End-to-end (live Anthropic key, local inference):** `claude-fable-5` returned valid answers — a one-word probe and a 17-scenario digital-twin job producing 17/17 valid probability distributions — where it previously 400'd on every call.
- Added a regression test (`test_temperature_unsupported_for_fable_and_47_plus`, `test_anthropic_request_omits_temperature_for_fable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)