### PR TITLE
Strip LLM-only instruction preamble from humanize survey payloads

### DIFF
--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2927,8 +2927,7 @@ class Coop(CoopFunctionsMixin):
             description=survey_description,
             alias=survey_alias,
             visibility=survey_visibility,
-            _object_dict=stripped_survey_dict,
-            _object_hash=str(dict_hash(stripped_hash_dict)),
+            _content_override=(stripped_survey_dict, str(dict_hash(stripped_hash_dict))),
         )
         survey_uuid = survey_details.get("uuid")
         if scenario_list is not None:
@@ -5434,14 +5433,18 @@ class Coop(CoopFunctionsMixin):
         alias: Optional[str] = None,
         visibility: Optional[VisibilityType] = "private",
         force: bool = False,
-        _object_dict: Optional[Dict[str, Any]] = None,
-        _object_hash: Optional[str] = None,
+        _content_override: Optional[Tuple[Dict[str, Any], str]] = None,
     ) -> "Scenario":
         """
         Upload an EDSL object to Coop via a signed GCS URL (PUT), then confirm the upload.
 
         Parameters:
             object: The EDSL object to upload (e.g. Survey, Scenario).
+            _content_override: Optional (object_dict, object_hash) pair to upload instead
+                of `object`'s own serialization — e.g. a version with fields stripped for
+                a human-facing destination. The dict and hash must describe the same
+                content; they travel together so callers can't pass a hash that doesn't
+                match what's actually uploaded.
 
         Returns:
             Scenario: Coop upload metadata as a ``Scenario`` so notebooks/terminals keep
@@ -5460,12 +5463,11 @@ class Coop(CoopFunctionsMixin):
         self._validate_alias(alias)
 
         object_type = ObjectRegistry.get_object_type_by_edsl_class(object)
-        object_dict = _object_dict if _object_dict is not None else object.to_dict()
-        object_hash = (
-            _object_hash
-            if _object_hash is not None
-            else (object.get_hash() if hasattr(object, "get_hash") else None)
-        )
+        if _content_override is not None:
+            object_dict, object_hash = _content_override
+        else:
+            object_dict = object.to_dict()
+            object_hash = object.get_hash() if hasattr(object, "get_hash") else None
 
         # Process FileStore objects: upload to GCS and offload
         object_dict = self._process_filestores_for_push(

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2826,16 +2826,25 @@ class Coop(CoopFunctionsMixin):
     def _strip_instruction_preambles_for_humanize(
         survey_dict: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Remove the LLM-only `preamble` field from Instruction entries.
+        """Return a copy of survey_dict with the LLM-only `preamble` field removed
+        from any Instruction entries.
 
         `Instruction.preamble` (e.g. "You were given the following instructions:")
         is scaffolding for LLM prompt construction and has no meaning to a human
         respondent. It must not appear in payloads that reach a human-facing survey.
+
+        Does not mutate `survey_dict` or its nested entries.
         """
-        for entry in survey_dict.get("questions", []):
-            if entry.get("edsl_class_name") == "Instruction":
-                entry.pop("preamble", None)
-        return survey_dict
+        result = dict(survey_dict)
+        result["questions"] = [
+            (
+                {k: v for k, v in entry.items() if k != "preamble"}
+                if entry.get("edsl_class_name") == "Instruction"
+                else entry
+            )
+            for entry in survey_dict.get("questions", [])
+        ]
+        return result
 
     def create_human_survey(
         self,
@@ -2905,14 +2914,21 @@ class Coop(CoopFunctionsMixin):
             agent_list_uuid = agent_list_details.get("uuid")
         else:
             agent_list_uuid = None
+        from ..utilities.utilities import dict_hash
+
+        stripped_survey_dict = self._strip_instruction_preambles_for_humanize(
+            survey.to_dict()
+        )
+        stripped_hash_dict = self._strip_instruction_preambles_for_humanize(
+            survey.to_dict(add_edsl_version=False)
+        )
         survey_details = self.push(
             object=survey,
             description=survey_description,
             alias=survey_alias,
             visibility=survey_visibility,
-            _object_dict=self._strip_instruction_preambles_for_humanize(
-                survey.to_dict()
-            ),
+            _object_dict=stripped_survey_dict,
+            _object_hash=str(dict_hash(stripped_hash_dict)),
         )
         survey_uuid = survey_details.get("uuid")
         if scenario_list is not None:
@@ -5419,6 +5435,7 @@ class Coop(CoopFunctionsMixin):
         visibility: Optional[VisibilityType] = "private",
         force: bool = False,
         _object_dict: Optional[Dict[str, Any]] = None,
+        _object_hash: Optional[str] = None,
     ) -> "Scenario":
         """
         Upload an EDSL object to Coop via a signed GCS URL (PUT), then confirm the upload.
@@ -5444,7 +5461,11 @@ class Coop(CoopFunctionsMixin):
 
         object_type = ObjectRegistry.get_object_type_by_edsl_class(object)
         object_dict = _object_dict if _object_dict is not None else object.to_dict()
-        object_hash = object.get_hash() if hasattr(object, "get_hash") else None
+        object_hash = (
+            _object_hash
+            if _object_hash is not None
+            else (object.get_hash() if hasattr(object, "get_hash") else None)
+        )
 
         # Process FileStore objects: upload to GCS and offload
         object_dict = self._process_filestores_for_push(

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2822,6 +2822,21 @@ class Coop(CoopFunctionsMixin):
             raise CoopValueError("Provide either max_jobs or deadline.")
         return payload
 
+    @staticmethod
+    def _strip_instruction_preambles_for_humanize(
+        survey_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Remove the LLM-only `preamble` field from Instruction entries.
+
+        `Instruction.preamble` (e.g. "You were given the following instructions:")
+        is scaffolding for LLM prompt construction and has no meaning to a human
+        respondent. It must not appear in payloads that reach a human-facing survey.
+        """
+        for entry in survey_dict.get("questions", []):
+            if entry.get("edsl_class_name") == "Instruction":
+                entry.pop("preamble", None)
+        return survey_dict
+
     def create_human_survey(
         self,
         survey: "Survey",
@@ -2895,6 +2910,9 @@ class Coop(CoopFunctionsMixin):
             description=survey_description,
             alias=survey_alias,
             visibility=survey_visibility,
+            _object_dict=self._strip_instruction_preambles_for_humanize(
+                survey.to_dict()
+            ),
         )
         survey_uuid = survey_details.get("uuid")
         if scenario_list is not None:
@@ -3978,7 +3996,7 @@ class Coop(CoopFunctionsMixin):
             raise CoopObjectTypeError("This is not a survey.")
         if humanize_schema is not None:
             self.validate_human_survey_humanize_schema(survey, humanize_schema)
-        survey_dict = survey.to_dict()
+        survey_dict = self._strip_instruction_preambles_for_humanize(survey.to_dict())
         payload: Dict[str, Any] = {"survey_json": survey_dict}
         if humanize_schema is not None:
             payload["humanize_schema"] = humanize_schema
@@ -5400,6 +5418,7 @@ class Coop(CoopFunctionsMixin):
         alias: Optional[str] = None,
         visibility: Optional[VisibilityType] = "private",
         force: bool = False,
+        _object_dict: Optional[Dict[str, Any]] = None,
     ) -> "Scenario":
         """
         Upload an EDSL object to Coop via a signed GCS URL (PUT), then confirm the upload.
@@ -5424,7 +5443,7 @@ class Coop(CoopFunctionsMixin):
         self._validate_alias(alias)
 
         object_type = ObjectRegistry.get_object_type_by_edsl_class(object)
-        object_dict = object.to_dict()
+        object_dict = _object_dict if _object_dict is not None else object.to_dict()
         object_hash = object.get_hash() if hasattr(object, "get_hash") else None
 
         # Process FileStore objects: upload to GCS and offload


### PR DESCRIPTION
## Summary
- `Instruction.preamble` (default `"You were given the following instructions:"`) is scaffolding for LLM prompt construction (`question_instructions_prompt_builder.py`) — it has no meaning to a human respondent.
- It was leaking straight through `Survey.to_dict()` into the humanize/preview payloads sent to Coop for human-facing surveys.
- Added `Coop._strip_instruction_preambles_for_humanize()` and applied it at the two call sites that build human-facing payloads: `create_human_survey()` and `get_survey_preview_url()`. The LLM prompt-building path (`Instruction.preamble`, `Instruction.to_dict()`) is untouched.

## Test plan
- [x] `tests/surveys/test_Instructions.py` — 4 passed
- [x] `tests/coop/test_coop_humanize_schema.py` — 33 passed
- [x] Manually verified `Coop._strip_instruction_preambles_for_humanize` removes `preamble` from `Instruction` entries only, leaving other question dicts untouched
- [x] Confirmed `Instruction.to_dict()` / `Instruction.preamble` still populated for the LLM prompt path (unchanged)


---
_Generated by [Claude Code](https://claude.ai/code/session_015jxV4d7mXVSB3x5mP3xo2n)_