### PR TITLE
Restore translated answer contract in local runner

### DIFF
--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -553,8 +553,18 @@ class ExecutionWorker:
 
         try:
             validated_dict = question._validate_answer(raw_answer_dict)
+            validated_answer = validated_dict.get("answer", answer)
+            # Match the legacy invigilator contract: validate the model's
+            # compact/code response first, then expose the translated answer
+            # to Results and downstream piping.  This is significant for
+            # QuestionBudget, whose validated response is a numeric list but
+            # whose public answer is a list of option-labelled allocations.
+            if getattr(question, "probabilistic_response", None) is None:
+                validated_answer = question._translate_answer_code_to_answer(
+                    validated_answer, scenario_data
+                )
             return (
-                validated_dict.get("answer", answer),
+                validated_answer,
                 validated_dict.get("comment", comment),
                 True,
                 validated_dict.get("distribution"),

--- a/tests/runner/test_budget_answer_translation.py
+++ b/tests/runner/test_budget_answer_translation.py
@@ -1,0 +1,32 @@
+from edsl import Agent, QuestionBudget, Survey
+from edsl.inference_services.services.test_service import TestService
+
+
+def test_budget_result_uses_labelled_public_answer_contract():
+    budget = QuestionBudget(
+        question_name="channel_budget",
+        question_text="Allocate channel spend.",
+        question_options=["Channel A", "Channel B", "Channel C"],
+        budget_sum=100,
+    )
+    model = TestService.create_model("test")(
+        skip_api_key_check=True,
+        func=lambda user_prompt, system_prompt, files_list: "[20,30,50]",
+    )
+
+    results = (
+        Survey([budget])
+        .by(Agent())
+        .by(model)
+        .run(
+            disable_remote_inference=True,
+            stop_on_exception=True,
+            cache=False,
+        )
+    )
+
+    assert results.select("answer.channel_budget").to_list()[0] == [
+        {"Channel A": 20.0},
+        {"Channel B": 30.0},
+        {"Channel C": 50.0},
+    ]


### PR DESCRIPTION
Addresses the second checklist item in #2563.

## Summary
- restore the legacy validate-then-translate answer flow in the new local execution worker
- expose `QuestionBudget` answers as ordered option-labelled allocations in Results and downstream piping
- preserve probabilistic-response handling

## Example
A validated `[20, 30, 50]` budget over three generic channels is stored as `[{"Channel A": 20.0}, {"Channel B": 30.0}, {"Channel C": 50.0}]`.

## Tests
- `pytest -q tests/runner/test_budget_answer_translation.py tests/questions/test_QuestionBudget.py tests/runner/test_interview_executor.py`
- 5 passed

The new regression uses scripted local `TestService` and makes no real LLM or network calls.