### PR TITLE
Render templates in individual question options

### DIFF
--- a/edsl/invigilators/question_option_processor.py
+++ b/edsl/invigilators/question_option_processor.py
@@ -1,5 +1,5 @@
 from ast import literal_eval
-from typing import Any, Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 
 
 # import edsl.scenarios.scenario  # noqa: F401
@@ -133,28 +133,47 @@ class QuestionOptionProcessor(QuestionAttributeProcessor):
             # Extract the base options from the "from" template
             from_template = options_entry.get("from")
             additional_options = options_entry.get("add", [])
+            rendered_additional_options = self._render_option_list(additional_options)
 
             # Get the base options using the template
             base_options = self._get_options_from_template(from_template)
 
             # Concatenate with additional options
             if base_options and base_options != self._get_default_options():
-                return base_options + additional_options
+                return base_options + rendered_additional_options
             else:
                 # If we can't resolve the template, just return additional options
                 # or default if no additional options
                 return (
-                    additional_options
-                    if additional_options
+                    rendered_additional_options
+                    if rendered_additional_options
                     else self._get_default_options()
                 )
 
-        # If not a template string or dict, return as is or default
+        # Render templates contained in ordinary option lists.
+        if isinstance(options_entry, list):
+            return (
+                self._render_option_list(options_entry)
+                if options_entry
+                else self._get_default_options()
+            )
+
+        # If not a template string, list, or dict, return as is or default.
         if not isinstance(options_entry, str):
             return options_entry if options_entry else self._get_default_options()
 
         # Handle simple template string (existing logic)
         return self._get_options_from_template(options_entry)
+
+    def _render_option_list(self, options: list) -> list:
+        """Render templated options individually while preserving static values."""
+        return [
+            self._render_template_to_native_value(option)
+            if isinstance(option, str)
+            and any(marker in option for marker in ("{{", "{%", "{#"))
+            else option
+            for option in options
+        ]
 
     def _get_options_from_template(self, template_string: str) -> list:
         """

--- a/edsl/invigilators/question_option_processor.py
+++ b/edsl/invigilators/question_option_processor.py
@@ -167,13 +167,23 @@ class QuestionOptionProcessor(QuestionAttributeProcessor):
 
     def _render_option_list(self, options: list) -> list:
         """Render templated options individually while preserving static values."""
-        return [
-            self._render_template_to_native_value(option)
-            if isinstance(option, str)
-            and any(marker in option for marker in ("{{", "{%", "{#"))
-            else option
-            for option in options
-        ]
+        rendered_options = []
+        for option in options:
+            if not (
+                isinstance(option, str)
+                and any(marker in option for marker in ("{{", "{%", "{#"))
+            ):
+                rendered_options.append(option)
+                continue
+
+            try:
+                rendered_options.append(self._render_template_to_native_value(option))
+            except Exception:
+                # Preserve option text that only resembles a template or
+                # contains malformed Jinja syntax.
+                rendered_options.append(option)
+
+        return rendered_options
 
     def _get_options_from_template(self, template_string: str) -> list:
         """

--- a/tests/invigilators/test_question_option_processor.py
+++ b/tests/invigilators/test_question_option_processor.py
@@ -72,3 +72,29 @@ def test_renders_templates_in_additional_options():
     )
 
     assert options == ["apple", "pear", "Other fruit", "None"]
+
+
+def test_preserves_malformed_template_in_individual_option():
+    processor = QuestionOptionProcessor(Scenario({}), {})
+
+    options = processor.get_question_options(
+        {"question_options": ["Use {{name", "Other"]}
+    )
+
+    assert options == ["Use {{name", "Other"]
+
+
+def test_preserves_malformed_template_in_additional_option():
+    prior_answers = {"q1": SimpleNamespace(answer=["apple", "pear"], comment=None)}
+    processor = QuestionOptionProcessor(Scenario({}), prior_answers)
+
+    options = processor.get_question_options(
+        {
+            "question_options": {
+                "from": "{{ q1.answer }}",
+                "add": ["Use {{name"],
+            }
+        }
+    )
+
+    assert options == ["apple", "pear", "Use {{name"]

--- a/tests/invigilators/test_question_option_processor.py
+++ b/tests/invigilators/test_question_option_processor.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from edsl import Scenario
+from edsl.invigilators.question_option_processor import QuestionOptionProcessor
+
+
+def test_renders_comment_template_in_individual_option():
+    prior_answers = {
+        "q1": SimpleNamespace(answer="Yes", comment="Because it is useful")
+    }
+    processor = QuestionOptionProcessor(Scenario({}), prior_answers)
+
+    options = processor.get_question_options(
+        {"question_options": ["{{ q1.comment }}", "No comment"]}
+    )
+
+    assert options == ["Because it is useful", "No comment"]
+
+
+def test_renders_multiple_prior_answers_in_individual_options():
+    prior_answers = {
+        "q1": SimpleNamespace(answer="apple", comment=None),
+        "q2": SimpleNamespace(answer="pear", comment=None),
+    }
+    processor = QuestionOptionProcessor(Scenario({}), prior_answers)
+
+    options = processor.get_question_options(
+        {
+            "question_options": [
+                "{{ q1.answer }}",
+                "blueberry",
+                "{{ q2.answer }}",
+            ]
+        }
+    )
+
+    assert options == ["apple", "blueberry", "pear"]
+
+
+def test_preserves_native_values_in_option_list():
+    processor = QuestionOptionProcessor(
+        Scenario({"rank": 2}),
+        {"q1": SimpleNamespace(answer=None, comment=None)},
+    )
+
+    options = processor.get_question_options(
+        {
+            "question_options": [
+                "{{ scenario.rank }}",
+                "{{ q1.answer }}",
+                3,
+            ]
+        }
+    )
+
+    assert options == [2, None, 3]
+
+
+def test_renders_templates_in_additional_options():
+    prior_answers = {
+        "q1": SimpleNamespace(answer=["apple", "pear"], comment="Other fruit")
+    }
+    processor = QuestionOptionProcessor(Scenario({}), prior_answers)
+
+    options = processor.get_question_options(
+        {
+            "question_options": {
+                "from": "{{ q1.answer }}",
+                "add": ["{{ q1.comment }}", "None"],
+            }
+        }
+    )
+
+    assert options == ["apple", "pear", "Other fruit", "None"]


### PR DESCRIPTION
Closes #2555.
Closes #2556.

## Summary
- render Jinja templates inside each element of an ordinary question-options list
- render templated elements in the dict-style `add` list
- preserve static option strings exactly and retain native values returned by Jinja
- keep existing whole-list `from` behavior unchanged

## Tests
- prior-answer comment used as one option (#2555)
- answers from multiple prior questions used as separate options (#2556)
- native value preservation, including `None` and numeric values
- templated additional options
- existing survey piping suites

Duplicate options produced at runtime continue through the existing validation path; this PR does not introduce implicit deduplication while #2556 awaits a product decision on that behavior.