### PR TITLE
Add embeddings support

### DIFF
--- a/edsl/__init__.py
+++ b/edsl/__init__.py
@@ -29,6 +29,10 @@ __all__ = [
     "logger",
     "Config",
     "CONFIG",
+    "EmbeddingCache",
+    "EmbeddingCacheEntry",
+    "EmbeddingModel",
+    "EmbeddingResult",
     "__version__",
     "modify_settings",
     "show_settings",
@@ -42,6 +46,7 @@ _LAZY_MODULES = {
     "questions",
     "scenarios",
     "language_models",
+    "embeddings",
     "results",
     "caching",
     "notebooks",
@@ -88,6 +93,11 @@ _EXPORT_TO_MODULE = {
     "Model": "language_models",
     "ModelList": "language_models",
     "LanguageModel": "language_models",
+    # embeddings
+    "EmbeddingModel": "embeddings",
+    "EmbeddingResult": "embeddings",
+    "EmbeddingCache": "embeddings",
+    "EmbeddingCacheEntry": "embeddings",
     # results
     "Results": "results",
     # dataset

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -4754,6 +4754,7 @@ class Coop(CoopFunctionsMixin):
         }
         async with aiohttp.ClientSession() as session:
             async with session.post(url, json=data, headers=self.headers) as response:
+                response.raise_for_status()
                 return await response.json()
 
     def web(

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -4746,6 +4746,16 @@ class Coop(CoopFunctionsMixin):
                 response_data = await response.json()
         return response_data
 
+    async def remote_async_embed(self, model_dict: dict, inputs: List[str]) -> dict:
+        url = self.api_url + "/embeddings/"
+        data = {
+            "model_dict": model_dict,
+            "input": inputs,
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=data, headers=self.headers) as response:
+                return await response.json()
+
     def web(
         self,
         survey: dict,

--- a/edsl/dataset/dataset.py
+++ b/edsl/dataset/dataset.py
@@ -227,6 +227,21 @@ class Dataset(UserList, DatasetOperationsMixin, PersistenceMixin, HashingMixin):
         """
         return self.to_scenario_list().collapse(field, separator).to_dataset()
 
+    def embed(
+        self,
+        field: str,
+        *,
+        model: Optional[Any] = None,
+        output_field: str = "embedding",
+        cache: Optional[Any] = None,
+    ) -> "Dataset":
+        """Embed a text column and return a Dataset with an embedding column."""
+        return (
+            self.to_scenario_list()
+            .embed(field, model=model, output_field=output_field, cache=cache)
+            .to_dataset()
+        )
+
     def long(self, *args, exclude_fields: Union[list[str], str] = None) -> Dataset:
         """Convert the dataset from wide to long format.
 

--- a/edsl/embeddings/__init__.py
+++ b/edsl/embeddings/__init__.py
@@ -1,0 +1,23 @@
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .embedding_cache import EmbeddingCache, EmbeddingCacheEntry
+    from .embedding_model import EmbeddingModel
+    from .embedding_result import EmbeddingResult
+
+__all__ = ["EmbeddingCache", "EmbeddingCacheEntry", "EmbeddingModel", "EmbeddingResult"]
+
+_LAZY_IMPORTS = {
+    "EmbeddingCache": ".embedding_cache",
+    "EmbeddingCacheEntry": ".embedding_cache",
+    "EmbeddingModel": ".embedding_model",
+    "EmbeddingResult": ".embedding_result",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module = importlib.import_module(_LAZY_IMPORTS[name], package="edsl.embeddings")
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/edsl/embeddings/embedding_cache.py
+++ b/edsl/embeddings/embedding_cache.py
@@ -123,13 +123,20 @@ class EmbeddingCache:
             usage=usage,
         )
         key = entry.key
+        self.data[key] = entry
         self.new_entries[key] = entry
         if self.immediate_write:
-            self.data[key] = entry
-            if self.filename:
-                with open(self.filename, "a", encoding="utf-8") as f:
-                    f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+            self.flush()
         return key
+
+    def flush(self) -> None:
+        if not self.new_entries:
+            return
+        if self.filename:
+            with open(self.filename, "a", encoding="utf-8") as f:
+                for entry in self.new_entries.values():
+                    f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+        self.new_entries.clear()
 
     def keys(self) -> list[str]:
         return list(self.data.keys())

--- a/edsl/embeddings/embedding_cache.py
+++ b/edsl/embeddings/embedding_cache.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class EmbeddingCacheEntry:
+    service_name: str
+    model: str
+    parameters: dict[str, Any]
+    input: str
+    embedding: list[float]
+    usage: Optional[dict[str, Any]] = None
+    timestamp: Optional[int] = None
+
+    @classmethod
+    def gen_key(
+        cls,
+        *,
+        service_name: str,
+        model: str,
+        parameters: dict[str, Any],
+        input: str,
+    ) -> str:
+        payload = {
+            "service_name": service_name,
+            "model": model,
+            "parameters": parameters,
+            "input": input,
+        }
+        return hashlib.md5(
+            json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()
+        ).hexdigest()
+
+    @property
+    def key(self) -> str:
+        return self.gen_key(
+            service_name=self.service_name,
+            model=self.model,
+            parameters=self.parameters,
+            input=self.input,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "service_name": self.service_name,
+            "model": self.model,
+            "parameters": self.parameters,
+            "input": self.input,
+            "embedding": self.embedding,
+            "usage": self.usage,
+            "timestamp": self.timestamp
+            or int(datetime.datetime.now(datetime.timezone.utc).timestamp()),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmbeddingCacheEntry":
+        return cls(**data)
+
+
+class EmbeddingCache:
+    def __init__(
+        self,
+        *,
+        filename: Optional[str] = None,
+        data: Optional[dict[str, EmbeddingCacheEntry]] = None,
+        immediate_write: bool = True,
+    ):
+        if filename and data is not None:
+            raise ValueError("Cannot provide both filename and data.")
+        self.filename = filename
+        self.immediate_write = immediate_write
+        self.data: dict[str, EmbeddingCacheEntry] = data or {}
+        self.new_entries: dict[str, EmbeddingCacheEntry] = {}
+        if filename and os.path.exists(filename):
+            self._load_jsonl(filename)
+
+    def _load_jsonl(self, filename: str) -> None:
+        with open(filename, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                entry = EmbeddingCacheEntry.from_dict(json.loads(line))
+                self.data[entry.key] = entry
+
+    def fetch(
+        self,
+        *,
+        service_name: str,
+        model: str,
+        parameters: dict[str, Any],
+        input: str,
+    ) -> tuple[Optional[EmbeddingCacheEntry], str]:
+        key = EmbeddingCacheEntry.gen_key(
+            service_name=service_name,
+            model=model,
+            parameters=parameters,
+            input=input,
+        )
+        return self.data.get(key), key
+
+    def store(
+        self,
+        *,
+        service_name: str,
+        model: str,
+        parameters: dict[str, Any],
+        input: str,
+        embedding: list[float],
+        usage: Optional[dict[str, Any]] = None,
+    ) -> str:
+        entry = EmbeddingCacheEntry(
+            service_name=service_name,
+            model=model,
+            parameters=parameters,
+            input=input,
+            embedding=embedding,
+            usage=usage,
+        )
+        key = entry.key
+        self.new_entries[key] = entry
+        if self.immediate_write:
+            self.data[key] = entry
+            if self.filename:
+                with open(self.filename, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+        return key
+
+    def keys(self) -> list[str]:
+        return list(self.data.keys())
+
+    def __len__(self) -> int:
+        return len(self.data)

--- a/edsl/embeddings/embedding_model.py
+++ b/edsl/embeddings/embedding_model.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+from .embedding_cache import EmbeddingCache
+from .embedding_result import EmbeddingResult
+from .services import get_embedding_service
+from ..utilities import jupyter_nb_handler
+
+
+class EmbeddingModel:
+    default_model_by_service = {
+        "openai": "text-embedding-3-small",
+        "sentence_transformers": "all-MiniLM-L6-v2",
+        "test": "test",
+    }
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        service_name: str = "openai",
+        *,
+        dimensions: Optional[int] = None,
+        remote: bool = False,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **parameters: Any,
+    ):
+        self.service_name = service_name.replace("-", "_")
+        self.model = model_name or self.default_model_by_service.get(self.service_name)
+        if self.model is None:
+            raise ValueError(f"No default embedding model for service '{service_name}'.")
+        self.remote = remote
+        self.api_key = api_key
+        self.base_url = base_url
+        self.parameters = {"dimensions": dimensions, **parameters}
+
+    @staticmethod
+    def _normalize_inputs(input: Union[str, list[str]]) -> tuple[list[str], bool]:
+        if isinstance(input, str):
+            return [input], True
+        if not isinstance(input, list) or not all(isinstance(item, str) for item in input):
+            raise TypeError("Embedding input must be a string or list of strings.")
+        return input, False
+
+    async def async_embed(
+        self,
+        input: Union[str, list[str]],
+        *,
+        cache: Optional[EmbeddingCache] = None,
+    ) -> EmbeddingResult:
+        inputs, _ = self._normalize_inputs(input)
+        embeddings: list[Optional[list[float]]] = [None] * len(inputs)
+        cache_keys: list[Optional[str]] = [None] * len(inputs)
+        cache_used = [False] * len(inputs)
+        uncached_inputs: list[str] = []
+        uncached_positions: list[int] = []
+
+        cache_parameters = {k: v for k, v in self.parameters.items() if v is not None}
+        if cache is not None:
+            for index, text in enumerate(inputs):
+                entry, key = cache.fetch(
+                    service_name=self.service_name,
+                    model=self.model,
+                    parameters=cache_parameters,
+                    input=text,
+                )
+                cache_keys[index] = key
+                if entry is None:
+                    uncached_inputs.append(text)
+                    uncached_positions.append(index)
+                else:
+                    embeddings[index] = entry.embedding
+                    cache_used[index] = True
+        else:
+            uncached_inputs = list(inputs)
+            uncached_positions = list(range(len(inputs)))
+
+        usage = None
+        if uncached_inputs:
+            if self.remote:
+                from edsl.coop import Coop
+
+                result = await Coop().remote_async_embed(self.to_dict(), uncached_inputs)
+                new_embeddings = result["embeddings"]
+                usage = result.get("usage")
+            else:
+                service = get_embedding_service(
+                    self.service_name, api_key=self.api_key, base_url=self.base_url
+                )
+                new_embeddings, usage = await service.async_embed(
+                    model=self.model,
+                    inputs=uncached_inputs,
+                    parameters=cache_parameters,
+                )
+
+            for position, text, vector in zip(
+                uncached_positions, uncached_inputs, new_embeddings
+            ):
+                embeddings[position] = vector
+                if cache is not None:
+                    cache_keys[position] = cache.store(
+                        service_name=self.service_name,
+                        model=self.model,
+                        parameters=cache_parameters,
+                        input=text,
+                        embedding=vector,
+                        usage=usage,
+                    )
+
+        return EmbeddingResult(
+            embeddings=[vector for vector in embeddings if vector is not None],
+            input=inputs,
+            model=self.model,
+            service_name=self.service_name,
+            dimensions=len(embeddings[0]) if embeddings and embeddings[0] else None,
+            usage=usage,
+            cache_keys=[key for key in cache_keys],
+            cache_used=cache_used,
+        )
+
+    @jupyter_nb_handler
+    def embed(
+        self,
+        input: Union[str, list[str]],
+        *,
+        cache: Optional[EmbeddingCache] = None,
+    ) -> EmbeddingResult:
+        async def main():
+            return await self.async_embed(input, cache=cache)
+
+        return main()
+
+    def to_dict(self, add_edsl_version: bool = True) -> dict[str, Any]:
+        data = {
+            "model": self.model,
+            "service_name": self.service_name,
+            "parameters": self.parameters,
+            "remote": self.remote,
+        }
+        if add_edsl_version:
+            from edsl import __version__
+
+            data["edsl_version"] = __version__
+            data["edsl_class_name"] = self.__class__.__name__
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmbeddingModel":
+        data = dict(data)
+        data.pop("edsl_version", None)
+        data.pop("edsl_class_name", None)
+        parameters = data.pop("parameters", {})
+        model = data.pop("model")
+        service_name = data.pop("service_name")
+        return cls(model, service_name=service_name, **parameters, **data)
+
+    def __repr__(self) -> str:
+        params = {k: v for k, v in self.parameters.items() if v is not None}
+        return (
+            f"EmbeddingModel(model_name={self.model!r}, "
+            f"service_name={self.service_name!r}, parameters={params!r})"
+        )

--- a/edsl/embeddings/embedding_model.py
+++ b/edsl/embeddings/embedding_model.py
@@ -10,7 +10,7 @@ from ..utilities import jupyter_nb_handler
 
 class EmbeddingModel:
     default_model_by_service = {
-        "openai": "text-embedding-3-small",
+        "openai": "text-embedding-3-large",
         "sentence_transformers": "all-MiniLM-L6-v2",
         "test": "test",
     }
@@ -29,7 +29,9 @@ class EmbeddingModel:
         self.service_name = service_name.replace("-", "_")
         self.model = model_name or self.default_model_by_service.get(self.service_name)
         if self.model is None:
-            raise ValueError(f"No default embedding model for service '{service_name}'.")
+            raise ValueError(
+                f"No default embedding model for service '{service_name}'."
+            )
         self.remote = remote
         self.api_key = api_key
         self.base_url = base_url
@@ -39,7 +41,9 @@ class EmbeddingModel:
     def _normalize_inputs(input: Union[str, list[str]]) -> tuple[list[str], bool]:
         if isinstance(input, str):
             return [input], True
-        if not isinstance(input, list) or not all(isinstance(item, str) for item in input):
+        if not isinstance(input, list) or not all(
+            isinstance(item, str) for item in input
+        ):
             raise TypeError("Embedding input must be a string or list of strings.")
         return input, False
 
@@ -81,7 +85,9 @@ class EmbeddingModel:
             if self.remote:
                 from edsl.coop import Coop
 
-                result = await Coop().remote_async_embed(self.to_dict(), uncached_inputs)
+                result = await Coop().remote_async_embed(
+                    self.to_dict(), uncached_inputs
+                )
                 if "embeddings" not in result:
                     raise ValueError(
                         "Remote embedding response did not include embeddings."

--- a/edsl/embeddings/embedding_model.py
+++ b/edsl/embeddings/embedding_model.py
@@ -82,6 +82,10 @@ class EmbeddingModel:
                 from edsl.coop import Coop
 
                 result = await Coop().remote_async_embed(self.to_dict(), uncached_inputs)
+                if "embeddings" not in result:
+                    raise ValueError(
+                        "Remote embedding response did not include embeddings."
+                    )
                 new_embeddings = result["embeddings"]
                 usage = result.get("usage")
             else:
@@ -93,6 +97,14 @@ class EmbeddingModel:
                     inputs=uncached_inputs,
                     parameters=cache_parameters,
                 )
+
+            if len(new_embeddings) != len(uncached_inputs):
+                raise ValueError(
+                    "Embedding service returned "
+                    f"{len(new_embeddings)} embeddings for {len(uncached_inputs)} inputs."
+                )
+            if any(vector is None for vector in new_embeddings):
+                raise ValueError("Embedding service returned a missing embedding.")
 
             for position, text, vector in zip(
                 uncached_positions, uncached_inputs, new_embeddings
@@ -108,12 +120,16 @@ class EmbeddingModel:
                         usage=usage,
                     )
 
+        if any(vector is None for vector in embeddings):
+            raise ValueError("Embedding result is incomplete.")
+        final_embeddings = [vector for vector in embeddings if vector is not None]
+
         return EmbeddingResult(
-            embeddings=[vector for vector in embeddings if vector is not None],
+            embeddings=final_embeddings,
             input=inputs,
             model=self.model,
             service_name=self.service_name,
-            dimensions=len(embeddings[0]) if embeddings and embeddings[0] else None,
+            dimensions=len(final_embeddings[0]) if final_embeddings else None,
             usage=usage,
             cache_keys=[key for key in cache_keys],
             cache_used=cache_used,

--- a/edsl/embeddings/embedding_result.py
+++ b/edsl/embeddings/embedding_result.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class EmbeddingResult:
+    embeddings: list[list[float]]
+    input: list[str]
+    model: str
+    service_name: str
+    dimensions: Optional[int] = None
+    usage: Optional[dict[str, Any]] = None
+    cache_keys: Optional[list[Optional[str]]] = None
+    cache_used: Optional[list[bool]] = None
+
+    def to_dict(self, add_edsl_version: bool = True) -> dict[str, Any]:
+        data = {
+            "embeddings": self.embeddings,
+            "input": self.input,
+            "model": self.model,
+            "service_name": self.service_name,
+            "dimensions": self.dimensions,
+            "usage": self.usage,
+            "cache_keys": self.cache_keys,
+            "cache_used": self.cache_used,
+        }
+        if add_edsl_version:
+            from edsl import __version__
+
+            data["edsl_version"] = __version__
+            data["edsl_class_name"] = self.__class__.__name__
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmbeddingResult":
+        data = dict(data)
+        data.pop("edsl_version", None)
+        data.pop("edsl_class_name", None)
+        return cls(**data)
+
+    def to_dataset(self):
+        from edsl.dataset import Dataset
+
+        return Dataset(
+            [
+                {"input": self.input},
+                {"embedding": self.embeddings},
+                {"model": [self.model] * len(self.input)},
+                {"service_name": [self.service_name] * len(self.input)},
+                {"dimensions": [self.dimensions] * len(self.input)},
+                {"cache_key": self.cache_keys or [None] * len(self.input)},
+                {"cache_used": self.cache_used or [False] * len(self.input)},
+            ]
+        )
+
+    def to_scenario_list(self):
+        return self.to_dataset().to_scenario_list()
+
+    def __len__(self) -> int:
+        return len(self.embeddings)
+
+    def __getitem__(self, index: int) -> list[float]:
+        return self.embeddings[index]

--- a/edsl/embeddings/services.py
+++ b/edsl/embeddings/services.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+
+class EmbeddingService(ABC):
+    service_name: str
+
+    @abstractmethod
+    async def async_embed(
+        self, *, model: str, inputs: list[str], parameters: dict[str, Any]
+    ) -> tuple[list[list[float]], Optional[dict[str, Any]]]:
+        pass
+
+
+class OpenAIEmbeddingService(EmbeddingService):
+    service_name = "openai"
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.base_url = base_url
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY is required for OpenAI embeddings.")
+
+    async def async_embed(
+        self, *, model: str, inputs: list[str], parameters: dict[str, Any]
+    ) -> tuple[list[list[float]], Optional[dict[str, Any]]]:
+        try:
+            from openai import AsyncOpenAI, DefaultAioHttpClient
+        except ImportError as e:
+            raise ImportError(
+                "The openai package is required. Install with `pip install edsl[inference]`."
+            ) from e
+
+        params = {"model": model, "input": inputs, "encoding_format": "float"}
+        params.update({k: v for k, v in parameters.items() if v is not None})
+        client = AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            http_client=DefaultAioHttpClient(),
+        )
+        try:
+            response = await client.embeddings.create(**params)
+        finally:
+            await client.close()
+
+        data = response.model_dump(mode="json") if hasattr(response, "model_dump") else response
+        embeddings = [item["embedding"] for item in data["data"]]
+        return embeddings, data.get("usage")
+
+
+class SentenceTransformersEmbeddingService(EmbeddingService):
+    service_name = "sentence_transformers"
+    _model_cache: dict[str, Any] = {}
+
+    async def async_embed(
+        self, *, model: str, inputs: list[str], parameters: dict[str, Any]
+    ) -> tuple[list[list[float]], Optional[dict[str, Any]]]:
+        if parameters.get("dimensions") is not None:
+            raise ValueError(
+                "`dimensions` is not supported by the sentence_transformers service."
+            )
+
+        def run_encode() -> list[list[float]]:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ImportError as e:
+                raise ImportError(
+                    "The sentence-transformers package is required. Install with `pip install edsl[agent_building]`."
+                ) from e
+
+            if model not in self._model_cache:
+                self._model_cache[model] = SentenceTransformer(model)
+            encoder = self._model_cache[model]
+            encode_params = {
+                k: v
+                for k, v in parameters.items()
+                if k in {"batch_size", "show_progress_bar", "normalize_embeddings"}
+                and v is not None
+            }
+            vectors = encoder.encode(inputs, convert_to_numpy=False, **encode_params)
+            return [list(map(float, vector)) for vector in vectors]
+
+        return await asyncio.to_thread(run_encode), None
+
+
+class TestEmbeddingService(EmbeddingService):
+    service_name = "test"
+
+    async def async_embed(
+        self, *, model: str, inputs: list[str], parameters: dict[str, Any]
+    ) -> tuple[list[list[float]], Optional[dict[str, Any]]]:
+        dimensions = parameters.get("dimensions") or 3
+        embeddings = []
+        for text in inputs:
+            base = float(len(text))
+            embeddings.append([base + float(i) for i in range(dimensions)])
+        return embeddings, {"prompt_tokens": sum(len(text.split()) for text in inputs)}
+
+
+def get_embedding_service(
+    service_name: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None
+) -> EmbeddingService:
+    normalized = service_name.replace("-", "_")
+    if normalized == "openai":
+        return OpenAIEmbeddingService(api_key=api_key, base_url=base_url)
+    if normalized in {"sentence_transformers", "sentence_transformer"}:
+        return SentenceTransformersEmbeddingService()
+    if normalized == "test":
+        return TestEmbeddingService()
+    raise ValueError(
+        f"Unknown embedding service '{service_name}'. Supported services: openai, sentence_transformers, test."
+    )

--- a/edsl/scenarios/scenario_list.py
+++ b/edsl/scenarios/scenario_list.py
@@ -1354,6 +1354,28 @@ class ScenarioList(MutableSequence, Base, ScenarioListOperationsMixin):
     def add_list(self, name: str, values: List[Any]) -> ScenarioList:
         return self._transformer.add_list(name, values)
 
+    def embed(
+        self,
+        field: str,
+        *,
+        model: Optional[Any] = None,
+        output_field: str = "embedding",
+        cache: Optional[Any] = None,
+    ) -> ScenarioList:
+        """Embed a text field and return a ScenarioList with an embedding field.
+
+        >>> ScenarioList.from_list("text", ["a", "bb"]).embed("text", model=__import__("edsl").EmbeddingModel("test", service_name="test"))  # doctest: +ELLIPSIS
+        ScenarioList(...)
+        """
+        from ..embeddings import EmbeddingModel
+
+        embedding_model = model or EmbeddingModel()
+        texts = [scenario.get(field) for scenario in self]
+        if any(not isinstance(text, str) for text in texts):
+            raise TypeError(f"All values in field '{field}' must be strings.")
+        result = embedding_model.embed(texts, cache=cache)
+        return self.add_list(output_field, result.embeddings)
+
     @classmethod
     def create_empty_scenario_list(cls, n: int) -> ScenarioList:
         """Create an empty ScenarioList with n scenarios.

--- a/tests/embeddings/test_embeddings.py
+++ b/tests/embeddings/test_embeddings.py
@@ -1,0 +1,95 @@
+from edsl import Dataset, EmbeddingCache, EmbeddingModel, EmbeddingResult, ScenarioList
+
+
+def test_test_embedding_model_embed_list():
+    model = EmbeddingModel("test", service_name="test")
+
+    result = model.embed(["a", "abcd"])
+
+    assert isinstance(result, EmbeddingResult)
+    assert result.embeddings == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    assert result.model == "test"
+    assert result.service_name == "test"
+    assert result.dimensions == 3
+
+
+def test_embedding_cache_reuses_entries():
+    model = EmbeddingModel("test", service_name="test")
+    cache = EmbeddingCache()
+
+    first = model.embed(["hello"], cache=cache)
+    second = model.embed(["hello"], cache=cache)
+
+    assert first.cache_used == [False]
+    assert second.cache_used == [True]
+    assert first.embeddings == second.embeddings
+    assert len(cache) == 1
+
+
+def test_embedding_cache_jsonl_roundtrip(tmp_path):
+    cache_path = tmp_path / "embeddings.jsonl"
+    model = EmbeddingModel("test", service_name="test")
+
+    cache = EmbeddingCache(filename=str(cache_path))
+    result = model.embed(["hello"], cache=cache)
+    reloaded = EmbeddingCache(filename=str(cache_path))
+    cached = model.embed(["hello"], cache=reloaded)
+
+    assert cached.cache_used == [True]
+    assert cached.embeddings == result.embeddings
+
+
+def test_embedding_result_conversions():
+    result = EmbeddingResult(
+        embeddings=[[1.0, 2.0]],
+        input=["hello"],
+        model="test",
+        service_name="test",
+        dimensions=2,
+    )
+
+    dataset = result.to_dataset()
+    scenario_list = result.to_scenario_list()
+
+    assert dataset.keys() == [
+        "input",
+        "embedding",
+        "model",
+        "service_name",
+        "dimensions",
+        "cache_key",
+        "cache_used",
+    ]
+    assert scenario_list[0]["embedding"] == [1.0, 2.0]
+
+
+def test_scenario_list_embed_adds_embedding_field():
+    model = EmbeddingModel("test", service_name="test")
+    scenario_list = ScenarioList.from_list("text", ["a", "bb"])
+
+    embedded = scenario_list.embed("text", model=model)
+
+    assert embedded[0]["embedding"] == [1.0, 2.0, 3.0]
+    assert embedded[1]["embedding"] == [2.0, 3.0, 4.0]
+
+
+def test_dataset_embed_adds_embedding_column():
+    model = EmbeddingModel("test", service_name="test")
+    dataset = Dataset([{"text": ["a", "bb"]}])
+
+    embedded = dataset.embed("text", model=model)
+
+    assert embedded.to_scenario_list()[0]["embedding"] == [1.0, 2.0, 3.0]
+
+
+def test_sentence_transformers_dimensions_guard_does_not_import_dependency():
+    model = EmbeddingModel(
+        "all-MiniLM-L6-v2", service_name="sentence-transformers", dimensions=10
+    )
+
+    try:
+        model.embed(["hello"])
+    except ValueError as e:
+        assert "dimensions" in str(e)
+    else:
+        raise AssertionError("Expected dimensions guard to raise ValueError")

--- a/tests/embeddings/test_embeddings.py
+++ b/tests/embeddings/test_embeddings.py
@@ -1,6 +1,11 @@
 from edsl import Dataset, EmbeddingCache, EmbeddingModel, EmbeddingResult, ScenarioList
 
 
+class PartialEmbeddingService:
+    async def async_embed(self, *, model, inputs, parameters):
+        return [[1.0], None], None
+
+
 def test_test_embedding_model_embed_list():
     model = EmbeddingModel("test", service_name="test")
 
@@ -37,6 +42,44 @@ def test_embedding_cache_jsonl_roundtrip(tmp_path):
 
     assert cached.cache_used == [True]
     assert cached.embeddings == result.embeddings
+
+
+def test_embedding_cache_deferred_write_fetches_and_flushes(tmp_path):
+    cache_path = tmp_path / "embeddings.jsonl"
+    model = EmbeddingModel("test", service_name="test")
+    cache = EmbeddingCache(filename=str(cache_path), immediate_write=False)
+
+    result = model.embed(["hello"], cache=cache)
+    cached = model.embed(["hello"], cache=cache)
+
+    assert cached.cache_used == [True]
+    assert cached.embeddings == result.embeddings
+    assert not cache_path.exists()
+
+    cache.flush()
+    reloaded = EmbeddingCache(filename=str(cache_path))
+    cached_after_reload = model.embed(["hello"], cache=reloaded)
+
+    assert cached_after_reload.cache_used == [True]
+    assert cached_after_reload.embeddings == result.embeddings
+
+
+def test_embedding_model_rejects_missing_embedding(monkeypatch):
+    import edsl.embeddings.embedding_model as embedding_model
+
+    monkeypatch.setattr(
+        embedding_model,
+        "get_embedding_service",
+        lambda *args, **kwargs: PartialEmbeddingService(),
+    )
+    model = EmbeddingModel("test", service_name="test")
+
+    try:
+        model.embed(["a", "b"])
+    except ValueError as e:
+        assert "missing embedding" in str(e)
+    else:
+        raise AssertionError("Expected missing embedding to raise ValueError")
 
 
 def test_embedding_result_conversions():


### PR DESCRIPTION
## Summary
- add EmbeddingModel, EmbeddingResult, and embedding-specific local cache support
- support OpenAI embeddings and local sentence-transformers embeddings behind a provider-neutral API
- add ScenarioList.embed and Dataset.embed convenience methods plus a Coop remote embeddings client hook

## Tests
- pytest -q tests/embeddings/test_embeddings.py
- pytest -q tests/embeddings/test_embeddings.py tests/language_models/test_model.py tests/scenarios/test_ScenarioList.py tests/dataset/test_DatasetOperationsMixin
- uv run python -m compileall -q edsl/embeddings edsl/__init__.py edsl/scenarios/scenario_list.py edsl/dataset/dataset.py edsl/coop/coop.py

## Notes
- Client-side remote=True is wired to Coop.remote_async_embed, but server-side /embeddings/ support still needs to be implemented.
- Live OpenAI smoke test passed for text-embedding-3-small with 1536 dimensions.