### PR TITLE
Preserve unresolved dynamic options during survey randomization

### DIFF
--- a/edsl/questions/question_base_gen_mixin.py
+++ b/edsl/questions/question_base_gen_mixin.py
@@ -184,6 +184,14 @@ class QuestionBaseGenMixin:
         if not hasattr(self, "question_options"):
             return copy.deepcopy(self)
 
+        # Dynamic options are rendered from prior answers at interview time,
+        # e.g. ``{{ available_options.answer }}``. Before those answers exist,
+        # the value is a template string rather than an option collection.
+        # Sampling it here would shuffle individual characters and create an
+        # invalid question, so preserve it for runtime rendering.
+        if not isinstance(self.question_options, list):
+            return copy.deepcopy(self)
+
         # Use provided random instance or create one with seed
         if random_instance is not None:
             rng = random_instance

--- a/tests/surveys/test_Survey.py
+++ b/tests/surveys/test_Survey.py
@@ -287,6 +287,31 @@ class TestSurvey(unittest.TestCase):
         for ordering in color_list:
             assert set(ordering) == {"Red", "Blue", "Green"}
 
+    def test_draw_preserves_unresolved_dynamic_options(self):
+        static = QuestionMultipleChoice(
+            question_name="static",
+            question_text="Pick one.",
+            question_options=["A", "B", "C"],
+        )
+        dynamic = QuestionMultipleChoice(
+            question_name="dynamic",
+            question_text="Pick a prior answer.",
+            question_options="{{ static.answer }}",
+        )
+        survey = Survey(
+            [static, dynamic],
+            questions_to_randomize=["static", "dynamic"],
+        )
+
+        drawn = survey.draw()
+
+        self.assertEqual(
+            sorted(drawn.questions[0].question_options), ["A", "B", "C"]
+        )
+        self.assertEqual(
+            drawn.questions[1].question_options, "{{ static.answer }}"
+        )
+
     @unittest.skip("Pre-existing bug: question_name_to_index cache not invalidated after rename")
     def test_with_renamed_question_basic(self):
         """Test basic question renaming functionality."""


### PR DESCRIPTION
Closes the first checklist item in #2563.

## Summary
- treat unresolved templated `question_options` as deferred runtime values during `Survey.draw()`
- avoid sampling template strings character-by-character
- preserve existing randomization behavior for static option lists

## Tests
- `pytest -q tests/surveys/test_Survey.py -k draw`
- 4 passed, 24 deselected

The regression test is fully local and makes no model or network calls.