### PR TITLE
Add Meta inference service provider

### DIFF
--- a/edsl/base/enums.py
+++ b/edsl/base/enums.py
@@ -70,6 +70,7 @@ class InferenceServiceType(EnumWithChecks):
     DEEPSEEK = "deepseek"
     XAI = "xai"
     OPEN_ROUTER = "open_router"
+    META = "meta"
 
 
 # unavoidable violation of the DRY principle but it is necessary
@@ -92,6 +93,7 @@ InferenceServiceLiteral = Literal[
     "deepseek",
     "xai",
     "open_router",
+    "meta",
 ]
 
 available_models_urls = {
@@ -100,6 +102,7 @@ available_models_urls = {
     "openai_v2": "https://platform.openai.com/docs/models/gp",
     "groq": "https://console.groq.com/docs/models",
     "google": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models",
+    "meta": "https://dev.meta.ai/docs/getting-started/overview/",
 }
 
 
@@ -120,6 +123,7 @@ service_to_api_keyname = {
     InferenceServiceType.DEEPSEEK.value: "DEEPSEEK_API_KEY",
     InferenceServiceType.XAI.value: "XAI_API_KEY",
     InferenceServiceType.OPEN_ROUTER.value: "OPEN_ROUTER_API_KEY",
+    InferenceServiceType.META.value: "META_API_KEY",
     InferenceServiceType.OLLAMA.value: "OLLAMA_API_KEY",
 }
 

--- a/edsl/inference_services/inference_service_registry.py
+++ b/edsl/inference_services/inference_service_registry.py
@@ -118,6 +118,7 @@ class InferenceServiceRegistry:
         "together",
         "xai",
         "open_router",
+        "meta",
         "bedrock",
         "azure",
         "ollama",

--- a/edsl/inference_services/services/meta_service.py
+++ b/edsl/inference_services/services/meta_service.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional, TYPE_CHECKING
+
+import aiohttp
+import requests
+
+from ..decorators import report_errors_async
+from .message_builder import MessageBuilder
+from .open_ai_service import OpenAIService
+
+if TYPE_CHECKING:
+    from ...invigilators.invigilator_base import InvigilatorBase as InvigilatorAI
+    from ...language_models import LanguageModel
+    from ...scenarios.file_store import FileStore as Files
+
+
+class MetaService(OpenAIService):
+    """Meta Model API service class."""
+
+    _inference_service_ = "meta"
+    _env_key_name_ = "META_API_KEY"
+    _fallback_env_key_name_ = "LLAMA_API_KEY"
+    _base_url_ = "https://api.meta.ai/v1"
+    _responses_url_ = f"{_base_url_}/responses"
+    _models_url_ = f"{_base_url_}/models"
+    _supports_files_api_ = False
+    available_models_url = "https://dev.meta.ai/docs/getting-started/overview/"
+
+    @classmethod
+    def _api_key_from_env(cls) -> Optional[str]:
+        return os.getenv(cls._env_key_name_) or os.getenv(cls._fallback_env_key_name_)
+
+    @classmethod
+    def get_model_info(cls, api_key=None):
+        if api_key is None:
+            api_key = cls._api_key_from_env()
+        if api_key is None:
+            raise ValueError(f"API key for {cls._inference_service_} is not set")
+
+        response = requests.get(
+            cls._models_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, dict) and isinstance(data.get("data"), list):
+            return data["data"]
+        if isinstance(data, list):
+            return data
+        return []
+
+    @classmethod
+    def create_model(
+        cls, model_name="muse-spark-1.1", model_class_name=None
+    ) -> "LanguageModel":
+        if model_class_name is None:
+            model_class_name = cls.to_class_name(model_name)
+
+        from ...language_models import LanguageModel
+
+        class LLM(LanguageModel):
+            """Child class of LanguageModel for interacting with Meta models."""
+
+            key_sequence = cls.key_sequence
+            usage_sequence = cls.usage_sequence
+            input_token_name = cls.input_token_name
+            output_token_name = cls.output_token_name
+            thinking_token_sequence = cls.thinking_token_sequence
+
+            _inference_service_ = cls._inference_service_
+            _model_ = model_name
+            _parameters_ = {
+                "temperature": 0.5,
+                "max_tokens": 1000,
+                "top_p": 1,
+            }
+
+            @staticmethod
+            def _response_text(response: dict[str, Any]) -> str:
+                if isinstance(response.get("output_text"), str):
+                    return response["output_text"]
+
+                text_parts = []
+                for item in response.get("output", []) or []:
+                    if not isinstance(item, dict):
+                        continue
+                    for content in item.get("content", []) or []:
+                        if not isinstance(content, dict):
+                            continue
+                        text = content.get("text")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+                return "\n".join(text_parts)
+
+            @staticmethod
+            def _normalized_usage(response: dict[str, Any]) -> dict[str, Any]:
+                usage = response.get("usage")
+                if not isinstance(usage, dict):
+                    return {}
+                return {
+                    "prompt_tokens": usage.get(
+                        "prompt_tokens", usage.get("input_tokens", 0)
+                    ),
+                    "completion_tokens": usage.get(
+                        "completion_tokens", usage.get("output_tokens", 0)
+                    ),
+                    "total_tokens": usage.get("total_tokens", usage.get("total", 0)),
+                }
+
+            def _payload(
+                self,
+                user_prompt: str,
+                system_prompt: str = "",
+                files_list: Optional[List["Files"]] = None,
+            ) -> dict[str, Any]:
+                message_builder = MessageBuilder(
+                    model=self.model,
+                    files_list=files_list,
+                    user_prompt=user_prompt,
+                    system_prompt=system_prompt,
+                    omit_system_prompt_if_empty=self.omit_system_prompt_if_empty,
+                    supports_files_api=False,
+                )
+                messages = message_builder.get_messages(sync_client=None)
+                input_messages = []
+                for message in messages:
+                    content = message.get("content", "")
+                    if isinstance(content, str):
+                        content = [{"type": "input_text", "text": content}]
+                    else:
+                        content = [
+                            (
+                                {"type": "input_text", "text": item["text"]}
+                                if isinstance(item, dict) and item.get("type") == "text"
+                                else item
+                            )
+                            for item in content
+                        ]
+                    input_messages.append(
+                        {
+                            "role": message["role"],
+                            "content": content,
+                        }
+                    )
+
+                return {
+                    "model": self.model,
+                    "input": input_messages,
+                    "stream": False,
+                }
+
+            @report_errors_async
+            async def async_execute_model_call(
+                self,
+                user_prompt: str,
+                system_prompt: str = "",
+                question_name: Optional[str] = None,
+                files_list: Optional[List["Files"]] = None,
+                invigilator: Optional["InvigilatorAI"] = None,
+                cache_key: Optional[str] = None,
+                response_schema: Optional[dict] = None,
+                response_schema_name: Optional[str] = None,
+            ) -> dict[str, Any]:
+                payload = self._payload(
+                    user_prompt=user_prompt,
+                    system_prompt=system_prompt,
+                    files_list=files_list,
+                )
+                headers = {
+                    "Authorization": f"Bearer {self.api_token}",
+                    "Content-Type": "application/json",
+                }
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        cls._responses_url_,
+                        headers=headers,
+                        json=payload,
+                        timeout=120,
+                    ) as response:
+                        response.raise_for_status()
+                        raw_response = await response.json()
+
+                return {
+                    **raw_response,
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": self._response_text(raw_response),
+                            }
+                        }
+                    ],
+                    "usage": self._normalized_usage(raw_response),
+                }
+
+        LLM.__name__ = "LanguageModel"
+        LLM.__qualname__ = "LanguageModel"
+
+        return LLM

--- a/edsl/key_management/key_lookup_builder.py
+++ b/edsl/key_management/key_lookup_builder.py
@@ -44,6 +44,7 @@ for service, key in service_to_api_keyname.items():
             api_keyname_to_service[k] = service
     else:
         api_keyname_to_service[key] = service
+api_keyname_to_service["LLAMA_API_KEY"] = "meta"
 
 api_id_to_service = {"AWS_ACCESS_KEY_ID": "bedrock"}
 

--- a/edsl/runner/queues.py
+++ b/edsl/runner/queues.py
@@ -351,6 +351,7 @@ DEFAULT_RATE_LIMITS = {
     "xai": {"rpm": 10_000, "tpm": 1_000_000},
     "together": {"rpm": 10_000, "tpm": 1_000_000},
     "perplexity": {"rpm": 10_000, "tpm": 1_000_000},
+    "meta": {"rpm": 10_000, "tpm": 1_000_000},
     "bedrock": {"rpm": 10_000, "tpm": 1_000_000},
     "azure": {"rpm": 10_000, "tpm": 1_000_000},
     "test": {"rpm": 10_000, "tpm": 1_000_000},
@@ -557,6 +558,8 @@ def load_queues_from_env(
         "XAI_API_KEY": ("xai", ["grok-2-latest"]),
         "TOGETHER_API_KEY": ("together", ["meta-llama/Llama-3.3-70B-Instruct-Turbo"]),
         "PERPLEXITY_API_KEY": ("perplexity", ["llama-3.1-sonar-large-128k-online"]),
+        "META_API_KEY": ("meta", ["muse-spark-1.1"]),
+        "LLAMA_API_KEY": ("meta", ["muse-spark-1.1"]),
         "AWS_ACCESS_KEY_ID": (
             "bedrock",
             [],

--- a/tests/inference_services/test_inference_service_registry.py
+++ b/tests/inference_services/test_inference_service_registry.py
@@ -128,6 +128,12 @@ class TestInferenceServiceRegistry:
         services = registry.list_registered_services()
         assert set(services) == {"service1", "service2"}
 
+    def test_default_registry_discovers_meta_service(self):
+        registry = InferenceServiceRegistry()
+
+        assert "meta" in registry.list_registered_services()
+        assert registry.get_service_class("meta")._inference_service_ == "meta"
+
     def test_services_property(self, registry):
         """Test services property returns the internal services dict."""
         registry.register("service1", MockInferenceService)
@@ -474,6 +480,7 @@ class TestInferenceServiceRegistry:
             "together",
             "xai",
             "open_router",
+            "meta",
             "bedrock",
             "azure",
             "ollama",

--- a/tests/inference_services/test_meta_service.py
+++ b/tests/inference_services/test_meta_service.py
@@ -1,0 +1,106 @@
+import asyncio
+
+from edsl.inference_services.services.meta_service import MetaService
+
+
+def test_meta_payload_uses_responses_input_text_shape():
+    model_class = MetaService.create_model("muse-spark-1.1")
+    model = model_class(skip_api_key_check=True)
+
+    payload = model._payload(
+        user_prompt="Write a haiku.",
+        system_prompt="Be concise.",
+    )
+
+    assert payload["model"] == "muse-spark-1.1"
+    assert payload["stream"] is False
+    assert payload["input"] == [
+        {
+            "role": "system",
+            "content": [{"type": "input_text", "text": "Be concise."}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Write a haiku."}],
+        },
+    ]
+
+
+def test_meta_response_text_extracts_output_text():
+    model_class = MetaService.create_model("muse-spark-1.1")
+
+    assert model_class._response_text({"output_text": "hello"}) == "hello"
+    assert (
+        model_class._response_text(
+            {
+                "output": [
+                    {
+                        "content": [
+                            {"type": "output_text", "text": "hello"},
+                            {"type": "output_text", "text": "world"},
+                        ]
+                    }
+                ]
+            }
+        )
+        == "hello\nworld"
+    )
+
+
+def test_meta_async_call_normalizes_response(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        async def json(self):
+            return {
+                "output": [{"content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 3, "output_tokens": 2, "total": 5},
+            }
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def post(self, url, headers, json, timeout):
+            captured.update(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "json": json,
+                    "timeout": timeout,
+                }
+            )
+            return DummyResponse()
+
+    monkeypatch.setattr(
+        "edsl.inference_services.services.meta_service.aiohttp.ClientSession",
+        DummySession,
+    )
+
+    model_class = MetaService.create_model("muse-spark-1.1")
+    model = model_class(skip_api_key_check=True)
+    model._api_token = "test-token"
+
+    response = asyncio.run(model.async_execute_model_call("hello"))
+
+    assert captured["url"] == "https://api.meta.ai/v1/responses"
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+    assert captured["json"]["input"][0]["content"][0]["type"] == "input_text"
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert response["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "total_tokens": 5,
+    }

--- a/tests/language_models/test_KeyLookupBuilder.py
+++ b/tests/language_models/test_KeyLookupBuilder.py
@@ -50,6 +50,7 @@ def test_invalid_fetch_order():
     [
         ("EDSL_SERVICE_RPM_OPENAI", "limit"),
         ("OPENAI_API_KEY", "api_key"),
+        ("LLAMA_API_KEY", "api_key"),
         ("AWS_ACCESS_KEY_ID", "api_id"),
         ("UNKNOWN_KEY", "unknown"),
     ],
@@ -89,6 +90,14 @@ def test_process_key_value_pairs(mock_env_vars):
         # Check API IDs were processed
         assert "bedrock" in builder.id_data
         assert isinstance(builder.id_data["bedrock"], APIIDEntry)
+
+
+def test_llama_api_key_maps_to_meta_service():
+    with patch.dict("os.environ", {"LLAMA_API_KEY": "test-meta-key"}, clear=True):
+        builder = KeyLookupBuilder(fetch_order=("env",))
+
+    assert builder.key_data["meta"][-1].value == "test-meta-key"
+    assert builder.build()["meta"].api_token == "test-meta-key"
 
 
 def test_get_language_model_input(builder):


### PR DESCRIPTION
## Summary
- Add a native Meta Model API inference service using the Responses API
- Register the meta provider in service enums, discovery preferences, key lookup, and queue loading
- Support both META_API_KEY and LLAMA_API_KEY for credentials
- Normalize Meta responses into EDSL's existing choices/message/usage shape

## Tests
- pytest -q tests/inference_services tests/language_models/test_KeyLookupBuilder.py
- Live smoke test against Meta Model API with muse-spark-1.1