### PR TITLE
Add interview intro screen to humanize schema; gpt-5.6 temperature fix

### DIFF
--- a/docs/mintlify-migration/en/latest/humanize_schema.mdx
+++ b/docs/mintlify-migration/en/latest/humanize_schema.mdx
@@ -59,6 +59,18 @@ Each `questions[question_name]` value is a `HumanizeQuestionSchema` object.
   - `"both"` — respondent can choose between text and voice.
 </ParamField>
 
+<ParamField path="intro_screen" type="dict" required={false}>
+  **Interview only** (`interview`). The intro screen shown to the respondent before the interview begins. The intro screen is always shown; this field customizes its text. Omit or set to `null` to use the default text (`"This will be a conversation with an AI agent."`).
+  <Expandable title="properties">
+    <ParamField path="type" type="string" default="default">
+      Must be `"default"`.
+    </ParamField>
+    <ParamField path="instruction" type="string" required={true}>
+      The intro screen body text. Must be between 1 and 2500 characters.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
 <ParamField path="voice_interview_config" type="dict" required={false}>
   **Interview only** (`interview`). Optional configuration for voice-mode interviews. Ignored when `interview_mode` is `"text"`.
   <Expandable title="properties">

--- a/edsl/coop/coop_humanize_schema.py
+++ b/edsl/coop/coop_humanize_schema.py
@@ -259,11 +259,32 @@ class VoiceInterviewConfig(HumanizeSchemaBase):
         return normalize_voice_interview_language(v)
 
 
+class DefaultIntroScreen(HumanizeSchemaBase):
+    """The default intro screen: a single instruction shown before the interview
+    starts.
+
+    Discriminated by ``type`` so alternative intro screens can join later as a
+    ``Union`` without reshaping stored configs. ``default`` is the only variant
+    today.
+    """
+
+    type: Literal["default"] = "default"
+    instruction: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=2500),
+    ]
+
+
 class InterviewHumanizeSchema(HumanizeSchemaBase):
     """Humanize options for the interview question type."""
 
     optional: bool = False
     interview_mode: Literal["text", "voice", "both"] = "text"
+    # The intro screen shown before the interview starts. The intro screen is
+    # always shown; None falls back to the default text ("This will be a
+    # conversation with an AI agent."). When set, ``instruction`` supplies the
+    # body text.
+    intro_screen: Optional[DefaultIntroScreen] = None
     voice_interview_config: Optional[VoiceInterviewConfig] = None
     text_interview_config: Optional[TextInterviewConfig] = None
 

--- a/edsl/inference_services/services/open_ai_service.py
+++ b/edsl/inference_services/services/open_ai_service.py
@@ -5,7 +5,7 @@ import os
 from ..inference_service_abc import InferenceServiceABC
 from .message_builder import MessageBuilder
 from ..decorators import report_errors_async
-from .service_enums import OPENAI_REASONING_MODELS
+from .service_enums import OPENAI_REASONING_MODELS, openai_requires_temperature_one
 
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
@@ -38,17 +38,26 @@ class OpenAIParameterBuilder:
         default_max_tokens = model_params.get("max_tokens", 1000)
         default_temperature = model_params.get("temperature", 0.5)
         default_reasoning_effort = model_params.get("reasoning_effort", "medium")
-        if model in OPENAI_REASONING_MODELS:
+        # Substring match so suffixed variants (e.g. gpt-5.6-terra) are still
+        # recognized as reasoning models, consistent with the other services.
+        is_reasoning_model = any(tag in model for tag in OPENAI_REASONING_MODELS)
+        if is_reasoning_model:
             # For reasoning models, use much higher completion tokens to allow for reasoning + response
             max_tokens = max(default_max_tokens, 5000)
-            temperature = 1
             # If no reasoning effort is provided, use "medium" as the default
             # Some models (e.g. gpt-5) do not support null values for reasoning_effort
             reasoning_effort = default_reasoning_effort or "medium"
         else:
             max_tokens = default_max_tokens
-            temperature = default_temperature
             reasoning_effort = None
+
+        # GPT-5+ and o-series models reject any temperature other than 1, even
+        # when the exact model id isn't in OPENAI_REASONING_MODELS (e.g. dated
+        # variants of gpt-5.6).
+        if openai_requires_temperature_one(model):
+            temperature = 1
+        else:
+            temperature = default_temperature
 
         # Base parameters
         params = {
@@ -67,7 +76,7 @@ class OpenAIParameterBuilder:
             ),
         }
 
-        if model in OPENAI_REASONING_MODELS:
+        if is_reasoning_model:
             params["reasoning_effort"] = reasoning_effort
 
         return params

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 from ..inference_service_abc import InferenceServiceABC
 from ..decorators import report_errors_async
-from .service_enums import OPENAI_REASONING_MODELS
+from .service_enums import OPENAI_REASONING_MODELS, openai_requires_temperature_one
 
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
@@ -341,8 +341,8 @@ class OpenAIServiceV2(InferenceServiceABC):
                 # instead of max_tokens (which is for the completions API)
                 params["max_output_tokens"] = self.max_tokens
 
-                # Specifically for o-series, we also set temperature to 1
-                if is_reasoning_model:
+                # GPT-5+ and o-series models only accept temperature=1.
+                if openai_requires_temperature_one(self.model):
                     params["temperature"] = 1
 
                 client = self.async_client()

--- a/edsl/inference_services/services/service_enums.py
+++ b/edsl/inference_services/services/service_enums.py
@@ -1,3 +1,5 @@
+import re
+
 OPENAI_REASONING_MODELS = [
     "o1",
     "o1-mini",
@@ -10,4 +12,23 @@ OPENAI_REASONING_MODELS = [
     "gpt-5-nano",
     "gpt-5.1",
     "gpt-5.5",
+    "gpt-5.6",
 ]
+
+
+def openai_requires_temperature_one(model_name: str) -> bool:
+    """Return whether an OpenAI model only accepts ``temperature=1``.
+
+    The o-series reasoning models (o1, o3, o4-mini, ...) and the GPT-5 and later
+    generation (gpt-5, gpt-5.6, gpt-6, ...) reject any temperature other than 1,
+    so we pin it regardless of the exact model id (dates/suffixes included).
+    """
+    name = model_name.lower()
+    # o-series reasoning models: an "o" followed immediately by a digit.
+    if re.match(r"o\d", name):
+        return True
+    # gpt-5 and later.
+    gpt_match = re.match(r"gpt-(\d+)", name)
+    if gpt_match and int(gpt_match.group(1)) >= 5:
+        return True
+    return False


### PR DESCRIPTION
The gpt-5.6-series takes temperature 1, and this needs to be set at the EDSL level - otherwise we get remote inference failures with the default temperature.