### PR TITLE
Add unselected field to questions for carry-forward

### DIFF
--- a/edsl/questions/question_base.py
+++ b/edsl/questions/question_base.py
@@ -392,6 +392,41 @@ class QuestionBase(
         """
         return self.question_name
 
+    @property
+    def unselected(self) -> list:
+        """The options NOT chosen in this question's answer.
+
+        Complements ``.answer`` (the selected option(s)) so a later question can
+        carry forward the *unselected* choices, mirroring Qualtrics' "Unselected
+        Choices". Works for both list-valued answers (checkbox, top_k, rank) and
+        single-valued answers (multiple_choice, dropdown, etc.). Returns an empty
+        list for questions without options, or before the question is answered.
+
+        Examples:
+            >>> from edsl import QuestionMultipleChoice as MC
+            >>> q = MC(question_name="q", question_text="Pick",
+            ...        question_options=["A", "B", "C"])
+            >>> q.unselected
+            []
+            >>> q.answer = "B"
+            >>> q.unselected
+            ['A', 'C']
+            >>> from edsl import QuestionCheckBox as CB
+            >>> c = CB(question_name="c", question_text="Pick",
+            ...        question_options=["A", "B", "C", "D"])
+            >>> c.answer = ["A", "C"]
+            >>> c.unselected
+            ['B', 'D']
+        """
+        options = getattr(self, "question_options", None)
+        if not isinstance(options, (list, tuple)):
+            return []
+        answer = getattr(self, "answer", None)
+        if answer is None:
+            return []
+        selected = set(answer) if isinstance(answer, (list, tuple, set)) else {answer}
+        return [o for o in options if o not in selected]
+
     def __hash__(self) -> int:
         """
         Calculate a hash value for this question instance.
@@ -427,14 +462,18 @@ class QuestionBase(
             # "_include_comment",
             # "_use_code",
             "_model_instructions",
-            "_model",                  # live Model object; serialized via _thinking_model
-            "_invigilator_class",      # runtime-only; restored by thinking_question()
-            "_system_prompt",          # serialized via _thinking_system_prompt
-            "_is_thinking_question",   # serialized via from_dict detection
+            "_model",  # live Model object; serialized via _thinking_model
+            "_invigilator_class",  # runtime-only; restored by thinking_question()
+            "_system_prompt",  # serialized via _thinking_system_prompt
+            "_is_thinking_question",  # serialized via from_dict detection
         ]
         only_if_not_na_list = ["_answering_instructions", "_question_presentation"]
 
-        only_if_not_default_list = {"_include_comment": True, "_use_code": False, "_enumeration": "none"}
+        only_if_not_default_list = {
+            "_include_comment": True,
+            "_use_code": False,
+            "_enumeration": "none",
+        }
 
         def ok(key, value):
             if not key.startswith("_"):
@@ -566,6 +605,7 @@ class QuestionBase(
         # Re-wrap as thinking question if needed
         if thinking_model_data is not None:
             from .question_thinking import thinking_question
+
             new_q = thinking_question(
                 new_q, model=thinking_model_data, system_prompt=thinking_system_prompt
             )
@@ -916,14 +956,23 @@ class QuestionBase(
         ]
 
         if hasattr(self, "question_options") and self.question_options:
-            rows.append(("question_options", ", ".join(str(o) for o in self.question_options)))
+            rows.append(
+                ("question_options", ", ".join(str(o) for o in self.question_options))
+            )
 
         if hasattr(self, "option_labels") and self.option_labels:
             labels = ", ".join(f"{k}: {v!r}" for k, v in self.option_labels.items())
             rows.append(("option_labels", f"{{{labels}}}"))
 
-        for attr in ("min_value", "max_value", "min_selections", "max_selections",
-                      "num_selections", "max_list_items", "weight"):
+        for attr in (
+            "min_value",
+            "max_value",
+            "min_selections",
+            "max_selections",
+            "num_selections",
+            "max_list_items",
+            "weight",
+        ):
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 rows.append((attr, repr(getattr(self, attr))))
 

--- a/edsl/questions/question_check_box.py
+++ b/edsl/questions/question_check_box.py
@@ -687,32 +687,6 @@ class QuestionCheckBox(QuestionBase):
         self.question_presentation = question_presentation
         self.answering_instructions = answering_instructions
 
-    @property
-    def unselected(self) -> list:
-        """The options NOT chosen in this question's answer.
-
-        Complements ``.answer`` (the selected options) so a later question can
-        carry forward the *unselected* choices, mirroring Qualtrics' "Unselected
-        Choices". Only meaningful once the question has been answered; returns an
-        empty list if there is no list-valued answer yet.
-
-        Examples:
-            >>> q = QuestionCheckBox(
-            ...     question_name="q_banks",
-            ...     question_text="Which banks do you use?",
-            ...     question_options=["Chase", "Citi", "US Bank"],
-            ... )
-            >>> q.unselected
-            []
-            >>> q.answer = ["Chase"]
-            >>> q.unselected
-            ['Citi', 'US Bank']
-        """
-        answer = getattr(self, "answer", None)
-        if not isinstance(answer, (list, tuple, set)):
-            return []
-        return [o for o in self.question_options if o not in answer]
-
     def create_response_model(self):
         """
         Create a response model with the appropriate constraints.

--- a/edsl/questions/question_check_box.py
+++ b/edsl/questions/question_check_box.py
@@ -687,6 +687,32 @@ class QuestionCheckBox(QuestionBase):
         self.question_presentation = question_presentation
         self.answering_instructions = answering_instructions
 
+    @property
+    def unselected(self) -> list:
+        """The options NOT chosen in this question's answer.
+
+        Complements ``.answer`` (the selected options) so a later question can
+        carry forward the *unselected* choices, mirroring Qualtrics' "Unselected
+        Choices". Only meaningful once the question has been answered; returns an
+        empty list if there is no list-valued answer yet.
+
+        Examples:
+            >>> q = QuestionCheckBox(
+            ...     question_name="q_banks",
+            ...     question_text="Which banks do you use?",
+            ...     question_options=["Chase", "Citi", "US Bank"],
+            ... )
+            >>> q.unselected
+            []
+            >>> q.answer = ["Chase"]
+            >>> q.unselected
+            ['Citi', 'US Bank']
+        """
+        answer = getattr(self, "answer", None)
+        if not isinstance(answer, (list, tuple, set)):
+            return []
+        return [o for o in self.question_options if o not in answer]
+
     def create_response_model(self):
         """
         Create a response model with the appropriate constraints.


### PR DESCRIPTION
## What

Adds an `unselected` property to `QuestionBase`, so **every option-bearing question type** exposes the options **not** chosen in its answer (`question_options` − `answer`).

## Why

EDSL already carries forward **selected** choices via `{{ q.answer }}`. This adds the symmetric case — carrying forward the **unselected** choices — with the same, discoverable syntax:

```python
# Selected choices (already worked)
question_options="{{ q_banks.answer }}"      # -> ['Chase', 'Wells Fargo', 'Citi']

# Unselected choices (NEW)
question_options="{{ q_banks.unselected }}"  # -> ['Bank of America', 'US Bank']
```

This is the EDSL equivalent of Qualtrics' **"Unselected Choices"** carry-forward, mirroring `.answer` for **"Selected Choices"**.

## How

A single `@property` on `QuestionBase`, so it works for every question type without per-class duplication:

```python
@property
def unselected(self) -> list:
    options = getattr(self, "question_options", None)
    if not isinstance(options, (list, tuple)):
        return []
    answer = getattr(self, "answer", None)
    if answer is None:
        return []
    selected = set(answer) if isinstance(answer, (list, tuple, set)) else {answer}
    return [o for o in options if o not in selected]
```

Handles both **list-valued** answers (check_box, top_k, rank) and **single-valued** answers (multiple_choice, dropdown, yes_no, likert_five, linear_scale, multiple_choice_with_other). Returns `[]` for types without options (free_text, numerical, …) or before the question is answered.

At interview time EDSL places each answered question object into the render context under its name (`_add_answers` sets `.answer` on it), so `{{ q.unselected }}` resolves through the normal `QuestionOptionProcessor` path with no other changes.

## Testing

Verified across all option types:

| Type | answer | `unselected` |
|---|---|---|
| MultipleChoice | `"B"` | `['A', 'C', 'D']` |
| Dropdown | `"C"` | `['A', 'B', 'D']` |
| YesNo | `"Yes"` | `['No']` |
| LinearScale | `3` | `[1, 2, 4, 5]` |
| CheckBox | `['A','C']` | `['B', 'D']` |
| TopK | `['A','B']` | `['C', 'D']` |
| Rank | `['D','A']` | `['B', 'C']` |
| FreeText | `"hello"` | `[]` (no options) |

All `question_base` (83) and `question_check_box` (49) doctests pass, including new ones on the property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SV5i41t7vwHQLisCzvkFgQ