### PR TITLE
Add remote task timeout option

### DIFF
--- a/docs/en/latest/remote_inference.mdx
+++ b/docs/en/latest/remote_inference.mdx
@@ -3,6 +3,16 @@ title: "Remote Inference"
 description: "Remote inference allows you to run surveys at the Expected Parrot server instead of locally on your own machine, and to use [Remote Caching](/en/latest/remote_caching) to store survey results and logs at your account."
 ---
 
+## Per-interview execution timeout
+
+Use `--task-timeout` to limit how long each remotely executed interview may run:
+
+```bash
+ep run --jobs jobs.ep --task-timeout 900 --output results.ep
+```
+
+This is different from `--timeout`: `--task-timeout` is enforced for each interview on the remote worker, while `--timeout` limits how long the local CLI waits or polls. The value is specified in seconds and must be positive. It is supported by the current remote-inference format; the legacy format ignores it and emits a warning.
+
 <Note>
 *Note: You must have an Expected Parrot account in order to use remote inference and caching. By using remote inference you agree to any terms of use of service providers, which Expected Parrot may accept on your behalf and enforce in accordance with our terms of use.*
 </Note>

--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -47,6 +47,7 @@ def register(app: click.Group) -> None:
     @click.option("--wait", is_flag=True, default=False, help="With --background, poll until the remote job reaches a terminal status.")
     @click.option("--poll_interval", default=10.0, type=float, help="Seconds between status checks with --wait.")
     @click.option("--timeout", default=None, type=float, help="Maximum seconds to wait with --wait.")
+    @click.option("--task-timeout", default=None, type=click.IntRange(min=1), help="Maximum seconds for each remotely executed interview.")
     @click.option("--remote_inference_description", default=None, help="Description for the remote job.")
     @click.option("--remote_inference_results_visibility", default="private", type=click.Choice(["private", "public", "unlisted"]), help="Visibility for remote results.")
     @click.option("--results_description", default=None, help="Description for the remote results object.")
@@ -58,7 +59,7 @@ def register(app: click.Group) -> None:
     @click.argument("input_path", required=False, type=click.Path(exists=True))
     def run(jobs, survey, json_data, question, agent_list, scenario_list,
             model_list, model, qtype, options, name, progress, background,
-            wait, poll_interval, timeout, remote_inference_description,
+            wait, poll_interval, timeout, task_timeout, remote_inference_description,
             remote_inference_results_visibility, results_description, fresh,
             iterations, local, save, output_path, input_path):
         """Run question(s) and get results.
@@ -71,6 +72,7 @@ def register(app: click.Group) -> None:
           ep run --jobs jobs.ep --local --output results.ep
           ep run --jobs jobs.ep --background
           ep run --jobs jobs.ep --background --wait --timeout 600 --output results.ep
+          ep run --jobs jobs.ep --task-timeout 900 --output results.ep
           cat jobs.json | ep run --output results.json
         """
         from edsl.jobs import Jobs
@@ -206,6 +208,7 @@ def register(app: click.Group) -> None:
                     remote_inference_description=remote_inference_description,
                     remote_inference_results_visibility=remote_inference_results_visibility,
                     results_description=results_description,
+                    task_timeout=task_timeout,
                     fresh=fresh,
                     n=iterations,
                     disable_remote_inference=local,

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2056,6 +2056,7 @@ class Coop(CoopFunctionsMixin):
         iterations: Optional[int] = 1,
         fresh: Optional[bool] = False,
         alert_on_completion_config: Optional[Any] = None,
+        task_timeout: Optional[int] = None,
     ) -> RemoteInferenceCreationInfo:
         """
         Create a remote inference job for execution in the Expected Parrot cloud.
@@ -2159,6 +2160,7 @@ class Coop(CoopFunctionsMixin):
                 "message": "Job uploaded successfully",
                 "nr_questions": job.nr_questions,
                 "initial_results_description": initial_results_description,
+                "task_timeout": task_timeout,
             },
         )
         response_json = response.json()

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2152,16 +2152,19 @@ class Coop(CoopFunctionsMixin):
 
         job_uuid = response_json.get("job_uuid")
 
+        uploaded_payload = {
+            "job_uuid": job_uuid,
+            "message": "Job uploaded successfully",
+            "nr_questions": job.nr_questions,
+            "initial_results_description": initial_results_description,
+        }
+        if task_timeout is not None:
+            uploaded_payload["task_timeout"] = task_timeout
+
         response = self._send_server_request(
             uri="api/v0/new-remote-inference/uploaded",
             method="POST",
-            payload={
-                "job_uuid": job_uuid,
-                "message": "Job uploaded successfully",
-                "nr_questions": job.nr_questions,
-                "initial_results_description": initial_results_description,
-                "task_timeout": task_timeout,
-            },
+            payload=uploaded_payload,
         )
         response_json = response.json()
 

--- a/edsl/jobs/data_structures.py
+++ b/edsl/jobs/data_structures.py
@@ -89,6 +89,8 @@ class RunParameters(Base):
         new_format (bool): If True, uses remote_inference_create method, if False uses old_remote_inference_create method, default is True
         alert_on_completion_config (dict, optional): Config for job completion alerts (email and/or webhooks). Dict with "email" (bool) and "webhooks" (list of {"url": str}, max 3).
         results_description (str, optional): Description for the initial results object created by remote inference. Only used with offloaded execution.
+        task_timeout (int, optional): Maximum seconds allowed for each remotely
+            executed interview. The service may impose an upper bound.
     """
 
     n: int = 1
@@ -125,6 +127,7 @@ class RunParameters(Base):
     )
     alert_on_completion_config: Optional[dict] = None
     results_description: Optional[str] = None
+    task_timeout: Optional[int] = None
 
     def to_dict(self, add_edsl_version=False) -> dict:
         d = asdict(self)

--- a/edsl/jobs/jobs.py
+++ b/edsl/jobs/jobs.py
@@ -1160,6 +1160,7 @@ class Jobs(Base):
             new_format=self.run_config.parameters.new_format,
             alert_on_completion_config=self.run_config.parameters.alert_on_completion_config,
             results_description=self.run_config.parameters.results_description,
+            task_timeout=self.run_config.parameters.task_timeout,
         )
         return job_info
 

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -142,6 +142,7 @@ class JobsRemoteInferenceHandler:
         new_format: Optional[bool] = True,
         alert_on_completion_config: Optional[Any] = None,
         results_description: Optional[str] = None,
+        task_timeout: Optional[int] = None,
     ) -> RemoteJobInfo:
         """
         Create a remote inference job and return job information.
@@ -183,6 +184,7 @@ class JobsRemoteInferenceHandler:
                 fresh=fresh,
                 alert_on_completion_config=alert_on_completion_config,
                 initial_results_description=results_description,
+                task_timeout=task_timeout,
             )
         else:
             remote_job_creation_data = coop.old_remote_inference_create(

--- a/edsl/jobs/remote_inference.py
+++ b/edsl/jobs/remote_inference.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, Literal, TYPE_CHECKING, NewType, Callable, Any
 from dataclasses import dataclass
 import time
+import warnings
 from datetime import datetime
 
 
@@ -155,6 +156,7 @@ class JobsRemoteInferenceHandler:
             new_format: If True, use pull method for result retrieval; if False, use legacy get method
             alert_on_completion_config: Optional config for job completion alerts (email and/or webhooks)
             results_description: Optional description for the initial results object
+            task_timeout: Maximum execution time in seconds for each remote interview
 
         Returns:
             RemoteJobInfo: Information about the created job including UUID and logger
@@ -187,6 +189,12 @@ class JobsRemoteInferenceHandler:
                 task_timeout=task_timeout,
             )
         else:
+            if task_timeout is not None:
+                warnings.warn(
+                    "task_timeout is not supported by the legacy remote inference format and will be ignored.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             remote_job_creation_data = coop.old_remote_inference_create(
                 self.jobs,
                 description=remote_inference_description,


### PR DESCRIPTION
Adds `ep run --task-timeout SECONDS` for long-running remotely executed interviews while preserving `--timeout` as the local polling deadline. The value is propagated through RunParameters and remote job creation.\n\nValidation: 210 CLI tests passed; no-network payload smoke test confirmed task_timeout=900 reaches remote submission.