### PR TITLE
Unwrap structured multiple-choice-with-other answers

### DIFF
--- a/edsl/questions/question_multiple_choice_with_other.py
+++ b/edsl/questions/question_multiple_choice_with_other.py
@@ -130,6 +130,7 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
         """
         # Create a copy to avoid modifying the original that may be needed elsewhere
         response_dict = response_dict.copy()
+        self._unwrap_structured_answer(response_dict)
         answer = str(response_dict.get("answer", ""))
 
         # Check for "{other_option_text}: X" format directly in the answer field
@@ -187,6 +188,9 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
         Returns:
             A fixed response dict if possible, otherwise the original response
         """
+        response = response.copy()
+        self._unwrap_structured_answer(response)
+
         # Check if this is an "Other" response with additional text
         response_text = str(response.get("answer", ""))
 
@@ -233,6 +237,24 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
 
         # If not an "Other" response, try the parent class fix method
         return super().fix(response, verbose)
+
+    @staticmethod
+    def _unwrap_structured_answer(response):
+        """Unwrap a model's redundant ``{"answer": {"answer": value}}`` shape."""
+        nested = response.get("answer")
+        if not isinstance(nested, dict) or "answer" not in nested:
+            return
+
+        # Only unwrap an EDSL response envelope, never an arbitrary mapping that
+        # happens to contain application data under an ``answer`` key.
+        response_fields = {"answer", "comment", "generated_tokens"}
+        if not set(nested).issubset(response_fields):
+            return
+
+        response["answer"] = nested["answer"]
+        for field in ("comment", "generated_tokens"):
+            if response.get(field) is None and nested.get(field) is not None:
+                response[field] = nested[field]
 
     valid_examples = [
         (

--- a/tests/questions/test_QuestionMultipleChoiceWithOther.py
+++ b/tests/questions/test_QuestionMultipleChoiceWithOther.py
@@ -114,6 +114,25 @@ def test_validator_regular_answer():
     assert validated["answer"] == "Blue"
 
 
+def test_validator_unwraps_structured_answer_envelope():
+    long_option = (
+        "We share full postback data with only the attributed network and "
+        "limited/partial postback data with the other non-attributed networks"
+    )
+    q = QuestionMultipleChoiceWithOther(
+        question_name="postback_policy",
+        question_text="How do you share postback data?",
+        question_options=["We do not share postback data", long_option, "Not sure"],
+    )
+
+    validated = q.response_validator.validate(
+        {"answer": {"answer": long_option, "comment": "From the profile"}}
+    )
+
+    assert validated["answer"] == long_option
+    assert validated["comment"] == "From the profile"
+
+
 def test_validator_invalid_answer():
     """Test that invalid answers (not in options) are rejected."""
     # Create the question

--- a/tests/runner/test_multiple_choice_with_other_validation.py
+++ b/tests/runner/test_multiple_choice_with_other_validation.py
@@ -1,0 +1,34 @@
+"""Local runner regression for structured multiple-choice-with-other output."""
+
+import json
+
+from edsl import Model, QuestionMultipleChoiceWithOther
+
+
+def test_long_listed_option_in_structured_response_runs_locally():
+    long_option = (
+        "We share full postback data with only the attributed network and "
+        "limited/partial postback data with the other non-attributed networks"
+    )
+    question = QuestionMultipleChoiceWithOther(
+        question_name="q19b_postback_policy",
+        question_text="How do you share postback data?",
+        question_options=[
+            "We do not share postback data with ad networks",
+            "We share full postback data with the attributed ad network only",
+            "We share full postback data with all ad networks",
+            long_option,
+            "Not sure",
+        ],
+        other_option_text="Other (please specify)",
+    )
+    model = Model("test", canned_response=json.dumps({"answer": long_option}))
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    assert results.select("answer.q19b_postback_policy").to_list() == [long_option]
+


### PR DESCRIPTION
## Summary
- unwrap a redundant structured response envelope before `multiple_choice_with_other` validation
- preserve nested comment and generated-token metadata when the outer response lacks them
- leave arbitrary answer mappings untouched
- cover the exact long postback-policy option through the local runner

## Root cause
A structured response for this question type can arrive as `{"answer": {"answer": "<option>"}}`. The validator stringified the inner mapping rather than validating the selected value, causing a listed option to fail strict validation.

## Verification
- `pytest -q tests/questions/test_QuestionMultipleChoiceWithOther.py tests/runner/test_multiple_choice_with_other_validation.py --doctest-modules edsl/questions/question_multiple_choice_with_other.py`
- 11 passed
- scripted local `test` model only; no real LLM or network calls

Tracks #2563.