### PR TITLE
Repair safe QuestionBudget response formats and rounding

### DIFF
--- a/edsl/questions/question_budget.py
+++ b/edsl/questions/question_budget.py
@@ -370,7 +370,8 @@ class BudgetResponseValidator(ResponseValidatorABC):
             try:
                 fixed_answer = [float(x) for x in answer]
             except (ValueError, TypeError):
-                pass
+                if len(answer) == 1 and isinstance(answer[0], str):
+                    fixed_answer = self._parse_labeled_allocation(answer[0])
 
         fixed_answer = self._repair_small_rounding_error(fixed_answer)
 
@@ -385,6 +386,18 @@ class BudgetResponseValidator(ResponseValidatorABC):
             fixed_response["comment"] = response["comment"]
 
         return fixed_response
+
+    def _parse_labeled_allocation(self, text):
+        """Parse ``Option: value`` pairs only when every option is identified."""
+        values = []
+        number_pattern = r"([-+]?\d+(?:\.\d+)?)"
+        for option in self.question_options:
+            pattern = rf"{re.escape(str(option))}\s*:\s*{number_pattern}"
+            matches = re.findall(pattern, text, flags=re.IGNORECASE)
+            if len(matches) != 1:
+                return []
+            values.append(float(matches[0]))
+        return values
 
     def _repair_small_rounding_error(self, answer):
         """Correct a rounding-sized residual without changing an unsafe answer."""

--- a/edsl/questions/question_budget.py
+++ b/edsl/questions/question_budget.py
@@ -340,24 +340,30 @@ class BudgetResponseValidator(ResponseValidatorABC):
                 ]
             except ValueError:
                 # If conversion fails, try to extract numbers using regex
-                pattern = r"\b\d+(?:\.\d+)?\b"
+                pattern = r"[-+]?\d+(?:\.\d+)?"
                 matches = re.findall(pattern, answer.replace(",", " "))
                 if matches:
                     fixed_answer = [float(match) for match in matches]
 
         # Strategy 2: Handle dictionary inputs (convert to list)
         elif isinstance(answer, dict):
-            # If keys are numeric or string indices, convert to a list
             try:
-                # Sort by key (if keys are integers or can be converted to integers)
-                sorted_keys = sorted(
-                    answer.keys(),
-                    key=lambda k: int(k) if isinstance(k, str) and k.isdigit() else k,
-                )
-                fixed_answer = [float(answer[k]) for k in sorted_keys]
+                # Prefer semantic labels, in the same order as the question.
+                if set(answer) == set(self.question_options):
+                    fixed_answer = [
+                        float(answer[option]) for option in self.question_options
+                    ]
+                else:
+                    # Indexed mappings are safe only when every expected index exists.
+                    indexed_answer = {int(key): value for key, value in answer.items()}
+                    expected_indices = set(range(len(self.question_options)))
+                    if set(indexed_answer) == expected_indices:
+                        fixed_answer = [
+                            float(indexed_answer[index])
+                            for index in range(len(self.question_options))
+                        ]
             except (ValueError, TypeError):
-                # If we can't sort, just take values in whatever order
-                fixed_answer = [float(v) for v in answer.values()]
+                pass
 
         # Strategy 3: If it's already a list but might contain non-numeric values
         elif isinstance(answer, list):
@@ -365,6 +371,8 @@ class BudgetResponseValidator(ResponseValidatorABC):
                 fixed_answer = [float(x) for x in answer]
             except (ValueError, TypeError):
                 pass
+
+        fixed_answer = self._repair_small_rounding_error(fixed_answer)
 
         if verbose:
             print(f"Fixed answer: {fixed_answer}")
@@ -377,6 +385,30 @@ class BudgetResponseValidator(ResponseValidatorABC):
             fixed_response["comment"] = response["comment"]
 
         return fixed_response
+
+    def _repair_small_rounding_error(self, answer):
+        """Correct a rounding-sized residual without changing an unsafe answer."""
+        if self.permissive or len(answer) != len(self.question_options):
+            return answer
+        if not answer or any(value < 0 for value in answer):
+            return answer
+
+        residual = float(self.budget_sum) - sum(answer)
+        tolerance = min(0.5, max(abs(float(self.budget_sum)) * 0.01, 1e-9))
+        if residual == 0 or abs(residual) > tolerance:
+            return answer
+
+        # Put the residual on the largest allocation. This is deterministic and
+        # avoids making a small or zero allocation negative due to rounding.
+        index = max(range(len(answer)), key=answer.__getitem__)
+        repaired = answer.copy()
+        repaired[index] += residual
+        if repaired[index] < 0:
+            return answer
+
+        # Eliminate any final binary-float residual used by the strict validator.
+        repaired[index] += float(self.budget_sum) - sum(repaired)
+        return repaired
 
     def _check_constraints(self, pydantic_edsl_answer: BaseModel):
         """Method preserved for compatibility, constraints handled in Pydantic model."""

--- a/tests/questions/test_QuestionBudget.py
+++ b/tests/questions/test_QuestionBudget.py
@@ -161,6 +161,33 @@ def test_QuestionBudget_repairs_small_rounding_residual():
     assert validated["answer"] == pytest.approx([33.4, 33.3, 33.3, 0])
 
 
+def test_QuestionBudget_repairs_single_labeled_allocation_string():
+    q = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+
+    validated = q.response_validator.validate(
+        {"answer": ["Product revenue %: 50, Advertising revenue %: 50"]}
+    )
+
+    assert validated["answer"] == [50, 50]
+
+
+def test_QuestionBudget_rejects_partial_labeled_allocation_string():
+    q = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": ["Product revenue %: 100"]})
+
+
 @pytest.mark.parametrize(
     "answer",
     [

--- a/tests/questions/test_QuestionBudget.py
+++ b/tests/questions/test_QuestionBudget.py
@@ -135,6 +135,54 @@ def test_QuestionBudget_answers():
         q._validate_answer(invalid_answer)
 
 
+def test_QuestionBudget_repairs_labeled_mapping_in_question_order():
+    q = QuestionBudget(**valid_question)
+
+    validated = q.response_validator.validate(
+        {
+            "answer": {
+                "Salad": 10,
+                "Pizza": 40,
+                "Burgers": 20,
+                "Ice Cream": 30,
+            }
+        }
+    )
+
+    assert validated["answer"] == [40, 30, 20, 10]
+
+
+def test_QuestionBudget_repairs_small_rounding_residual():
+    q = QuestionBudget(**valid_question)
+
+    validated = q.response_validator.validate({"answer": [33.3, 33.3, 33.3, 0]})
+
+    assert sum(validated["answer"]) == q.budget_sum
+    assert validated["answer"] == pytest.approx([33.4, 33.3, 33.3, 0])
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        [30, 30, 30, 0],  # discrepancy is too large to be rounding
+        [40, 30, -1, 31],  # repair must not mask a negative allocation
+        {"Pizza": 50, "unknown": 50},  # labels do not identify every option
+    ],
+)
+def test_QuestionBudget_does_not_repair_unsafe_answers(answer):
+    q = QuestionBudget(**valid_question)
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": answer})
+
+
+def test_QuestionBudget_regex_repair_preserves_negative_sign():
+    q = QuestionBudget(**valid_question)
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": "40, 30, -1, 31"})
+
+
 def test_QuestionBudget_extras():
     """Test QuestionBudget's extra functionalities."""
     q = QuestionBudget(**valid_question)

--- a/tests/runner/test_budget_response_repair.py
+++ b/tests/runner/test_budget_response_repair.py
@@ -20,3 +20,24 @@ def test_budget_rounding_repair_runs_through_local_job_runner():
 
     answer = results.select("answer.allocation").to_list()[0]
     assert sum(answer) == 100
+
+
+def test_labeled_budget_string_repairs_through_local_job_runner():
+    question = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+    model = Model(
+        "test",
+        canned_response="[Product revenue %: 50, Advertising revenue %: 50]",
+    )
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    assert results.select("answer.revenue_split").to_list() == [[50.0, 50.0]]

--- a/tests/runner/test_budget_response_repair.py
+++ b/tests/runner/test_budget_response_repair.py
@@ -1,0 +1,22 @@
+"""Regression coverage for budget repair using only the local test model."""
+
+from edsl import Model, QuestionBudget
+
+
+def test_budget_rounding_repair_runs_through_local_job_runner():
+    question = QuestionBudget(
+        question_name="allocation",
+        question_text="Allocate 100 points.",
+        question_options=["A", "B", "C", "D"],
+        budget_sum=100,
+    )
+    model = Model("test", canned_response="[33.3, 33.3, 33.3, 0]")
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    answer = results.select("answer.allocation").to_list()[0]
+    assert sum(answer) == 100


### PR DESCRIPTION
## Summary
- preserve question option order when repairing labeled budget mappings
- repair only small strict-budget rounding residuals, deterministically
- reject unsafe mappings, negative allocations, and material sum discrepancies
- preserve negative signs during string fallback parsing

## Verification
- `pytest -q tests/questions/test_QuestionBudget.py tests/runner/test_budget_response_repair.py --doctest-modules edsl/questions/question_budget.py`
- 19 passed
- local scripted `test` model only; no API calls, remote inference, or remote cache

Tracks #2563.