### PR TITLE
Preserve Survey question IDs and add native .ep merges

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
           "en/latest/questions",
           "en/latest/scenarios",
           "en/latest/surveys",
+          "en/latest/survey_ep_format",
           "en/latest/agents",
           "en/latest/prompts",
           "en/latest/language_models"

--- a/docs/en/latest/survey_ep_format.mdx
+++ b/docs/en/latest/survey_ep_format.mdx
@@ -436,6 +436,109 @@ survey.git.switch("main")
 requires a clean package before switching, pulling, or checking out another
 version, which protects uncommitted changes.
 
+## Merge a survey branch
+
+Suppose the `short-form` branch removes the follow-up question `q1`:
+
+```python
+survey.git.switch("short-form")
+survey.delete_question("q1")
+survey.git.save(message="Remove follow-up from short form")
+```
+
+At this point, `main` still has all three questions and `short-form` has two.
+Switch back before merging:
+
+```python
+survey.git.switch("main")
+survey.question_names
+```
+
+```python
+["q0", "q1", "q2"]
+```
+
+EDSL exposes branch creation and switching, but does not currently have a
+high-level `survey.git.merge()` method. The package is a real Git repository,
+so use Git for the merge:
+
+```python
+import subprocess
+
+subprocess.run(
+    [
+        "git",
+        "-C",
+        str(survey.git.worktree_path),
+        "-c",
+        "user.name=EDSL",
+        "-c",
+        "user.email=edsl@example.invalid",
+        "merge",
+        "--no-ff",
+        "short-form",
+        "-m",
+        "Merge short-form survey",
+    ],
+    check=True,
+)
+```
+
+`--no-ff` asks Git to create a merge commit even though this simple example
+could be fast-forwarded. That makes the point where the alternative survey
+entered `main` visible in history.
+
+The Git operation changes the unpacked working tree. Refresh the in-memory
+`Survey` from the merged branch and repack the `.ep` archive:
+
+```python
+survey.git.switch("main")
+survey.question_names
+```
+
+```python
+["q0", "q2"]
+```
+
+Calling `switch("main")` here is intentional even though Git is already on
+`main`: it reloads the merged files into the EDSL object and writes the
+updated repository back into `example-survey.ep`.
+
+The package history now contains a two-parent merge:
+
+```python
+survey.git.log()[:3]
+```
+
+```python
+[
+    {"message": "Merge short-form survey", "...": "..."},
+    {"message": "Remove follow-up from short form", "...": "..."},
+    {"message": "Create example survey", "...": "..."},
+]
+```
+
+From an unpacked inspection copy, Git can display the topology:
+
+```bash
+git log --graph --oneline --all
+```
+
+```text
+*   <merge> Merge short-form survey
+|\
+| * <branch> Remove follow-up from short form
+|/
+*   <initial> Create example survey
+```
+
+This is more informative than copying the short survey over the long one. The
+merge records both lines of development, their common ancestor, and the exact
+decision that joined them. If both branches edit the same part of a question
+or manifest, Git stops with a conflict rather than silently choosing one
+survey design; resolve the affected JSON, commit the resolution, reload the
+Survey, and repack the archive in the same way.
+
 ## Communicate only the changes
 
 An `.ep` file is already a self-contained handoff: its recipient gets both the

--- a/docs/en/latest/survey_ep_format.mdx
+++ b/docs/en/latest/survey_ep_format.mdx
@@ -458,41 +458,47 @@ survey.question_names
 ["q0", "q1", "q2"]
 ```
 
-EDSL exposes branch creation and switching, but does not currently have a
-high-level `survey.git.merge()` method. The package is a real Git repository,
-so use Git for the merge:
+Merge the branch through the same Git-backed accessor:
 
 ```python
-import subprocess
-
-subprocess.run(
-    [
-        "git",
-        "-C",
-        str(survey.git.worktree_path),
-        "-c",
-        "user.name=EDSL",
-        "-c",
-        "user.email=edsl@example.invalid",
-        "merge",
-        "--no-ff",
-        "short-form",
-        "-m",
-        "Merge short-form survey",
-    ],
-    check=True,
+merge_info = survey.git.merge(
+    "short-form",
+    message="Merge short-form survey",
+    no_ff=True,
 )
+merge_info
 ```
 
-`--no-ff` asks Git to create a merge commit even though this simple example
+```python
+{
+    "status": "ok",
+    "path": "example-survey.ep",
+    "commit": "<merge-commit>",
+    "branch": "main",
+    "merged_ref": "short-form",
+    "fast_forward": False,
+    "changed": [
+        "manifest.json",
+        "metadata/memory_plan.json",
+        "metadata/rule_collection.json",
+        "questions/000002.json",
+    ],
+    "conflicts": [],
+    "aborted": False,
+    "message": "Merge short-form survey",
+}
+```
+
+`no_ff=True` asks Git to create a merge commit even though this simple example
 could be fast-forwarded. That makes the point where the alternative survey
 entered `main` visible in history.
 
-The Git operation changes the unpacked working tree. Refresh the in-memory
-`Survey` from the merged branch and repack the `.ep` archive:
+The method completes all three layers of the operation: it merges the embedded
+repository, reloads the merged files into the in-memory `Survey`, and repacks
+the repository into `example-survey.ep`. The object is ready to use
+immediately:
 
 ```python
-survey.git.switch("main")
 survey.question_names
 ```
 
@@ -500,22 +506,14 @@ survey.question_names
 ["q0", "q2"]
 ```
 
-Calling `switch("main")` here is intentional even though Git is already on
-`main`: it reloads the merged files into the EDSL object and writes the
-updated repository back into `example-survey.ep`.
-
-The package history now contains a two-parent merge:
+The newest package history entry is the merge commit:
 
 ```python
-survey.git.log()[:3]
+survey.git.log()[0]
 ```
 
 ```python
-[
-    {"message": "Merge short-form survey", "...": "..."},
-    {"message": "Remove follow-up from short form", "...": "..."},
-    {"message": "Create example survey", "...": "..."},
-]
+{"message": "Merge short-form survey", "...": "..."}
 ```
 
 From an unpacked inspection copy, Git can display the topology:
@@ -534,10 +532,37 @@ git log --graph --oneline --all
 
 This is more informative than copying the short survey over the long one. The
 merge records both lines of development, their common ancestor, and the exact
-decision that joined them. If both branches edit the same part of a question
-or manifest, Git stops with a conflict rather than silently choosing one
-survey design; resolve the affected JSON, commit the resolution, reload the
-Survey, and repack the archive in the same way.
+decision that joined them.
+
+### What happens on a conflict
+
+If both branches edit the same part of a question or manifest, EDSL does not
+silently choose one survey design. It aborts the merge, leaves the current
+branch and `.ep` archive unchanged, and returns a structured report:
+
+```python
+conflict = survey.git.merge("alternative-wording", no_ff=True)
+```
+
+```python
+{
+    "status": "conflict",
+    "path": "example-survey.ep",
+    "commit": "<unchanged-main-commit>",
+    "branch": "main",
+    "merged_ref": "alternative-wording",
+    "fast_forward": False,
+    "changed": [],
+    "conflicts": ["questions/000001.json"],
+    "aborted": True,
+    "message": "merge of alternative-wording aborted due to conflicts",
+}
+```
+
+The automatic abort is important for a portable package: the in-memory
+Survey, embedded working tree, and archived `.ep` file continue to describe
+the same committed object. A researcher can inspect the reported files,
+revise one of the branches, and try the merge again.
 
 ## Communicate only the changes
 
@@ -641,6 +666,9 @@ latest.git.diff("HEAD~1", "HEAD")
 latest.git.tag("pilot-v1", message="Pilot instrument")
 latest.git.branch("alternative")
 latest.git.switch("alternative")
+# Edit and save the alternative, then merge it into main.
+latest.git.switch("main")
+latest.git.merge("alternative", message="Merge alternative", no_ff=True)
 
 # Validate and synchronize
 latest.git.validate()

--- a/docs/en/latest/survey_ep_format.mdx
+++ b/docs/en/latest/survey_ep_format.mdx
@@ -1,0 +1,562 @@
+---
+title: "Versioning Surveys with .ep Files"
+description: "A hands-on tour of the Git-backed .ep format for EDSL Surveys: package contents, commits, diffs, history, and efficient collaboration."
+---
+
+An EDSL `Survey` can be saved either as serialized JSON or as an `.ep`
+package. JSON is useful for a quick interchange. An `.ep` package is intended
+for work that will evolve: it keeps the survey's current state and its Git
+history together in one portable file.
+
+This tutorial creates a package from `Survey.example()`, opens it up, changes
+one question, and follows that change through Git.
+
+## The format in one picture
+
+```text
+example-survey.ep                   one portable ZIP-compatible file
+└── unpacked contents               a complete Git working tree
+    ├── .git/                       commits, trees, blobs, refs, and configuration
+    ├── manifest.json               package type, format version, and question order
+    ├── questions/
+    │   ├── 000001.json             one question per file
+    │   ├── 000002.json
+    │   └── 000003.json
+    └── metadata/
+        ├── memory_plan.json
+        ├── question_groups.json
+        └── rule_collection.json
+```
+
+There are two layers to keep straight:
+
+- On disk, `example-survey.ep` is a single ZIP-compatible archive. It is easy
+  to attach, copy, archive, or deposit in a replication package.
+- Inside the archive is a real Git repository. EDSL uses that repository for
+  commits, history, diffs, branches, tags, and synchronization.
+
+The `.ep` suffix therefore does not mean “a JSON file with another extension.”
+It means “a portable EDSL object with its version history.”
+
+## Create the example Survey
+
+Start with EDSL's built-in example:
+
+```python
+from edsl import Survey
+
+survey = Survey.example()
+survey
+```
+
+The example has three multiple-choice questions named `q0`, `q1`, and `q2`.
+Save it as a package with an informative commit message:
+
+```python
+first_save = survey.git.save(
+    "example-survey.ep",
+    message="Create example survey",
+)
+first_save
+```
+
+A successful save returns package and commit information:
+
+```python
+{
+    "status": "ok",
+    "path": "example-survey.ep",
+    "commit": "65801c7e03eb93c0f31c8bee6b2a29cc9152be14",
+    "branch": "main",
+    "message": "Create example survey",
+}
+```
+
+Your commit hash will differ. Git derives it from the commit and its contents,
+so it is an identifier for that particular version.
+
+Calling `save()` again without changing the survey does not create an empty
+commit:
+
+```python
+survey.git.save(message="Save again")
+```
+
+```python
+{
+    "status": "unchanged",
+    "path": "example-survey.ep",
+    "commit": "...",
+    "branch": "main",
+    "message": "no changes",
+}
+```
+
+This makes repeated saves safe: history records substantive package changes,
+not every call to `save()`.
+
+## Inspect the package as an EDSL object
+
+For ordinary use, let EDSL inspect and load the file:
+
+```bash
+ep inspect example-survey.ep
+```
+
+The CLI writes a JSON envelope to stdout:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "object_type": "Survey",
+    "length": 3,
+    "question_count": 3,
+    "question_names": ["q0", "q1", "q2"],
+    "question_types": [
+      "multiple_choice",
+      "multiple_choice",
+      "multiple_choice"
+    ]
+  },
+  "warnings": []
+}
+```
+
+Load the latest committed version in Python with:
+
+```python
+loaded = Survey.git.load("example-survey.ep")
+loaded == survey
+```
+
+```python
+True
+```
+
+Loading binds the object to its package. A later
+`loaded.git.save(message="...")` writes a new version back to the same `.ep`
+file unless a different path is supplied.
+
+## Unpack the Git repository
+
+You do not need to unpack a package to use it. Unpacking is useful when you
+want to audit the representation or use lower-level Git commands:
+
+```bash
+ep unpack example-survey.ep
+```
+
+The returned JSON includes a temporary directory in `data.path` and a
+`next_step` command. Change into that directory:
+
+```bash
+cd /tmp/path-returned-by-ep-unpack
+git status
+git log --oneline --decorate
+```
+
+<Warning>
+The directory returned by `ep unpack` is a temporary inspection copy. Editing
+it does not rewrite the original `.ep` archive. Make durable changes through
+the loaded EDSL object and call `save()`.
+</Warning>
+
+Because `.ep` is ZIP-compatible, a standard archive utility can also confirm
+what is present:
+
+```bash
+unzip -l example-survey.ep
+```
+
+The listing includes `.git/HEAD`, `.git/objects/`, `.git/refs/heads/main`, the
+manifest, question files, and survey metadata. EDSL omits transient Git files
+such as hooks when packing the archive.
+
+## Read the working-tree files
+
+The manifest identifies the format and reconstructs question order:
+
+```json
+{
+  "edsl_class_name": "Survey",
+  "edsl_version": "1.0.8.dev1",
+  "format": "edsl.survey.git_package",
+  "format_version": 1,
+  "n_questions": 3,
+  "object_type": "Survey",
+  "question_order": [
+    "000001",
+    "000002",
+    "000003"
+  ]
+}
+```
+
+The exact `edsl_version` reflects the installed version that wrote the
+package.
+
+Each question is stored separately. For example,
+`questions/000001.json` contains:
+
+```json
+{
+  "question_name": "q0",
+  "question_options": [
+    "yes",
+    "no"
+  ],
+  "question_text": "Do you like school?",
+  "question_type": "multiple_choice"
+}
+```
+
+The split representation is deliberate. If a survey has 500 questions and
+one changes, Git does not need to treat one giant serialized survey document
+as the unit of review. The diff can focus on the affected question and any
+metadata that actually changed.
+
+The files under `metadata/` preserve behavior that is not contained in an
+individual question:
+
+- `rule_collection.json` stores survey flow, including skip and stop rules.
+- `memory_plan.json` records which earlier answers are made available later.
+- `question_groups.json` records named groups.
+
+Optional survey properties, when present, are stored in additional metadata
+files such as `name.json`, `questions_to_randomize.json`, and
+`options_to_pin.json`.
+
+## Make and commit a change
+
+Change the wording of the first question:
+
+```python
+survey = Survey.git.load("example-survey.ep")
+survey.questions[0].question_text = "Do you enjoy school?"
+
+second_save = survey.git.save(
+    message="Clarify the first question",
+)
+second_save
+```
+
+The package remains one file, but it now contains two commits. View them
+without unpacking:
+
+```python
+survey.git.log()
+```
+
+```python
+[
+    {
+        "commit": "d1f44ff624288e48e8835597d247c039ceffeb48",
+        "message": "Clarify the first question",
+        "timestamp": "2026-07-29 07:47:56 -0400",
+    },
+    {
+        "commit": "65801c7e03eb93c0f31c8bee6b2a29cc9152be14",
+        "message": "Create example survey",
+        "timestamp": "2026-07-29 07:47:34 -0400",
+    },
+]
+```
+
+Again, hashes and timestamps will differ.
+
+Now ask Git what changed:
+
+```python
+print(survey.git.diff("HEAD~1", "HEAD"))
+```
+
+The essential part of the diff is:
+
+```diff
+diff --git a/questions/000001.json b/questions/000001.json
+index 353b419..33b47da 100644
+--- a/questions/000001.json
++++ b/questions/000001.json
+@@
+-  "question_text": "Do you like school?",
++  "question_text": "Do you enjoy school?",
+```
+
+Two identifiers are doing different jobs:
+
+- `q0` is the EDSL `question_name`. Prompts, rules, and results use it to refer
+  to the logical question.
+- `000001` is the package-internal question ID. EDSL uses `question_name` to
+  recognize the same logical question and retain this file ID when its wording,
+  options, or other properties change.
+
+The manifest and the other two question files do not change. A genuinely new
+question receives the next available package ID; deleting a question removes
+its file from the current tree while retaining it in Git history.
+
+## What Git stores
+
+The `.git` directory does not contain a second full copy of the survey for
+every version. Git stores content-addressed objects:
+
+- **blobs** hold file contents;
+- **trees** describe directory snapshots;
+- **commits** point to a tree, a parent commit, and commit metadata;
+- **refs** such as `main` and tags give memorable names to commits.
+
+From the unpacked repository, inspect the current commit:
+
+```bash
+git cat-file -p HEAD
+```
+
+Representative output:
+
+```text
+tree <tree-id>
+parent <first-commit-id>
+author EDSL <edsl@example.invalid> ...
+committer EDSL <edsl@example.invalid> ...
+
+Clarify the first question
+```
+
+Follow the tree to a stored file:
+
+```bash
+git ls-tree HEAD
+git ls-tree HEAD:questions
+git show HEAD:questions/000001.json
+git show HEAD~1:questions/000001.json
+```
+
+The last two commands read different survey versions directly from Git
+without changing the working tree.
+
+Git addresses every stored object by a hash of its contents. Files that did
+not change are reused by the new tree instead of being stored as new logical
+versions. When repositories are packed or transferred, Git can also delta
+compress similar objects. This is why Git can communicate a small survey
+revision without treating the entire history as an opaque replacement file.
+
+The `.ep` archive itself is repacked after a save, so copying the file with a
+generic file-copy tool still copies the whole archive. The transfer
+efficiency comes into play when the embedded repository is synchronized with
+a Git remote through EDSL's push and pull operations.
+
+## Load or render an older version
+
+Save the first commit ID before making further changes:
+
+```python
+first_commit = first_save["commit"]
+```
+
+Load that exact historical survey:
+
+```python
+original = Survey.git.load(
+    "example-survey.ep",
+    ref=first_commit,
+)
+
+original.questions[0].question_text
+```
+
+```python
+"Do you like school?"
+```
+
+The current version remains:
+
+```python
+current = Survey.git.load("example-survey.ep")
+current.questions[0].question_text
+```
+
+```python
+"Do you enjoy school?"
+```
+
+The CLI can also render a historical version to HTML:
+
+```bash
+ep open example-survey.ep --ref <first-commit-id> --output original-survey.html
+```
+
+This is useful in review or replication: a commit ID identifies the exact
+survey being discussed, even after the package has moved forward.
+
+## Name important versions
+
+Commit IDs are precise but not memorable. Add a Git tag to a milestone:
+
+```python
+survey.git.tag(
+    "pilot-v1",
+    message="Survey used for the first pilot",
+)
+```
+
+List tags:
+
+```python
+survey.git.tags()
+```
+
+```python
+["pilot-v1"]
+```
+
+Tags are helpful for statements such as “the preregistered instrument was
+`pilot-v1`” or “production used `field-v2`.” A verifier can resolve the tag to
+the exact commit and inspect the difference between milestones.
+
+## Explore alternatives with branches
+
+Branches let collaborators develop alternative instruments without
+overwriting the main line:
+
+```python
+survey.git.branch("short-form")
+survey.git.switch("short-form")
+
+# Make edits to the in-memory Survey here.
+survey.git.save(message="Create short-form variant")
+```
+
+Return to the main version:
+
+```python
+survey.git.switch("main")
+```
+
+`switch()` refreshes the in-memory `Survey` from the selected branch. EDSL
+requires a clean package before switching, pulling, or checking out another
+version, which protects uncommitted changes.
+
+## Communicate only the changes
+
+An `.ep` file is already a self-contained handoff: its recipient gets both the
+current Survey and its history. For ongoing collaboration, attach a Git remote
+and use EDSL's synchronization methods:
+
+```python
+survey.git.remote_add("origin", "<git-remote-url>")
+survey.git.push("origin")
+```
+
+A collaborator can clone the package and later fetch or pull new commits:
+
+```python
+collaborator = Survey.git.clone(
+    "<git-remote-url>",
+    "collaborator-copy.ep",
+)
+
+collaborator.git.pull()
+```
+
+At the CLI level, Expected Parrot-backed packages can be shared with:
+
+```bash
+ep push example-survey.ep
+ep pull example-survey.ep
+```
+
+Git negotiates which objects the receiver already has and transfers the
+missing objects. This matters when a team repeatedly revises a large survey:
+the communication unit is a commit and its changed objects, not a succession
+of unrelated `survey-final-2-revised.json` files.
+
+## Working inside another Git repository
+
+An `.ep` package contains its own Git repository. If it is placed inside a
+different Git repository, the outer Git repository sees an embedded
+repository. EDSL warns about this because the relationship should be
+intentional.
+
+Usually, choose one of these approaches:
+
+- Ignore the `.ep` package in the outer repository and let its own Git history
+  and remote manage it.
+- Intentionally manage it as a Git submodule.
+- Store an exported JSON snapshot in the outer repository when independent
+  `.ep` history is unnecessary.
+
+For the first option, a loaded package can update the outer `.gitignore`:
+
+```python
+survey.git.ignore_in_parent()
+```
+
+## Why this design is useful
+
+For survey research, a Git-backed object provides several practical
+guarantees:
+
+1. **Exact references.** A commit hash identifies the complete survey,
+   including questions, order, rules, memory, and groups.
+2. **Readable review.** Questions and metadata are formatted JSON, so a
+   reviewer can see wording and logic changes as ordinary diffs.
+3. **Focused changes.** Unchanged questions retain their stored objects;
+   revisions affect the relevant question and dependent metadata.
+4. **Recoverable history.** Old instruments remain loadable even after the
+   working version changes.
+5. **Named milestones.** Tags can identify preregistration, pilot, field, and
+   publication versions.
+6. **Parallel development.** Branches can hold experimental variants.
+7. **Efficient synchronization.** Git remotes exchange missing objects rather
+   than treating every revision as an unrelated dataset.
+8. **Portable provenance.** Copying one `.ep` file carries the current object
+   and its complete embedded history.
+
+The result is a survey format that works at two levels: researchers can use it
+as a normal EDSL `Survey`, while reviewers and collaborators can use familiar
+Git concepts to understand how that Survey evolved.
+
+## Command reference
+
+```python
+from edsl import Survey
+
+# Create and save
+survey = Survey.example()
+info = survey.git.save("example-survey.ep", message="Initial survey")
+
+# Load latest or historical state
+latest = Survey.git.load("example-survey.ep")
+older = Survey.git.load("example-survey.ep", ref=info["commit"])
+
+# Inspect history and changes
+latest.git.status()
+latest.git.log()
+latest.git.diff("HEAD~1", "HEAD")
+
+# Mark and navigate versions
+latest.git.tag("pilot-v1", message="Pilot instrument")
+latest.git.branch("alternative")
+latest.git.switch("alternative")
+
+# Validate and synchronize
+latest.git.validate()
+latest.git.remotes()
+latest.git.push()
+latest.git.pull()
+```
+
+```bash
+# Inspect without writing
+ep inspect example-survey.ep
+
+# Unpack a temporary audit copy
+ep unpack example-survey.ep
+
+# Render the latest or a historical version
+ep open example-survey.ep --output survey.html
+ep open example-survey.ep --ref <commit> --output old-survey.html
+
+# Use the package in a job
+ep run --survey example-survey.ep --model test --output results.ep
+```

--- a/docs/en/latest/survey_ep_format.mdx
+++ b/docs/en/latest/survey_ep_format.mdx
@@ -283,17 +283,42 @@ index 353b419..33b47da 100644
 +  "question_text": "Do you enjoy school?",
 ```
 
-Two identifiers are doing different jobs:
+Three identifiers are doing different jobs:
 
-- `q0` is the EDSL `question_name`. Prompts, rules, and results use it to refer
-  to the logical question.
-- `000001` is the package-internal question ID. EDSL uses `question_name` to
-  recognize the same logical question and retain this file ID when its wording,
-  options, or other properties change.
+- `0` is the question's current position in the Survey.
+- `q0` is its EDSL `question_name`. Prompts, rules, and results use this name
+  to refer to the logical question.
+- `000001` is its stable package file ID. It is not a position and it is not
+  the public question name.
 
 The manifest and the other two question files do not change. A genuinely new
 question receives the next available package ID; deleting a question removes
 its file from the current tree while retaining it in Git history.
+
+The package ID also survives a pure `question_name` rename:
+
+```python
+survey.git.branch("rename-demo")
+survey.git.switch("rename-demo")
+survey = survey.with_renamed_question("q0", "school_enjoyment")
+survey.git.save("example-survey.ep", message="Rename q0")
+```
+
+```diff
+diff --git a/questions/000001.json b/questions/000001.json
+-  "question_name": "q0",
++  "question_name": "school_enjoyment",
+```
+
+That is why the package needs an identity separate from `question_name`:
+renaming a question is a one-line edit inside a stable file, not a file rename
+and not a new question.
+
+Return to the unchanged main line before continuing:
+
+```python
+survey.git.switch("main")
+```
 
 ## What Git stores
 
@@ -419,14 +444,39 @@ Branches let collaborators develop alternative instruments without
 overwriting the main line:
 
 ```python
-survey.git.branch("short-form")
-survey.git.switch("short-form")
-
-# Make edits to the in-memory Survey here.
-survey.git.save(message="Create short-form variant")
+survey.git.branch("without-q1")
+survey.git.switch("without-q1")
+survey.delete_question("q1")
+survey.git.save(message="Create variant without q1")
 ```
 
-Return to the main version:
+Deleting one question changes more than one file:
+
+```python
+print(survey.git.diff("--stat", "HEAD~1", "HEAD"))
+```
+
+```text
+ manifest.json                 | 3 +--
+ metadata/memory_plan.json     | 2 --
+ metadata/rule_collection.json | 6 +++---
+ questions/000002.json         | 9 ---------
+ 4 files changed, 4 insertions(+), 16 deletions(-)
+```
+
+`questions/000002.json` is deleted, not renumbered. The other question files
+retain their IDs. The manifest changes because the question order no longer
+includes `000002`; the memory plan and flow rules change because they describe
+relationships among the remaining questions. This is why metadata is split
+into named files rather than buried in one survey blob: Git shows exactly
+which parts of survey behavior changed.
+
+Methods that return a `changed` list use “changed” in Git's broad sense:
+touched paths, including additions, modifications, and deletions.
+
+This branch represents a genuine alternative instrument, so do not merge it
+merely because it exists. Keep it parallel, field or review it independently,
+and return to `main`:
 
 ```python
 survey.git.switch("main")
@@ -436,35 +486,51 @@ survey.git.switch("main")
 requires a clean package before switching, pulling, or checking out another
 version, which protects uncommitted changes.
 
-## Merge a survey branch
+## Merge independent work
 
-Suppose the `short-form` branch removes the follow-up question `q1`:
+Merging is appropriate when reviewed work belongs back on the main survey.
+The useful case is not a sequential edit forced into a merge commit. It is two
+authors making divergent commits from the same base.
+
+Alice and Bob begin with the current `main`. Create Bob's branch before either
+person edits:
 
 ```python
-survey.git.switch("short-form")
-survey.delete_question("q1")
-survey.git.save(message="Remove follow-up from short form")
+survey.git.branch("bob-options")
 ```
 
-At this point, `main` still has all three questions and `short-form` has two.
-Switch back before merging:
+Bob changes only the options for `q2`:
+
+```python
+survey.git.switch("bob-options")
+survey.questions[2].question_options.append("not sure")
+survey.git.save(message="Bob: add a q2 response option")
+```
+
+Meanwhile, Alice changes only the wording of `q0` on `main`:
 
 ```python
 survey.git.switch("main")
-survey.question_names
+survey.questions[0].question_text = "Do you enjoy attending school?"
+survey.git.save(message="Alice: clarify q0 wording")
 ```
 
-```python
-["q0", "q1", "q2"]
+The histories now diverge. Neither commit is an ancestor of the other, and the
+edits live in different question files:
+
+```text
+* Alice: clarify q0 wording                 questions/000001.json
+| * Bob: add a q2 response option           questions/000003.json
+|/
+* Clarify the first question
 ```
 
-Merge the branch through the same Git-backed accessor:
+Now perform a genuine three-way merge:
 
 ```python
 merge_info = survey.git.merge(
-    "short-form",
-    message="Merge short-form survey",
-    no_ff=True,
+    "bob-options",
+    message="Merge Bob's reviewed options",
 )
 merge_info
 ```
@@ -475,23 +541,20 @@ merge_info
     "path": "example-survey.ep",
     "commit": "<merge-commit>",
     "branch": "main",
-    "merged_ref": "short-form",
+    "merged_ref": "bob-options",
     "fast_forward": False,
-    "changed": [
-        "manifest.json",
-        "metadata/memory_plan.json",
-        "metadata/rule_collection.json",
-        "questions/000002.json",
-    ],
+    "changed": ["questions/000003.json"],
     "conflicts": [],
+    "conflict_contents": {},
     "aborted": False,
-    "message": "Merge short-form survey",
+    "message": "Merge Bob's reviewed options",
 }
 ```
 
-`no_ff=True` asks Git to create a merge commit even though this simple example
-could be fast-forwarded. That makes the point where the alternative survey
-entered `main` visible in history.
+No `no_ff=True` is needed: Alice's and Bob's commits are genuinely divergent,
+so Git must reconcile them. `changed` lists the paths introduced to Alice's
+pre-merge `main`; her `q0` edit was already there, while Bob's `q2` edit arrives
+through the merge.
 
 The method completes all three layers of the operation: it merges the embedded
 repository, reloads the merged files into the in-memory `Survey`, and repacks
@@ -503,17 +566,19 @@ survey.question_names
 ```
 
 ```python
-["q0", "q2"]
+["q0", "q1", "q2"]
 ```
 
-The newest package history entry is the merge commit:
+Both authors' changes survive:
 
 ```python
-survey.git.log()[0]
+survey.questions[0].question_text
+survey.questions[2].question_options
 ```
 
 ```python
-{"message": "Merge short-form survey", "...": "..."}
+"Do you enjoy attending school?"
+["**lack*** of killer bees in cafeteria", "other", "not sure"]
 ```
 
 From an unpacked inspection copy, Git can display the topology:
@@ -523,80 +588,108 @@ git log --graph --oneline --all
 ```
 
 ```text
-*   <merge> Merge short-form survey
+*   <merge> Merge Bob's reviewed options
 |\
-| * <branch> Remove follow-up from short form
+| * <bob> Bob: add a q2 response option
+* | <alice> Alice: clarify q0 wording
 |/
-*   <initial> Create example survey
+*   <base> Clarify the first question
 ```
 
-This is more informative than copying the short survey over the long one. The
-merge records both lines of development, their common ancestor, and the exact
-decision that joined them.
+This is the payoff from storing questions separately. Git performs a real
+three-way merge, sees that Alice and Bob changed disjoint files, and retains
+both changes without human intervention. With one large `survey.json`, Git
+would be reconciling edits inside the same 4,000-line blob.
 
 ### What happens on a conflict
 
-If both branches edit the same part of a question or manifest, EDSL does not
-silently choose one survey design. It aborts the merge, leaves the current
-branch and `.ep` archive unchanged, and returns a structured report:
+Now repeat the experiment with both authors editing `q0`. Starting from a
+one-question package makes the conflict especially clear:
 
 ```python
-conflict = survey.git.merge("alternative-wording", no_ff=True)
+from edsl import QuestionFreeText, Survey
+
+wording = Survey([
+    QuestionFreeText(
+        question_name="q0",
+        question_text="Original wording",
+    )
+])
+wording.git.save("wording.ep", message="Shared wording")
+wording.git.branch("bob-wording")
+
+wording.git.switch("bob-wording")
+wording.questions[0].question_text = "Bob's wording"
+wording.git.save(message="Bob: revise q0")
+
+wording.git.switch("main")
+wording.questions[0].question_text = "Alice's wording"
+wording.git.save(message="Alice: revise q0")
+
+conflict = wording.git.merge("bob-wording")
 ```
 
 ```python
 {
     "status": "conflict",
-    "path": "example-survey.ep",
+    "path": "wording.ep",
     "commit": "<unchanged-main-commit>",
     "branch": "main",
-    "merged_ref": "alternative-wording",
+    "merged_ref": "bob-wording",
     "fast_forward": False,
     "changed": [],
     "conflicts": ["questions/000001.json"],
+    "conflict_contents": {
+        "questions/000001.json": "<conflicted text shown below>"
+    },
     "aborted": True,
-    "message": "merge of alternative-wording aborted due to conflicts",
+    "message": "merge of bob-wording aborted due to conflicts",
 }
 ```
 
-The automatic abort is important for a portable package: the in-memory
-Survey, embedded working tree, and archived `.ep` file continue to describe
-the same committed object. A researcher can inspect the reported files,
-revise one of the branches, and try the merge again.
+EDSL captures the conflicted file before aborting. Its `question_text` conflict
+is local and legible:
+
+```diff
+{
+  "question_name": "q0",
+ <<<<<<< HEAD
+  "question_text": "Alice's wording",
+ =======
+  "question_text": "Bob's wording",
+ >>>>>>> bob-wording
+  "question_type": "free_text"
+}
+```
+
+This is a conflict that a reviewer can understand and resolve. It is isolated
+to one small question file rather than buried among thousands of unrelated
+survey lines. The marker lines are indented one space above only so Git does
+not mistake this documentation example for an unresolved repository conflict.
+
+EDSL then aborts the merge, leaving the current branch and `.ep` archive
+unchanged and clean. A researcher can use `conflict_contents` to inspect the
+two alternatives, revise one branch, and try again. The API never silently
+chooses a survey design or leaves the portable package in a half-merged state.
 
 ## Communicate only the changes
 
-An `.ep` file is already a self-contained handoff: its recipient gets both the
-current Survey and its history. For ongoing collaboration, attach a Git remote
-and use EDSL's synchronization methods:
+An `.ep` file is a self-contained handoff: its recipient gets both the current
+Survey and its history. For ongoing collaboration, attach a GitHub remote and
+push:
 
 ```python
-survey.git.remote_add("origin", "<git-remote-url>")
+survey.git.remote_add("origin", "git@github.com:team/research-survey.git")
 survey.git.push("origin")
 ```
 
-A collaborator can clone the package and later fetch or pull new commits:
-
-```python
-collaborator = Survey.git.clone(
-    "<git-remote-url>",
-    "collaborator-copy.ep",
-)
-
-collaborator.git.pull()
-```
-
-At the CLI level, Expected Parrot-backed packages can be shared with:
-
-```bash
-ep push example-survey.ep
-ep pull example-survey.ep
-```
-
-Git negotiates which objects the receiver already has and transfers the
-missing objects. This matters when a team repeatedly revises a large survey:
-the communication unit is a commit and its changed objects, not a succession
-of unrelated `survey-final-2-revised.json` files.
+What lands on GitHub is the unpacked tree of readable JSON, not an opaque ZIP
+diff. A collaborator can review a one-line question-wording change as an
+ordinary pull request. Git negotiates which objects the receiver already has
+and transfers the missing objects, while EDSL repacks the history into `.ep`
+when it returns to the portable-file workflow. Zipping does not defeat the
+point: the archive is the transport artifact; the embedded repository is the
+collaboration artifact.
 
 ## Working inside another Git repository
 
@@ -640,9 +733,11 @@ guarantees:
 8. **Portable provenance.** Copying one `.ep` file carries the current object
    and its complete embedded history.
 
-The result is a survey format that works at two levels: researchers can use it
-as a normal EDSL `Survey`, while reviewers and collaborators can use familiar
-Git concepts to understand how that Survey evolved.
+The result works at two levels. Researchers use a normal EDSL `Survey`;
+reviewers and collaborators see ordinary Git history and readable diffs.
+Agents can understand and operate the versioning plumbing so researchers do
+not have to—but the repository remains available whenever a human needs to
+audit exactly what changed.
 
 ## Command reference
 

--- a/edsl/base/git_accessor.py
+++ b/edsl/base/git_accessor.py
@@ -301,6 +301,29 @@ class GitBackedInstanceAccessor(GitBackedClassAccessor):
         )
         self._pack_archive()
 
+    def merge(
+        self,
+        ref: str,
+        *,
+        message: Optional[str] = None,
+        no_ff: bool = False,
+    ) -> dict:
+        info = self._bound_package().merge(
+            ref,
+            message=message,
+            no_ff=no_ff,
+        )
+        if info["status"] != "conflict":
+            loaded = self._load_from_worktree()
+            self._spec.refresh(self._instance, loaded)
+            self._copy_loaded_accessor_state(loaded)
+            self.commit = info["commit"]
+            self.current_branch = info["branch"]
+            self._pack_archive()
+        if self.path is not None:
+            info["path"] = str(self.path)
+        return info
+
     def restore(self, ref: str = "HEAD") -> dict:
         loaded = self._load_from_worktree(ref=ref)
         self._spec.refresh(self._instance, loaded)

--- a/edsl/base/git_package.py
+++ b/edsl/base/git_package.py
@@ -111,6 +111,120 @@ class GitPackage:
         ensure_clean(self.path, "switch", error_cls=self.error_cls)
         git(self.path, "switch", name, error_cls=self.error_cls)
 
+    def merge(
+        self,
+        ref: str,
+        *,
+        message: Optional[str] = None,
+        no_ff: bool = False,
+    ) -> dict:
+        """Merge ``ref`` into the current branch.
+
+        Conflicting merges are aborted automatically so that the package
+        worktree remains clean and its archive can continue to represent a
+        valid committed object.
+        """
+        ensure_clean(self.path, "merge", error_cls=self.error_cls)
+        branch = require_current_branch(self.path, error_cls=self.error_cls)
+        before = head_commit(self.path, error_cls=self.error_cls)
+        command = [
+            "-c",
+            "user.name=EDSL",
+            "-c",
+            "user.email=edsl@example.invalid",
+            "merge",
+        ]
+        if no_ff:
+            command.append("--no-ff")
+        if message is not None:
+            command.extend(["-m", message])
+        else:
+            command.append("--no-edit")
+        command.append(ref)
+
+        try:
+            git(self.path, *command, error_cls=self.error_cls)
+        except self.error_cls:
+            conflicts = [
+                line.strip()
+                for line in git(
+                    self.path,
+                    "diff",
+                    "--name-only",
+                    "--diff-filter=U",
+                    capture=True,
+                    error_cls=self.error_cls,
+                ).splitlines()
+                if line.strip()
+            ]
+            if not conflicts:
+                raise
+            git(self.path, "merge", "--abort", error_cls=self.error_cls)
+            return {
+                "status": "conflict",
+                "path": str(self.path),
+                "commit": before,
+                "branch": branch,
+                "merged_ref": ref,
+                "fast_forward": False,
+                "changed": [],
+                "conflicts": conflicts,
+                "aborted": True,
+                "message": f"merge of {ref} aborted due to conflicts",
+            }
+
+        commit = head_commit(self.path, error_cls=self.error_cls)
+        if commit == before:
+            return {
+                "status": "unchanged",
+                "path": str(self.path),
+                "commit": commit,
+                "branch": branch,
+                "merged_ref": ref,
+                "fast_forward": False,
+                "changed": [],
+                "conflicts": [],
+                "aborted": False,
+                "message": f"{ref} is already merged",
+            }
+
+        parent_line = git(
+            self.path,
+            "rev-list",
+            "--parents",
+            "-n",
+            "1",
+            commit,
+            capture=True,
+            error_cls=self.error_cls,
+        ).strip()
+        is_merge_commit = len(parent_line.split()) > 2
+        changed = [
+            line.strip()
+            for line in git(
+                self.path,
+                "diff",
+                "--name-only",
+                before,
+                commit,
+                capture=True,
+                error_cls=self.error_cls,
+            ).splitlines()
+            if line.strip()
+        ]
+        return {
+            "status": "ok",
+            "path": str(self.path),
+            "commit": commit,
+            "branch": branch,
+            "merged_ref": ref,
+            "fast_forward": not is_merge_commit,
+            "changed": changed,
+            "conflicts": [],
+            "aborted": False,
+            "message": message or f"Merge {ref}",
+        }
+
     def diff(self, *refs: str) -> str:
         return git(self.path, "diff", *refs, capture=True, error_cls=self.error_cls)
 

--- a/edsl/base/git_package.py
+++ b/edsl/base/git_package.py
@@ -159,6 +159,14 @@ class GitPackage:
             ]
             if not conflicts:
                 raise
+            conflict_contents = {}
+            for conflict_path in conflicts:
+                try:
+                    conflict_contents[conflict_path] = (
+                        self.path / conflict_path
+                    ).read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
             git(self.path, "merge", "--abort", error_cls=self.error_cls)
             return {
                 "status": "conflict",
@@ -169,6 +177,7 @@ class GitPackage:
                 "fast_forward": False,
                 "changed": [],
                 "conflicts": conflicts,
+                "conflict_contents": conflict_contents,
                 "aborted": True,
                 "message": f"merge of {ref} aborted due to conflicts",
             }
@@ -184,6 +193,7 @@ class GitPackage:
                 "fast_forward": False,
                 "changed": [],
                 "conflicts": [],
+                "conflict_contents": {},
                 "aborted": False,
                 "message": f"{ref} is already merged",
             }
@@ -221,6 +231,7 @@ class GitPackage:
             "fast_forward": not is_merge_commit,
             "changed": changed,
             "conflicts": [],
+            "conflict_contents": {},
             "aborted": False,
             "message": message or f"Merge {ref}",
         }

--- a/edsl/surveys/survey_git.py
+++ b/edsl/surveys/survey_git.py
@@ -264,6 +264,23 @@ def _question_ids_for_questions(
                     matched_id = question_id
                     break
         if matched_id is None:
+            question_without_name = {
+                key: value
+                for key, value in question_dict.items()
+                if key != "question_name"
+            }
+            for question_id in existing_order:
+                if question_id in used:
+                    continue
+                existing_without_name = {
+                    key: value
+                    for key, value in existing_questions.get(question_id, {}).items()
+                    if key != "question_name"
+                }
+                if existing_without_name == question_without_name:
+                    matched_id = question_id
+                    break
+        if matched_id is None:
             while True:
                 candidate = f"{next_index:06d}"
                 next_index += 1

--- a/edsl/surveys/survey_git.py
+++ b/edsl/surveys/survey_git.py
@@ -252,6 +252,18 @@ def _question_ids_for_questions(
                 matched_id = question_id
                 break
         if matched_id is None:
+            question_name = question_dict.get("question_name")
+            for question_id in existing_order:
+                if question_id in used:
+                    continue
+                existing_question = existing_questions.get(question_id, {})
+                if (
+                    question_name is not None
+                    and existing_question.get("question_name") == question_name
+                ):
+                    matched_id = question_id
+                    break
+        if matched_id is None:
             while True:
                 candidate = f"{next_index:06d}"
                 next_index += 1

--- a/tests/surveys/test_survey_git.py
+++ b/tests/surveys/test_survey_git.py
@@ -546,6 +546,97 @@ def test_survey_git_branch_tag_restore(tmp_path):
     )
 
 
+def test_survey_git_merge_refreshes_object_and_repackages_archive(tmp_path):
+    package_path = tmp_path / "merge.survey.ep"
+    survey = Survey(
+        [QuestionFreeText(question_name="q0", question_text="First?")]
+    )
+    initial = survey.git.save(package_path, message="initial survey")
+
+    survey.git.branch("short-form")
+    survey.git.switch("short-form")
+    survey.add_question(
+        QuestionFreeText(question_name="q1", question_text="Second?")
+    )
+    branch_commit = survey.git.save(message="add second question")
+
+    survey.git.switch("main")
+    merge_info = survey.git.merge(
+        "short-form",
+        message="Merge short-form survey",
+        no_ff=True,
+    )
+
+    assert merge_info["status"] == "ok"
+    assert merge_info["branch"] == "main"
+    assert merge_info["merged_ref"] == "short-form"
+    assert merge_info["fast_forward"] is False
+    assert merge_info["conflicts"] == []
+    assert merge_info["aborted"] is False
+    assert "manifest.json" in merge_info["changed"]
+    assert "questions/000002.json" in merge_info["changed"]
+    assert merge_info["commit"] not in {
+        initial["commit"],
+        branch_commit["commit"],
+    }
+    assert survey.question_names == ["q0", "q1"]
+    assert Survey.git.load(package_path).question_names == ["q0", "q1"]
+
+    parent_line = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(survey.git.worktree_path),
+            "rev-list",
+            "--parents",
+            "-n",
+            "1",
+            "HEAD",
+        ],
+        text=True,
+    ).strip()
+    assert len(parent_line.split()) == 3
+
+
+def test_survey_git_merge_conflict_aborts_and_preserves_current_survey(tmp_path):
+    package_path = tmp_path / "conflict.survey.ep"
+    survey = Survey(
+        [QuestionFreeText(question_name="q0", question_text="Original wording")]
+    )
+    survey.git.save(package_path, message="initial survey")
+
+    survey.git.branch("alternative")
+    survey.git.switch("alternative")
+    survey.questions[0].question_text = "Alternative wording"
+    survey.git.save(message="edit wording on alternative")
+
+    survey.git.switch("main")
+    survey.questions[0].question_text = "Main wording"
+    main_commit = survey.git.save(message="edit wording on main")
+
+    merge_info = survey.git.merge("alternative", no_ff=True)
+
+    assert merge_info == {
+        "status": "conflict",
+        "path": str(package_path),
+        "commit": main_commit["commit"],
+        "branch": "main",
+        "merged_ref": "alternative",
+        "fast_forward": False,
+        "changed": [],
+        "conflicts": ["questions/000001.json"],
+        "aborted": True,
+        "message": "merge of alternative aborted due to conflicts",
+    }
+    assert survey.git.status()["clean"] is True
+    assert survey.git.commit == main_commit["commit"]
+    assert survey.questions[0].question_text == "Main wording"
+    assert (
+        Survey.git.load(package_path).questions[0].question_text
+        == "Main wording"
+    )
+
+
 def test_survey_git_push_and_pull_with_remote(tmp_path):
     remote_path = tmp_path / "remote.git"
     first_path = tmp_path / "first.survey.ep"

--- a/tests/surveys/test_survey_git.py
+++ b/tests/surveys/test_survey_git.py
@@ -339,6 +339,30 @@ def test_survey_git_mutation_save_cleans_stale_questions_and_round_trips(tmp_pat
     assert second["commit"] != first["commit"]
 
 
+def test_survey_git_question_edit_preserves_question_file_id(tmp_path):
+    package_path = tmp_path / "edited.survey.ep"
+    survey = Survey.example()
+    first = survey.git.save(package_path, message="initial survey")
+
+    survey.questions[0].question_text = "Do you enjoy school?"
+    second = survey.git.save(message="clarify first question")
+
+    manifest = _package_json(package_path, "manifest.json")
+    edited_question = _package_json(package_path, "questions/000001.json")
+    diff = survey.git.diff(first["commit"], second["commit"])
+
+    assert manifest["question_order"] == ["000001", "000002", "000003"]
+    assert edited_question["question_name"] == "q0"
+    assert edited_question["question_text"] == "Do you enjoy school?"
+    assert "questions/000001.json" in diff
+    assert "questions/000004.json" not in diff
+    assert "manifest.json" not in diff
+    assert (
+        Survey.git.load(package_path).questions[0].question_text
+        == "Do you enjoy school?"
+    )
+
+
 def test_survey_git_archive_excludes_transient_git_pack_files(tmp_path):
     package_path = tmp_path / "survey.survey.ep"
     survey = Survey.example()

--- a/tests/surveys/test_survey_git.py
+++ b/tests/surveys/test_survey_git.py
@@ -363,6 +363,25 @@ def test_survey_git_question_edit_preserves_question_file_id(tmp_path):
     )
 
 
+def test_survey_git_question_name_rename_preserves_question_file_id(tmp_path):
+    package_path = tmp_path / "renamed.survey.ep"
+    survey = Survey.example()
+    first = survey.git.save(package_path, message="initial survey")
+
+    survey = survey.with_renamed_question("q0", "school_enjoyment")
+    second = survey.git.save(package_path, message="rename first question")
+
+    manifest = _package_json(package_path, "manifest.json")
+    renamed_question = _package_json(package_path, "questions/000001.json")
+    diff = survey.git.diff(first["commit"], second["commit"])
+
+    assert manifest["question_order"] == ["000001", "000002", "000003"]
+    assert renamed_question["question_name"] == "school_enjoyment"
+    assert "questions/000001.json" in diff
+    assert "questions/000004.json" not in diff
+    assert "rename from" not in diff
+
+
 def test_survey_git_archive_excludes_transient_git_pack_files(tmp_path):
     package_path = tmp_path / "survey.survey.ep"
     survey = Survey.example()
@@ -572,6 +591,7 @@ def test_survey_git_merge_refreshes_object_and_repackages_archive(tmp_path):
     assert merge_info["merged_ref"] == "short-form"
     assert merge_info["fast_forward"] is False
     assert merge_info["conflicts"] == []
+    assert merge_info["conflict_contents"] == {}
     assert merge_info["aborted"] is False
     assert "manifest.json" in merge_info["changed"]
     assert "questions/000002.json" in merge_info["changed"]
@@ -625,6 +645,19 @@ def test_survey_git_merge_conflict_aborts_and_preserves_current_survey(tmp_path)
         "fast_forward": False,
         "changed": [],
         "conflicts": ["questions/000001.json"],
+        "conflict_contents": {
+            "questions/000001.json": (
+                "{\n"
+                '  "question_name": "q0",\n'
+                "<<<<<<< HEAD\n"
+                '  "question_text": "Main wording",\n'
+                "=======\n"
+                '  "question_text": "Alternative wording",\n'
+                ">>>>>>> alternative\n"
+                '  "question_type": "free_text"\n'
+                "}\n"
+            )
+        },
         "aborted": True,
         "message": "merge of alternative aborted due to conflicts",
     }


### PR DESCRIPTION
## Summary

- preserve stable Survey package file IDs across content edits and pure `question_name` renames
- add native `object.git.merge(ref, message=..., no_ff=...)` support for Git-backed `.ep` objects
- refresh the in-memory object and repack the `.ep` archive after successful merges
- automatically abort conflicting merges while returning both conflict paths and the legible conflicted text
- cover in-place edits, renamed questions, genuine two-parent merges, archive round trips, and conflict safety
- add a hands-on Survey `.ep` tutorial demonstrating divergent Alice/Bob edits, automatic disjoint-file merging, same-question conflict markers, metadata cascades on deletion, and GitHub review

## Testing

- `python -m pytest -q tests/base/test_git_package.py tests/surveys/test_survey_git.py` (21 passed)
- focused CLI package tests (2 passed)
- exact Alice/Bob tutorial sequence exercised successfully
- `git diff --check`

## Full-suite note

A requested `make test` run reached 74% with no failures, then remained stuck in `tests/serialization/test_serialization.py` for over 30 minutes and was stopped. `make test-doctests` was not started.