### PR TITLE
Fix local runner compute piping and failure propagation

### DIFF
--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -177,7 +177,29 @@ class DirectAnswerRegistry:
                 entry.job_id, entry.interview_id
             )
 
-        kwargs = {"scenario": entry.scenario, "agent_traits": agent_traits}
+        # Functional/self-answering questions historically ran through
+        # InvigilatorFunctional, which enriched the scenario with answered
+        # Question objects.  Jinja piping relies on that object shape, e.g.
+        # ``{{ q0.answer }}``.  The direct-answer runner bypasses the
+        # invigilator, so reconstruct the same context here rather than passing
+        # only the original job scenario.
+        scenario = entry.scenario
+        if current_answers and self._job_service and entry.job_id:
+            survey_data = self._job_service._jobs.get_survey(entry.job_id)
+            if survey_data:
+                from ..surveys import Survey
+
+                answered_questions = Survey.from_dict(
+                    survey_data
+                ).question_names_to_questions()
+                for question_name, answer in current_answers.items():
+                    if question_name in answered_questions:
+                        answered_questions[question_name].answer = answer
+
+                agent_context = {"agent": agent_traits} if agent_traits else {}
+                scenario = scenario | answered_questions | agent_context
+
+        kwargs = {"scenario": scenario, "agent_traits": agent_traits}
         signature = inspect.signature(entry.question.answer_question_directly)
         if "current_answers" in signature.parameters:
             kwargs["current_answers"] = current_answers

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -1140,18 +1140,40 @@ class JobService:
     def _propagate_failure(
         self, job_id: str, interview_id: str, dependent_ids: list[str]
     ) -> None:
-        """Recursively mark dependents as blocked."""
-        for dep_id in dependent_ids:
-            self._tasks.set_status(dep_id, TaskStatus.BLOCKED)
-            self._tasks.set_error(
-                dep_id, "upstream_failure", "Blocked by failed dependency"
-            )
-            self._interviews.mark_task_blocked(job_id, interview_id)
+        """Mark every downstream task blocked exactly once.
 
-            # Recurse
-            dep_def = self._tasks.get_definition(job_id, interview_id, dep_id)
-            if dep_def:
-                self._propagate_failure(job_id, interview_id, dep_def.dependents)
+        A dependency DAG can converge, so recursive path traversal revisits the
+        same task many times (exponentially in a dense graph), over-counts
+        blocked tasks, and repeatedly finalizes the interview.  Traverse by
+        unique task ID and batch state changes instead.
+        """
+        blocked_ids: set[str] = set()
+        frontier = list(dependent_ids)
+
+        while frontier:
+            current = list(dict.fromkeys(frontier))
+            frontier = []
+            unseen = [task_id for task_id in current if task_id not in blocked_ids]
+            if not unseen:
+                continue
+
+            blocked_ids.update(unseen)
+            definitions = self._tasks.get_definitions_batch(
+                job_id, interview_id, unseen
+            )
+            for task_id in unseen:
+                task_def = definitions.get(task_id)
+                if task_def:
+                    frontier.extend(task_def.dependents)
+
+        ordered_ids = list(blocked_ids)
+        self._tasks.set_statuses_batch(ordered_ids, TaskStatus.BLOCKED)
+        self._tasks.set_errors_batch(
+            ordered_ids, "upstream_failure", "Blocked by failed dependency"
+        )
+        self._interviews.mark_tasks_blocked(
+            job_id, interview_id, len(ordered_ids)
+        )
 
     # =========================================================================
     # Job Status & Results

--- a/edsl/runner/stores.py
+++ b/edsl/runner/stores.py
@@ -570,6 +570,17 @@ class InterviewStore:
         self.increment_blocked(interview_id)
         self._maybe_finalize(job_id, interview_id)
 
+    def mark_tasks_blocked(
+        self, job_id: str, interview_id: str, count: int
+    ) -> None:
+        """Record several blocked tasks and finalize the interview once."""
+        if count <= 0:
+            return
+        self._storage.increment_volatile(
+            f"interview:{interview_id}:blocked", count
+        )
+        self._maybe_finalize(job_id, interview_id)
+
     def _maybe_finalize(self, job_id: str, interview_id: str) -> None:
         """Check if interview is done and update state accordingly."""
         definition = self.get_definition(job_id, interview_id)
@@ -925,6 +936,16 @@ class TaskStore:
         if not task_ids:
             return
         items = {f"task:{task_id}:status": status.value for task_id in task_ids}
+        self._storage.batch_write_volatile(items)
+
+    def set_errors_batch(
+        self, task_ids: list[str], error_type: str, error_message: str
+    ) -> None:
+        """Set the same error on several tasks in one storage operation."""
+        if not task_ids:
+            return
+        error = {"type": error_type, "message": error_message}
+        items = {f"task:{task_id}:error": error for task_id in task_ids}
         self._storage.batch_write_volatile(items)
 
     # Ready task operations

--- a/tests/runner/test_compute_piping_direct_answer.py
+++ b/tests/runner/test_compute_piping_direct_answer.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from edsl import (
+    Agent,
+    QuestionBudget,
+    QuestionCheckBox,
+    QuestionCompute,
+    QuestionFreeText,
+    Scenario,
+    Survey,
+)
+from edsl.inference_services.services.test_service import TestService
+from edsl.runner.direct_answer import DirectAnswerEntry, DirectAnswerRegistry
+
+
+@pytest.mark.asyncio
+async def test_compute_direct_answer_receives_prior_answer_piping_context():
+    prior = QuestionFreeText(question_name="channels", question_text="Channels?")
+    compute = QuestionCompute(
+        question_name="clean_channels",
+        question_text="{{ channels.answer }}",
+    )
+    survey = Survey([prior, compute])
+
+    service = SimpleNamespace(
+        _gather_current_answers=lambda job_id, interview_id: {
+            "channels": ["Channel A", "Channel B"],
+            "channels.answer": ["Channel A", "Channel B"],
+        },
+        _jobs=SimpleNamespace(get_survey=lambda job_id: survey.to_dict()),
+    )
+    registry = DirectAnswerRegistry(job_service=service)
+    entry = DirectAnswerEntry(
+        task_id="compute-task",
+        execution_type="functional",
+        agent=None,
+        question=compute,
+        scenario=Scenario(),
+        job_id="job",
+        interview_id="interview",
+    )
+    registry.register(entry.task_id, entry)
+
+    result = await registry.execute(entry.task_id)
+
+    assert result["answer"] == "['Channel A', 'Channel B']"
+
+
+def test_compute_answer_can_supply_dynamic_budget_options_without_memory():
+    channels = QuestionCheckBox(
+        question_name="channels",
+        question_text="Which channels are used?",
+        question_options=["Channel A", "Channel B", "Channel C", "Channel D"],
+        min_selections=2,
+    )
+    clean_channels = QuestionCompute(
+        question_name="clean_channels",
+        question_text="{{ channels.answer | map('trim') | list }}",
+    )
+    allocation = QuestionBudget(
+        question_name="allocation",
+        question_text="Allocate channel spend.",
+        question_options="{{ clean_channels.answer }}",
+        budget_sum=100,
+    )
+    survey = Survey([channels, clean_channels, allocation])
+
+    def scripted_response(user_prompt, system_prompt, files_list):
+        if "Allocate your budget" in user_prompt:
+            return "[20,24,28,28]"
+        return '["Channel A","Channel B","Channel C","Channel D"]'
+
+    model = TestService.create_model("test")(
+        skip_api_key_check=True,
+        func=scripted_response,
+    )
+
+    results = (
+        survey.by(Agent())
+        .by(model)
+        .run(
+            disable_remote_inference=True,
+            stop_on_exception=True,
+            cache=False,
+        )
+    )
+
+    row = results.select(
+        "answer.channels",
+        "answer.clean_channels",
+        "answer.allocation",
+    ).to_list()[0]
+    assert row == (
+        ["Channel A", "Channel B", "Channel C", "Channel D"],
+        "['Channel A', 'Channel B', 'Channel C', 'Channel D']",
+        [20.0, 24.0, 28.0, 28.0],
+    )

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -1,0 +1,53 @@
+from edsl import Agent, QuestionCompute, QuestionFreeText, Survey
+from edsl.inference_services.services.test_service import TestService
+from edsl.runner.models import InterviewState, TaskStatus
+from edsl.runner.service import JobService
+from edsl.runner.storage import InMemoryStorage
+
+
+def test_failure_propagation_blocks_converging_dag_nodes_once():
+    root = QuestionFreeText(question_name="root", question_text="Root?")
+    left = QuestionCompute(question_name="left", question_text="{{ root.answer }}")
+    right = QuestionCompute(
+        question_name="right", question_text="{{ root.answer }}"
+    )
+    join = QuestionCompute(
+        question_name="join",
+        question_text="{{ left.answer }} {{ right.answer }}",
+    )
+    survey = Survey([root, left, right, join])
+    model = TestService.create_model("test")(skip_api_key_check=True)
+    job = survey.to_jobs().by(Agent()).by(model)
+
+    service = JobService(InMemoryStorage())
+    job_id, _, _ = service.submit_job(job, job_id="job")
+    interview_id = service.jobs.get_definition(job_id).interview_ids[0]
+    interview = service.interviews.get_definition(job_id, interview_id)
+    tasks = {
+        service.tasks.get_definition(job_id, interview_id, task_id).question_name:
+        service.tasks.get_definition(job_id, interview_id, task_id)
+        for task_id in interview.task_ids
+    }
+
+    service.on_task_failed(
+        job_id,
+        interview_id,
+        tasks["root"].task_id,
+        "test_failure",
+        "boom",
+        force_permanent=True,
+    )
+
+    status = service.interviews.get_status(interview_id)
+    assert status.failed == 1
+    assert status.blocked == 3
+    assert service.interviews.get_state(interview_id) == (
+        InterviewState.COMPLETED_WITH_FAILURES
+    )
+    assert service.tasks.get_statuses_batch(
+        [tasks[name].task_id for name in ("left", "right", "join")]
+    ) == {
+        tasks["left"].task_id: TaskStatus.BLOCKED,
+        tasks["right"].task_id: TaskStatus.BLOCKED,
+        tasks["join"].task_id: TaskStatus.BLOCKED,
+    }


### PR DESCRIPTION
## Summary
- restore prior-answer scenario enrichment for functional/self-answering questions in the local direct-answer runner
- make downstream failure propagation iterative, deduplicated, and batched
- add offline regression coverage for compute piping, dynamic budget options, and converging DAG failures

## Root causes
The direct-answer registry bypassed the legacy functional invigilator enrichment, so `QuestionCompute` received the original scenario without prior answered Question objects. Separately, failure propagation recursively traversed DAG paths, revisiting converging nodes and overcounting blocked tasks.

## Tests
- `pytest -q tests/runner/test_compute_piping_direct_answer.py tests/runner/test_failure_propagation.py tests/runner/test_stored_answer_routing.py tests/questions/test_QuestionBudget.py`
- 21 passed

All new inference tests use the scripted local `TestService`; they make no real LLM or network calls.