### PR TITLE
Fix $0 cost for image-generation questions on the direct-answer runner path

### DIFF
--- a/edsl/image_generation/generated_image.py
+++ b/edsl/image_generation/generated_image.py
@@ -4,6 +4,11 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+# Google reports roughly this many output tokens for a single generated image.
+# Used as a fallback when the provider response omits usage metadata so that a
+# generated image still carries a non-zero cost.
+FALLBACK_OUTPUT_TOKENS_PER_IMAGE = 1290
+
 
 class GeneratedImage(BaseModel):
     """A generated image plus provider metadata."""
@@ -14,6 +19,50 @@ class GeneratedImage(BaseModel):
     service_name: Optional[str] = None
     prompt: Optional[str] = None
     raw_response: Optional[dict[str, Any]] = None
+    # Normalized provider token usage, using edsl's Google field names
+    # (prompt_token_count / candidates_token_count / thoughts_token_count).
+    usage: Optional[dict[str, Any]] = None
+
+    def token_usage(self) -> dict[str, Optional[int]]:
+        """Return input/output/thinking token counts for cost calculation.
+
+        Reads the normalized ``usage`` metadata when present. When the provider
+        omits usage, falls back to a per-image output-token estimate and a
+        prompt-length-based input estimate so the image is still priced.
+        """
+        usage = self.usage or {}
+        input_tokens = usage.get("prompt_token_count")
+        output_tokens = usage.get("candidates_token_count")
+        thinking_tokens = usage.get("thoughts_token_count")
+
+        if not output_tokens:
+            output_tokens = FALLBACK_OUTPUT_TOKENS_PER_IMAGE
+        if not input_tokens:
+            # Rough estimate: ~4 characters per token.
+            input_tokens = max(1, len(self.prompt or "") // 4)
+
+        return {
+            "input_tokens": int(input_tokens),
+            "output_tokens": int(output_tokens),
+            "thinking_tokens": int(thinking_tokens) if thinking_tokens else None,
+        }
+
+    def cost(self):
+        """Compute a ResponseCost for this image, priced against its own model.
+
+        Attributes cost to the image service/model (e.g. google /
+        gemini-3.1-flash-image) rather than the interview's default model.
+        """
+        from ..language_models.price_manager import PriceManager
+
+        usage = self.token_usage()
+        return PriceManager().calculate_cost(
+            inference_service=self.service_name,
+            model=self.model,
+            usage=usage,
+            input_token_name="input_tokens",
+            output_token_name="output_tokens",
+        )
 
     @property
     def suffix(self) -> str:

--- a/edsl/image_generation/services/google_image_service.py
+++ b/edsl/image_generation/services/google_image_service.py
@@ -68,7 +68,9 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
         )
         output_image = getattr(interaction, "output_image", None)
         if output_image is None:
-            raise ValueError("Google image generation response did not include output_image.")
+            raise ValueError(
+                "Google image generation response did not include output_image."
+            )
 
         mime_type = getattr(output_image, "mime_type", None) or "image/png"
         return [
@@ -79,6 +81,7 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
                 service_name=self.service_name,
                 prompt=prompt,
                 raw_response=raw_response,
+                usage=self._extract_usage(raw_response),
             )
         ]
 
@@ -118,6 +121,7 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
                 service_name=self.service_name,
                 prompt=prompt,
                 raw_response=raw_response,
+                usage=self._extract_usage(raw_response),
             )
         ]
 
@@ -158,6 +162,76 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
                 return decoded[-1]
             raise
 
+    # Candidate key names for each token count, covering both the genai SDK's
+    # snake_case model_dump and the REST endpoint's camelCase, and the
+    # Interactions API's "response_token_count" alias for output tokens.
+    _INPUT_TOKEN_KEYS = ("prompt_token_count", "promptTokenCount")
+    _OUTPUT_TOKEN_KEYS = (
+        "candidates_token_count",
+        "candidatesTokenCount",
+        "response_token_count",
+        "responseTokenCount",
+    )
+    _THINKING_TOKEN_KEYS = ("thoughts_token_count", "thoughtsTokenCount")
+
+    @classmethod
+    def _extract_usage(cls, raw_response) -> Optional[dict]:
+        """Pull token usage out of a Google response into edsl's field names.
+
+        Searches for a ``usage_metadata``/``usage`` block anywhere in the
+        response (top level or nested within interaction steps) and normalizes
+        it to prompt_token_count / candidates_token_count / thoughts_token_count.
+        Returns None when no usage information is present.
+        """
+        usage_block = cls._find_usage_block(raw_response)
+        if not usage_block:
+            return None
+
+        def _first(keys):
+            for key in keys:
+                value = usage_block.get(key)
+                if value is not None:
+                    return value
+            return None
+
+        normalized = {
+            "prompt_token_count": _first(cls._INPUT_TOKEN_KEYS),
+            "candidates_token_count": _first(cls._OUTPUT_TOKEN_KEYS),
+            "thoughts_token_count": _first(cls._THINKING_TOKEN_KEYS),
+        }
+        if all(value is None for value in normalized.values()):
+            return None
+        return normalized
+
+    @classmethod
+    def _find_usage_block(cls, node, _depth: int = 0) -> Optional[dict]:
+        """Recursively locate a usage dict (bounded depth) within a response."""
+        if _depth > 6 or not isinstance(node, (dict, list)):
+            return None
+        if isinstance(node, dict):
+            for key in ("usage_metadata", "usageMetadata", "usage"):
+                candidate = node.get(key)
+                if isinstance(candidate, dict) and cls._looks_like_usage(candidate):
+                    return candidate
+            # The response itself may be the usage block.
+            if cls._looks_like_usage(node):
+                return node
+            for value in node.values():
+                found = cls._find_usage_block(value, _depth + 1)
+                if found:
+                    return found
+        else:
+            for item in node:
+                found = cls._find_usage_block(item, _depth + 1)
+                if found:
+                    return found
+        return None
+
+    @classmethod
+    def _looks_like_usage(cls, candidate: dict) -> bool:
+        keys = cls._INPUT_TOKEN_KEYS + cls._OUTPUT_TOKEN_KEYS
+        return any(key in candidate for key in keys)
+
     @staticmethod
     def _extract_image_block(raw_response: dict) -> dict:
         for step in raw_response.get("steps", []):
@@ -166,7 +240,9 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
             for content_block in step.get("content", []):
                 if content_block.get("type") == "image" and content_block.get("data"):
                     return content_block
-        raise ValueError("Google image generation response did not include an image block.")
+        raise ValueError(
+            "Google image generation response did not include an image block."
+        )
 
     @staticmethod
     def _response_has_image(raw_response: dict) -> bool:

--- a/edsl/image_generation/services/test_image_service.py
+++ b/edsl/image_generation/services/test_image_service.py
@@ -37,6 +37,11 @@ class TestImageGenerationService(ImageGenerationServiceABC):
                     "prompt": prompt,
                     "input_image_count": len(input_images or []),
                 },
+                usage={
+                    "prompt_token_count": max(1, len(prompt) // 4),
+                    "candidates_token_count": 1290,
+                    "thoughts_token_count": None,
+                },
             )
             for _ in range(n)
         ]

--- a/edsl/invigilators/invigilator_image_generation.py
+++ b/edsl/invigilators/invigilator_image_generation.py
@@ -22,12 +22,22 @@ class InvigilatorImageGeneration(InvigilatorBase):
         input_images = []
         if "files_list" in prompts:
             input_images = [
-                file for file in prompts["files_list"] if file.mime_type.startswith("image/")
+                file
+                for file in prompts["files_list"]
+                if file.mime_type.startswith("image/")
             ]
 
         generator = self.question.image_generator
-        image = await generator.async_generate(prompt_text, input_images=input_images)
-        raw_response = getattr(image, "raw_response", None)
+        # Request the GeneratedImage (not a FileStore) so provider usage /
+        # cost metadata is available; convert to a FileStore for the answer.
+        generated = await generator.async_generate(
+            prompt_text, input_images=input_images, return_type="generated_image"
+        )
+        if isinstance(generated, list):
+            generated = generated[0]
+        image = generated.to_filestore()
+        raw_response = generated.raw_response
+        cost = generated.cost()
 
         data = {
             "answer": image,
@@ -41,11 +51,11 @@ class InvigilatorImageGeneration(InvigilatorBase):
             "cache_key": None,
             "validated": True,
             "exception_occurred": None,
-            "input_tokens": None,
-            "output_tokens": None,
-            "thinking_tokens": None,
-            "input_price_per_million_tokens": None,
-            "output_price_per_million_tokens": None,
-            "total_cost": None,
+            "input_tokens": cost.input_tokens,
+            "output_tokens": cost.output_tokens,
+            "thinking_tokens": cost.thinking_tokens,
+            "input_price_per_million_tokens": cost.input_price_per_million_tokens,
+            "output_price_per_million_tokens": cost.output_price_per_million_tokens,
+            "total_cost": cost.total_cost,
         }
         return EDSLResultObjectInput(**data)

--- a/edsl/questions/question_image_generation.py
+++ b/edsl/questions/question_image_generation.py
@@ -86,17 +86,26 @@ class QuestionImageGeneration(QuestionBase):
         )
         prompt = Template(self.question_text).render(template_context)
         input_images = self._referenced_input_images(scenario, current_answers)
-        image = await self.image_generator.async_generate(
-            prompt, input_images=input_images
+        # Request the GeneratedImage so provider usage / cost metadata survives;
+        # convert to a FileStore for the answer.
+        generated = await self.image_generator.async_generate(
+            prompt, input_images=input_images, return_type="generated_image"
         )
+        if isinstance(generated, list):
+            generated = generated[0]
+        image = generated.to_filestore()
+        cost = generated.cost()
         return {
             "answer": image,
             "comment": None,
             "cached": False,
-            "input_tokens": 0,
-            "output_tokens": 0,
+            "input_tokens": cost.input_tokens,
+            "output_tokens": cost.output_tokens,
+            "input_price_per_million_tokens": cost.input_price_per_million_tokens,
+            "output_price_per_million_tokens": cost.output_price_per_million_tokens,
+            "total_cost": cost.total_cost,
             "generated_tokens": prompt,
-            "raw_model_response": getattr(image, "raw_response", None),
+            "raw_model_response": generated.raw_response,
             "user_prompt": prompt,
             "system_prompt": "",
         }
@@ -142,7 +151,9 @@ class QuestionImageGeneration(QuestionBase):
 
     @property
     def _invigilator_class(self):
-        from ..invigilators.invigilator_image_generation import InvigilatorImageGeneration
+        from ..invigilators.invigilator_image_generation import (
+            InvigilatorImageGeneration,
+        )
 
         return InvigilatorImageGeneration
 

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -104,7 +104,7 @@ class DirectAnswerRegistry:
         if isinstance(result, dict) and "answer" in result:
             return {
                 "answer": result["answer"],
-            "comment": result.get("comment"),
+                "comment": result.get("comment"),
                 "cached": False,
                 "input_tokens": 0,
                 "output_tokens": 0,
@@ -154,8 +154,11 @@ class DirectAnswerRegistry:
                 "answer": result.get("answer"),
                 "comment": result.get("comment", "Functional question result"),
                 "cached": False,
-                "input_tokens": 0,
-                "output_tokens": 0,
+                # Preserve any token/cost metadata the question reported (e.g.
+                # QuestionImageGeneration prices each generated image); most
+                # functional questions omit these and default to 0.
+                "input_tokens": result.get("input_tokens", 0),
+                "output_tokens": result.get("output_tokens", 0),
                 **{
                     key: value
                     for key, value in result.items()

--- a/edsl/runner/runner.py
+++ b/edsl/runner/runner.py
@@ -869,6 +869,13 @@ class Runner:
                     comment=result.get("comment"),
                     input_tokens=result.get("input_tokens", 0),
                     output_tokens=result.get("output_tokens", 0),
+                    thinking_tokens=result.get("thinking_tokens"),
+                    input_price_per_million_tokens=result.get(
+                        "input_price_per_million_tokens"
+                    ),
+                    output_price_per_million_tokens=result.get(
+                        "output_price_per_million_tokens"
+                    ),
                     raw_model_response=result.get("raw_model_response"),
                     generated_tokens=result.get("generated_tokens"),
                     cached=result.get("cached", False),

--- a/tests/questions/test_QuestionImageGeneration.py
+++ b/tests/questions/test_QuestionImageGeneration.py
@@ -59,6 +59,47 @@ def test_question_image_generation_runs_as_filestore_answer():
     assert generated_tokens == "Create an icon for surveys"
 
 
+def test_question_image_generation_reports_nonzero_cost():
+    """The direct-answer runner path must surface per-image token cost.
+
+    Regression guard: the split runner previously hardcoded direct-answer
+    token counts to 0, so image-generation questions always cost $0. The
+    test image service reports 1290 output tokens per image (matching the
+    Google flash-image model), and the answer must carry that through to the
+    ``*_cost`` / ``*_output_tokens`` result columns.
+    """
+    question = QuestionImageGeneration(
+        question_name="img",
+        question_text="Create an icon for {{ topic }}",
+        model="test-image",
+        service_name="test",
+    )
+
+    results = (
+        question.by(Model("test"))
+        .by(Scenario({"topic": "surveys"}))
+        .run(disable_remote_inference=True, stop_on_exception=True)
+    )
+
+    output_tokens = results.select("raw_model_response.img_output_tokens").to_list()[0]
+    input_tokens = results.select("raw_model_response.img_input_tokens").to_list()[0]
+    cost = results.select("raw_model_response.img_cost").to_list()[0]
+    in_price = results.select(
+        "raw_model_response.img_input_price_per_million_tokens"
+    ).to_list()[0]
+    out_price = results.select(
+        "raw_model_response.img_output_price_per_million_tokens"
+    ).to_list()[0]
+
+    assert output_tokens == 1290
+    assert input_tokens > 0
+    assert cost is not None and cost > 0
+    expected = (in_price / 1_000_000 * input_tokens) + (
+        out_price / 1_000_000 * output_tokens
+    )
+    assert abs(cost - expected) < 1e-9
+
+
 def test_question_image_generation_can_pipe_prior_image_answer():
     original = QuestionImageGeneration(
         question_name="image",


### PR DESCRIPTION
## Problem

`QuestionImageGeneration` jobs always reported **\$0 cost**. The question runs as a *direct answer* through the split runner, and its token/price metadata was dropped at two points on that path:

1. `runner/direct_answer.py::_execute_functional` **hardcoded** `input_tokens`/`output_tokens` to `0`, clobbering the counts the question reported.
2. `runner/runner.py::_execute_ready_direct_answers` never **forwarded the per-million prices** (or thinking tokens) to `on_task_completed`, so `service.py`'s `cost = tokens × price` computation ran against missing prices.

## Fix

- `_execute_functional` now passes through the question's real `input_tokens`/`output_tokens` (still defaults to 0 for functional questions that don't report them).
- `_execute_ready_direct_answers` forwards `input_price_per_million_tokens`, `output_price_per_million_tokens`, and `thinking_tokens`.
- Question side sources real usage: `GeneratedImage` carries provider `usage` and a `cost()` method; `google_image_service` extracts `usage_metadata` for both the generateContent and Interactions field names; `answer_question_directly` returns tokens/prices/total_cost.

## Verification

- Local `Survey.run()` of a QIG now yields non-zero `*_cost` and correct token columns.
- Real `google/gemini-3.1-flash-image` resolves to \$0.50/\$3.00 per 1M → `total_cost = 0.00388` for 12 in + 1290 out tokens.
- New regression test locks in non-zero cost through the runner path; existing QIG, runner, and `QuestionFunctional` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SV5i41t7vwHQLisCzvkFgQ