### PR TITLE
Pulling humanize responses should not rerun image generation; small fixes

### DIFF
--- a/edsl/agents/agent_direct_answering.py
+++ b/edsl/agents/agent_direct_answering.py
@@ -212,6 +212,15 @@ class AgentDirectAnswering:
             def transferred_method(self, question, scenario):
                 return answer_question_directly(question, scenario)
 
+            # Agents are duplicated through to_dict/from_dict, which drops
+            # attributes hung on the instance - this wrapper is the only thing
+            # that survives, so any routing metadata has to ride along on it.
+            stored = getattr(
+                answer_question_directly, "stored_answer_question_names", None
+            )
+            if stored is not None:
+                transferred_method.stored_answer_question_names = stored
+
             target_agent.direct_answering.add_method(transferred_method)
 
     def has_method(self) -> bool:

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -4076,6 +4076,7 @@ class Coop(CoopFunctionsMixin):
         from ..agents import Agent, AgentList
         from ..caching import Cache
         from ..language_models import Model
+        from ..runner.models import _decode_answer_value
         from ..scenarios import Scenario, ScenarioList
         from ..surveys import Survey
 
@@ -4124,10 +4125,22 @@ class Coop(CoopFunctionsMixin):
 
                 a = Agent(name=response_uuid, instruction="", traits=agent_traits)
 
-                def create_answer_function(response_data):
+                def create_answer_function(response_data, question_names):
                     def f(self, question, scenario):
-                        return response_data.get(question.question_name, None)
+                        return _decode_answer_value(
+                            response_data.get(question.question_name)
+                        )
 
+                    # Every question in a humanized survey is answered from the
+                    # recorded response, never recomputed. Question types that can
+                    # answer themselves (image generation, compute, diagram, random)
+                    # would otherwise re-execute here and discard what the
+                    # respondent's session actually produced. Names absent from the
+                    # response - e.g. an image whose generation failed at survey
+                    # time - resolve to None rather than triggering a fresh run.
+                    f.stored_answer_question_names = set(question_names) | set(
+                        response_data
+                    )
                     return f
 
                 scenario = None
@@ -4135,7 +4148,7 @@ class Coop(CoopFunctionsMixin):
                     scenario = Scenario.from_dict(json.loads(scenario_json_string))
 
                 a.add_direct_question_answering_method(
-                    create_answer_function(response_dict)
+                    create_answer_function(response_dict, survey.question_names)
                 )
 
                 job = survey.by(a).by(model)

--- a/edsl/image_generation/services/google_image_service.py
+++ b/edsl/image_generation/services/google_image_service.py
@@ -186,14 +186,22 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
             raise
 
     # Candidate key names for each token count, covering both the genai SDK's
-    # snake_case model_dump and the REST endpoint's camelCase, and the
-    # Interactions API's "response_token_count" alias for output tokens.
-    _INPUT_TOKEN_KEYS = ("prompt_token_count", "promptTokenCount")
+    # snake_case model_dump and the REST endpoint's camelCase, the Interactions
+    # API's "response_token_count" alias for output tokens, and the newer
+    # "total_input_tokens"/"total_output_tokens" names it reports today.
+    _INPUT_TOKEN_KEYS = (
+        "prompt_token_count",
+        "promptTokenCount",
+        "total_input_tokens",
+        "totalInputTokens",
+    )
     _OUTPUT_TOKEN_KEYS = (
         "candidates_token_count",
         "candidatesTokenCount",
         "response_token_count",
         "responseTokenCount",
+        "total_output_tokens",
+        "totalOutputTokens",
     )
     _THINKING_TOKEN_KEYS = ("thoughts_token_count", "thoughtsTokenCount")
 

--- a/edsl/image_generation/services/google_image_service.py
+++ b/edsl/image_generation/services/google_image_service.py
@@ -19,6 +19,21 @@ def _get_genai():
     return _genai
 
 
+def _sdk_supports_interactions() -> bool:
+    """Whether the installed google-genai can talk to the Interactions API.
+
+    Versions below 2.0.0 send a request the API no longer accepts, so we skip
+    the client on those and post to the REST endpoint ourselves instead.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        return Version(version("google-genai")) >= Version("2.0.0")
+    except (PackageNotFoundError, InvalidVersion):
+        return False
+
+
 class GoogleImageGenerationService(ImageGenerationServiceABC):
     service_name = "google"
 
@@ -46,6 +61,14 @@ class GoogleImageGenerationService(ImageGenerationServiceABC):
             create_kwargs["previous_interaction_id"] = kwargs["previous_interaction_id"]
         if "response_format" in kwargs and kwargs["response_format"] is not None:
             create_kwargs["response_format"] = kwargs["response_format"]
+
+        if not _sdk_supports_interactions():
+            return await self._async_generate_with_rest(
+                api_key=api_key,
+                prompt=prompt,
+                model=model,
+                payload=create_kwargs,
+            )
 
         try:
             genai = _get_genai()

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -212,6 +212,18 @@ def detect_execution_type(agent: Any, question: Any) -> str:
         "agent_direct" - Agent with direct answering method
         "llm" - Standard LLM execution (default)
     """
+    direct = getattr(agent, "answer_question_directly", None) if agent else None
+
+    # An agent replaying recorded answers can mark itself authoritative for
+    # specific question names by tagging its direct-answering method with
+    # stored_answer_question_names. Those names take priority over the
+    # question's own answer_question_directly, so a question type that can
+    # answer itself replays the stored value instead of re-executing. Opt-in:
+    # agents that don't set the attribute keep the original precedence.
+    stored = getattr(direct, "stored_answer_question_names", None)
+    if stored and getattr(question, "question_name", None) in stored:
+        return "agent_direct"
+
     # Check question-level first (QuestionFunctional)
     # These have answer_question_directly on the question itself
     if hasattr(question, "answer_question_directly"):
@@ -219,7 +231,7 @@ def detect_execution_type(agent: Any, question: Any) -> str:
 
     # Check agent-level direct answering
     # These have answer_question_directly on the agent
-    if agent and hasattr(agent, "answer_question_directly"):
+    if direct is not None:
         return "agent_direct"
 
     # Default to LLM execution

--- a/tests/runner/test_stored_answer_routing.py
+++ b/tests/runner/test_stored_answer_routing.py
@@ -1,0 +1,151 @@
+"""Routing for agents that replay recorded answers.
+
+An agent built from a stored human response tags its direct-answering method
+with ``stored_answer_question_names``. Those names have to outrank a question's
+own ``answer_question_directly``, otherwise question types that can answer
+themselves - image generation above all - re-execute and throw away what the
+respondent's session actually produced.
+"""
+
+import pytest
+
+from edsl.agents import Agent
+from edsl.questions import QuestionFreeText, QuestionCompute, QuestionImageGeneration
+from edsl.runner.direct_answer import detect_execution_type
+
+
+def _replaying_agent(response_data, question_names=None):
+    """An agent that answers from a recorded response dict."""
+
+    def f(self, question, scenario):
+        return response_data.get(question.question_name)
+
+    names = question_names if question_names is not None else response_data
+    f.stored_answer_question_names = set(names) | set(response_data)
+
+    agent = Agent(traits={})
+    agent.add_direct_question_answering_method(f)
+    return agent
+
+
+def _plain_agent():
+    def f(self, question, scenario):
+        return "direct"
+
+    agent = Agent(traits={})
+    agent.add_direct_question_answering_method(f)
+    return agent
+
+
+IMAGE_Q = QuestionImageGeneration(
+    question_name="portrait",
+    question_text="Draw a house.",
+    model="test-image",
+    service_name="test",
+)
+COMPUTE_Q = QuestionCompute(question_name="total", question_text="{{ n }}")
+TEXT_Q = QuestionFreeText(question_name="why", question_text="Why?")
+
+
+class TestStoredAnswersOutrankSelfAnsweringQuestions:
+    def test_image_generation_replays_instead_of_regenerating(self):
+        agent = _replaying_agent({"portrait": {"base64_string": "abc"}})
+        assert detect_execution_type(agent, IMAGE_Q) == "agent_direct"
+
+    def test_compute_replays_instead_of_recomputing(self):
+        agent = _replaying_agent({"total": 42})
+        assert detect_execution_type(agent, COMPUTE_Q) == "agent_direct"
+
+    def test_plain_question_still_routes_to_agent(self):
+        agent = _replaying_agent({"why": "because"})
+        assert detect_execution_type(agent, TEXT_Q) == "agent_direct"
+
+    def test_missing_answer_still_replays_when_question_is_in_the_survey(self):
+        """A failed image generation has no stored value, but must not re-run.
+
+        Coverage is survey-scoped, so the name is authoritative even though the
+        response dict has no entry for it. The answer resolves to None.
+        """
+        agent = _replaying_agent({"why": "because"}, question_names=["why", "portrait"])
+        assert detect_execution_type(agent, IMAGE_Q) == "agent_direct"
+
+    def test_question_outside_the_covered_set_keeps_old_behavior(self):
+        agent = _replaying_agent({"why": "because"})
+        assert detect_execution_type(agent, IMAGE_Q) == "functional"
+
+
+class TestOptInDoesNotDisturbNormalJobs:
+    def test_self_answering_question_still_wins_without_the_tag(self):
+        assert detect_execution_type(_plain_agent(), IMAGE_Q) == "functional"
+        assert detect_execution_type(_plain_agent(), COMPUTE_Q) == "functional"
+
+    def test_agent_without_direct_answering_routes_to_llm(self):
+        assert detect_execution_type(Agent(traits={}), TEXT_Q) == "llm"
+
+    def test_no_agent_routes_to_llm(self):
+        assert detect_execution_type(None, TEXT_Q) == "llm"
+
+    def test_empty_covered_set_falls_through(self):
+        """An empty set means nothing recorded - don't hijack routing."""
+        agent = _replaying_agent({})
+        assert detect_execution_type(agent, IMAGE_Q) == "functional"
+
+
+class TestTagSurvivesAgentDuplication:
+    """Agents round-trip through to_dict/from_dict during a run.
+
+    Only the direct-answering method is carried across, by transfer_to, so the
+    tag has to travel on that wrapper. If it doesn't, routing silently reverts
+    and the regression is invisible.
+    """
+
+    def test_duplicate_preserves_the_covered_set(self):
+        agent = _replaying_agent({"portrait": None}, question_names=["portrait"])
+        copy = agent.duplicate()
+        assert copy.answer_question_directly.stored_answer_question_names == {
+            "portrait"
+        }
+
+    def test_duplicate_preserves_routing(self):
+        agent = _replaying_agent({"portrait": None}, question_names=["portrait"])
+        assert detect_execution_type(agent.duplicate(), IMAGE_Q) == "agent_direct"
+
+    def test_duplicate_without_the_tag_is_unaffected(self):
+        copy = _plain_agent().duplicate()
+        assert getattr(
+            copy.answer_question_directly, "stored_answer_question_names", None
+        ) is None
+        assert detect_execution_type(copy, IMAGE_Q) == "functional"
+
+
+class TestStoredImagesDecodeToFileStore:
+    """The wire form of a stored image has to come back as a real FileStore.
+
+    ImageGenerationResponse rejects anything without .base64_string/.mime_type,
+    so a raw dict off json.loads would fail validation downstream.
+    """
+
+    def test_filestore_round_trips(self):
+        from edsl.runner.models import _encode_answer_value, _decode_answer_value
+        from edsl.scenarios import FileStore
+
+        # example() returns None when the handler for a suffix isn't registered
+        original = FileStore.example("png")
+        if original is None:
+            pytest.skip("png FileStore handler unavailable")
+
+        decoded = _decode_answer_value(_encode_answer_value(original))
+        assert isinstance(decoded, FileStore)
+        assert decoded.base64_string == original.base64_string
+        assert decoded.mime_type == original.mime_type
+
+    def test_none_passes_through(self):
+        from edsl.runner.models import _decode_answer_value
+
+        assert _decode_answer_value(None) is None
+
+    def test_scalars_pass_through(self):
+        from edsl.runner.models import _decode_answer_value
+
+        assert _decode_answer_value("because") == "because"
+        assert _decode_answer_value(42) == 42


### PR DESCRIPTION
- Replaying agent answers should take priority over `answer_question_directly` for QuestionImageGeneration (QIG's answering method calls `async_generate`). Otherwise, we get `None` as an answer when calling `Coop._turn_human_responses_into_results`.

Small fixes:
- Skip unnecessary `interactions.create()` call when the `google-genai` version is less than 2 (this call will always error because the legacy interactions API is no longer supported). Go straight to `async_with_rest`. 
- Fix token counting for image generation - we were using legacy token names, causing token counting to fall back to an estimate instead of the actual number.