### PR TITLE
Keep ep run output as JSON envelope

### DIFF
--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import sys
 import time
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from typing import Optional
 
@@ -177,59 +179,52 @@ def register(app: click.Group) -> None:
             error("RUN_ERROR", f"Failed to apply overrides: {e}", exit_code=EXIT_ERROR)
 
         # Step 4: Execute
+        if save and output_path:
+            error("USAGE_ERROR", "--save and --output are mutually exclusive.",
+                   exit_code=EXIT_USAGE)
+
+        if not background and not (save or output_path):
+            error(
+                "USAGE_ERROR",
+                "Completed run results must be written to a file.",
+                suggestion="Use '--output results.ep' or '--output results.json'. Use '--background' to submit a remote job and return metadata without waiting for results.",
+                exit_code=EXIT_USAGE,
+            )
+
         if background and not wait and (save or output_path):
             error("USAGE_ERROR", "Background jobs cannot be saved before completion.",
                    suggestion="Use 'ep jobs results <job_uuid> --output results.ep' after the job completes.",
                    exit_code=EXIT_USAGE)
 
+        envelope_warnings = []
         try:
-            results_obj = job.run(
-                progress_bar=progress,
-                background=background,
-                remote_inference_description=remote_inference_description,
-                remote_inference_results_visibility=remote_inference_results_visibility,
-                results_description=results_description,
-                fresh=fresh,
-                n=iterations,
-                disable_remote_inference=local,
-                verbose=False,
-            )
+            stdout_buffer = StringIO()
+            with redirect_stdout(stdout_buffer):
+                results_obj = job.run(
+                    progress_bar=progress,
+                    background=background,
+                    remote_inference_description=remote_inference_description,
+                    remote_inference_results_visibility=remote_inference_results_visibility,
+                    results_description=results_description,
+                    fresh=fresh,
+                    n=iterations,
+                    disable_remote_inference=local,
+                    verbose=False,
+                )
+            captured_stdout = stdout_buffer.getvalue().strip()
+            if captured_stdout:
+                envelope_warnings.append(
+                    {
+                        "code": "SUPPRESSED_STDOUT",
+                        "message": "Output emitted during job execution was captured to keep stdout as a single JSON envelope.",
+                        "output": captured_stdout,
+                    }
+                )
         except Exception as e:
             error("RUN_ERROR", f"Job execution failed: {e}", exit_code=EXIT_ERROR)
 
-        # Format output
-        if background:
-            result_data = []
-        else:
-            try:
-                result_data = []
-                for r in results_obj:
-                    entry = {}
-                    # Answer
-                    entry["answer"] = dict(r.get("answer", {})) if hasattr(r, 'get') else {}
-
-                    # Agent, scenario, model
-                    if hasattr(r, 'agent'):
-                        entry["agent"] = {"traits": dict(r.agent.traits) if hasattr(r.agent, 'traits') else {}}
-                    if hasattr(r, 'scenario'):
-                        entry["scenario"] = dict(r.scenario) if r.scenario else {}
-                    if hasattr(r, 'model'):
-                        entry["model"] = {
-                            "model": r.model.model if hasattr(r.model, 'model') else str(r.model),
-                            "service": r.model.inference_service if hasattr(r.model, 'inference_service') else "",
-                        }
-                    result_data.append(entry)
-            except Exception:
-                # Fallback: use select().to_dicts()
-                try:
-                    result_data = results_obj.select("answer.*").to_dicts(remove_prefix=True)
-                except Exception:
-                    result_data = []
-
         saved = None
-        if save and output_path:
-            error("USAGE_ERROR", "--save and --output are mutually exclusive.",
-                   exit_code=EXIT_USAGE)
+        result_count = 0 if background else _safe_len(results_obj)
 
         # Save if requested
         if (save or output_path) and not background:
@@ -247,7 +242,7 @@ def register(app: click.Group) -> None:
             "model_count": len(job.models) if hasattr(job, 'models') else 0,
             "agent_count": len(job.agents) if hasattr(job, 'agents') else 0,
             "scenario_count": len(job.scenarios) if hasattr(job, 'scenarios') else 0,
-            "result_count": len(result_data),
+            "result_count": result_count,
             "n": iterations,
             "local": local,
         }
@@ -268,7 +263,7 @@ def register(app: click.Group) -> None:
         if saved is not None:
             meta["saved"] = saved
 
-        output({"results": result_data, "meta": meta})
+        output({"results": [], "meta": meta}, warnings=envelope_warnings)
 
 
     def _wait_for_remote_job(
@@ -373,6 +368,13 @@ def register(app: click.Group) -> None:
             "errors": f"ep jobs errors {meta['job_uuid']} --output error.md" if meta.get("job_uuid") else None,
         }
         return meta
+
+
+    def _safe_len(obj) -> Optional[int]:
+        try:
+            return len(obj)
+        except Exception:
+            return None
 
 
     def _build_job(input_mode, input_path, jobs_path, survey_path, json_str, stdin_data,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3866,6 +3866,17 @@ class TestRunValidation:
                       expect_exit=2)
         assert out["error"]["code"] == "UNKNOWN_QUESTION_TYPE"
 
+    def test_run_completed_results_require_output(self):
+        result = CliRunner().invoke(
+            cli_module.app,
+            ["run", "--question", "What is your name?"],
+        )
+
+        assert result.exit_code == cli_module.EXIT_USAGE
+        out = json.loads(result.output)
+        assert out["error"]["code"] == "USAGE_ERROR"
+        assert "written to a file" in out["error"]["message"]
+
     def test_run_jobs_package_saves_results_package(self, tmp_path):
         from edsl import Agent, AgentList, Jobs, Model, ModelList, Scenario, ScenarioList
         from edsl.questions import QuestionFreeText
@@ -4067,6 +4078,44 @@ class TestRunValidation:
         assert remote_job["commands"]["status"] == "ep jobs status job-uuid"
         assert remote_job["commands"]["results"] == "ep jobs results job-uuid --output results.ep"
 
+    def test_run_stdout_remains_json_when_runner_prints(self, monkeypatch):
+        from types import SimpleNamespace
+        from edsl.jobs import Jobs
+        from edsl.results import Results
+
+        def fake_run(self, **kwargs):
+            print("Results UUID: results-uuid")
+            print("Results URL: https://www.expectedparrot.com/content/results-uuid")
+            job_info = SimpleNamespace(
+                creation_data={"uuid": "job-uuid", "status": "queued"},
+                job_uuid="job-uuid",
+                new_format=True,
+                logger=SimpleNamespace(
+                    jobs_info=SimpleNamespace(
+                        progress_bar_url="https://example.com/progress/job-uuid",
+                        remote_inference_url=None,
+                        remote_cache_url=None,
+                        results_uuid=None,
+                        results_url=None,
+                        error_report_url=None,
+                    )
+                ),
+            )
+            return Results.from_job_info(job_info)
+
+        monkeypatch.setattr(Jobs, "run", fake_run)
+
+        result = CliRunner().invoke(
+            cli_module.app,
+            ["run", "--question", "What is your name?", "--background"],
+        )
+
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["status"] == "ok"
+        assert out["warnings"][0]["code"] == "SUPPRESSED_STDOUT"
+        assert "Results UUID: results-uuid" in out["warnings"][0]["output"]
+
     def test_run_background_rejects_output(self):
         result = CliRunner().invoke(
             cli_module.app,
@@ -4246,7 +4295,7 @@ class TestRunValidation:
         out = json.loads(result.output)
         assert out["error"]["code"] == "USAGE_ERROR"
 
-    def test_run_passes_iterations_and_local_flags(self, monkeypatch):
+    def test_run_passes_iterations_and_local_flags(self, tmp_path, monkeypatch):
         from edsl import Agent
         from edsl.jobs import Jobs
         from edsl.language_models import Model
@@ -4278,6 +4327,7 @@ class TestRunValidation:
             return fake_results
 
         monkeypatch.setattr(Jobs, "run", fake_run)
+        output_path = tmp_path / "results.json"
 
         result = CliRunner().invoke(
             cli_module.app,
@@ -4289,6 +4339,8 @@ class TestRunValidation:
                 "3",
                 "--local",
                 "--fresh",
+                "--output",
+                str(output_path),
             ],
         )
 
@@ -4297,8 +4349,11 @@ class TestRunValidation:
         assert captured["disable_remote_inference"] is True
         assert captured["fresh"] is True
         out = json.loads(result.output)
+        assert out["data"]["results"] == []
         assert out["data"]["meta"]["n"] == 3
         assert out["data"]["meta"]["local"] is True
+        assert out["data"]["meta"]["saved"]["path"] == str(output_path)
+        assert output_path.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require blocking ep run calls to save completed Results with --output or --save
- keep ep run stdout as a small JSON envelope with result metadata, not inline result rows
- capture incidental stdout from job execution into warnings so stdout remains parseable JSON

## Tests
- pytest -q tests/test_cli.py -k TestRunValidation

Note: local test output included warnings from an unrelated unstaged price_manager.py edit in the worktree; that file is not part of this PR.