### PR TITLE
Integrate local adaptive-survey reliability fixes

### DIFF
--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -18,6 +18,7 @@ from edsl.cli_shared import (
     EXIT_VALIDATION,
     error,
     jsonable,
+    load_any_object,
     output,
     raw_output_written,
     read_json_file,
@@ -145,27 +146,46 @@ def register(app: click.Group) -> None:
         # Step 3: Apply component overrides
         try:
             if agent_list:
-                data = read_json_file(agent_list)
+                agents_obj = load_any_object(
+                    agent_list, expected_object_type="AgentList"
+                )
+                if not isinstance(agents_obj, AgentListClass):
+                    raise TypeError(
+                        f"--agent_list requires AgentList, got {type(agents_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
-                    agents=AgentListClass.from_dict(data),
+                    agents=agents_obj,
                     models=job.models,
                     scenarios=job.scenarios,
                 )
             if scenario_list:
-                data = read_json_file(scenario_list)
+                scenarios_obj = load_any_object(
+                    scenario_list, expected_object_type="ScenarioList"
+                )
+                if not isinstance(scenarios_obj, ScenarioListClass):
+                    raise TypeError(
+                        "--scenario_list requires ScenarioList, "
+                        f"got {type(scenarios_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
                     agents=job.agents,
                     models=job.models,
-                    scenarios=ScenarioListClass.from_dict(data),
+                    scenarios=scenarios_obj,
                 )
             if model_list:
-                data = read_json_file(model_list)
+                models_obj = load_any_object(
+                    model_list, expected_object_type="ModelList"
+                )
+                if not isinstance(models_obj, ModelListClass):
+                    raise TypeError(
+                        f"--model_list requires ModelList, got {type(models_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
                     agents=job.agents,
-                    models=ModelListClass.from_dict(data),
+                    models=models_obj,
                     scenarios=job.scenarios,
                 )
             if model:
@@ -395,8 +415,11 @@ def register(app: click.Group) -> None:
             return _load_jobs_from_path(jobs_path)
 
         if input_mode == "survey":
-            data = read_json_file(survey_path)
-            sv = SurveyClass.from_dict(data)
+            sv = load_any_object(survey_path, expected_object_type="Survey")
+            if not isinstance(sv, SurveyClass):
+                raise TypeError(
+                    f"--survey requires Survey, got {type(sv).__name__}"
+                )
             return Jobs(survey=sv)
 
         if input_mode in ("json", "stdin"):
@@ -430,15 +453,12 @@ def register(app: click.Group) -> None:
 
 
     def _load_jobs_from_path(path: str):
-        path_obj = Path(path)
-        if path_obj.suffix == ".ep":
-            from edsl.jobs import Jobs
-
-            return Jobs.git.load(path_obj)
-        data = read_json_file(path)
         from edsl.jobs import Jobs
 
-        return Jobs.from_dict(data)
+        job = load_any_object(path, expected_object_type="Jobs")
+        if not isinstance(job, Jobs):
+            raise TypeError(f"Jobs input requires Jobs, got {type(job).__name__}")
+        return job
 
 
     def _build_job_from_json(data: dict):

--- a/edsl/cli_commands/validate.py
+++ b/edsl/cli_commands/validate.py
@@ -8,7 +8,14 @@ from typing import Optional
 
 import click
 
-from edsl.cli_shared import EXIT_USAGE, EXIT_VALIDATION, error, output, read_json_file
+from edsl.cli_shared import (
+    EXIT_USAGE,
+    EXIT_VALIDATION,
+    error,
+    load_any_object,
+    output,
+    read_serialized_object,
+)
 
 
 def register(app: click.Group) -> None:
@@ -23,8 +30,17 @@ def register(app: click.Group) -> None:
     def validate(file_path, json_data, force_type):
         """Validate a question, survey, or job spec without executing."""
         raw = None
+        loaded_type = None
         if file_path:
-            raw = read_json_file(file_path)
+            from pathlib import Path
+
+            path = Path(file_path)
+            if path.is_dir() or path.suffix == ".ep":
+                loaded = load_any_object(file_path)
+                loaded_type = loaded.__class__.__name__
+                raw = loaded.to_dict()
+            else:
+                raw = read_serialized_object(path)
         elif json_data:
             try:
                 raw = json.loads(json_data)
@@ -50,7 +66,16 @@ def register(app: click.Group) -> None:
         # Detect object type
         obj_type = force_type
         if not obj_type:
-            if "survey" in raw and isinstance(raw.get("survey"), dict):
+            class_name = loaded_type or raw.get("edsl_class_name")
+            serialized_types = {
+                "Survey": "survey",
+                "Jobs": "job",
+                "AgentList": "agent_list",
+                "ScenarioList": "scenario_list",
+            }
+            if class_name in serialized_types:
+                obj_type = serialized_types[class_name]
+            elif "survey" in raw and isinstance(raw.get("survey"), dict):
                 obj_type = "job"
             elif "questions" in raw and isinstance(raw.get("questions"), list):
                 obj_type = "job_lightweight"

--- a/edsl/questions/question_base_gen_mixin.py
+++ b/edsl/questions/question_base_gen_mixin.py
@@ -184,6 +184,14 @@ class QuestionBaseGenMixin:
         if not hasattr(self, "question_options"):
             return copy.deepcopy(self)
 
+        # Dynamic options are rendered from prior answers at interview time,
+        # e.g. ``{{ available_options.answer }}``. Before those answers exist,
+        # the value is a template string rather than an option collection.
+        # Sampling it here would shuffle individual characters and create an
+        # invalid question, so preserve it for runtime rendering.
+        if not isinstance(self.question_options, list):
+            return copy.deepcopy(self)
+
         # Use provided random instance or create one with seed
         if random_instance is not None:
             rng = random_instance

--- a/edsl/questions/question_budget.py
+++ b/edsl/questions/question_budget.py
@@ -370,7 +370,8 @@ class BudgetResponseValidator(ResponseValidatorABC):
             try:
                 fixed_answer = [float(x) for x in answer]
             except (ValueError, TypeError):
-                pass
+                if len(answer) == 1 and isinstance(answer[0], str):
+                    fixed_answer = self._parse_labeled_allocation(answer[0])
 
         fixed_answer = self._repair_small_rounding_error(fixed_answer)
 
@@ -385,6 +386,18 @@ class BudgetResponseValidator(ResponseValidatorABC):
             fixed_response["comment"] = response["comment"]
 
         return fixed_response
+
+    def _parse_labeled_allocation(self, text):
+        """Parse ``Option: value`` pairs only when every option is identified."""
+        values = []
+        number_pattern = r"([-+]?\d+(?:\.\d+)?)"
+        for option in self.question_options:
+            pattern = rf"{re.escape(str(option))}\s*:\s*{number_pattern}"
+            matches = re.findall(pattern, text, flags=re.IGNORECASE)
+            if len(matches) != 1:
+                return []
+            values.append(float(matches[0]))
+        return values
 
     def _repair_small_rounding_error(self, answer):
         """Correct a rounding-sized residual without changing an unsafe answer."""

--- a/edsl/questions/question_budget.py
+++ b/edsl/questions/question_budget.py
@@ -340,24 +340,30 @@ class BudgetResponseValidator(ResponseValidatorABC):
                 ]
             except ValueError:
                 # If conversion fails, try to extract numbers using regex
-                pattern = r"\b\d+(?:\.\d+)?\b"
+                pattern = r"[-+]?\d+(?:\.\d+)?"
                 matches = re.findall(pattern, answer.replace(",", " "))
                 if matches:
                     fixed_answer = [float(match) for match in matches]
 
         # Strategy 2: Handle dictionary inputs (convert to list)
         elif isinstance(answer, dict):
-            # If keys are numeric or string indices, convert to a list
             try:
-                # Sort by key (if keys are integers or can be converted to integers)
-                sorted_keys = sorted(
-                    answer.keys(),
-                    key=lambda k: int(k) if isinstance(k, str) and k.isdigit() else k,
-                )
-                fixed_answer = [float(answer[k]) for k in sorted_keys]
+                # Prefer semantic labels, in the same order as the question.
+                if set(answer) == set(self.question_options):
+                    fixed_answer = [
+                        float(answer[option]) for option in self.question_options
+                    ]
+                else:
+                    # Indexed mappings are safe only when every expected index exists.
+                    indexed_answer = {int(key): value for key, value in answer.items()}
+                    expected_indices = set(range(len(self.question_options)))
+                    if set(indexed_answer) == expected_indices:
+                        fixed_answer = [
+                            float(indexed_answer[index])
+                            for index in range(len(self.question_options))
+                        ]
             except (ValueError, TypeError):
-                # If we can't sort, just take values in whatever order
-                fixed_answer = [float(v) for v in answer.values()]
+                pass
 
         # Strategy 3: If it's already a list but might contain non-numeric values
         elif isinstance(answer, list):
@@ -365,6 +371,8 @@ class BudgetResponseValidator(ResponseValidatorABC):
                 fixed_answer = [float(x) for x in answer]
             except (ValueError, TypeError):
                 pass
+
+        fixed_answer = self._repair_small_rounding_error(fixed_answer)
 
         if verbose:
             print(f"Fixed answer: {fixed_answer}")
@@ -377,6 +385,30 @@ class BudgetResponseValidator(ResponseValidatorABC):
             fixed_response["comment"] = response["comment"]
 
         return fixed_response
+
+    def _repair_small_rounding_error(self, answer):
+        """Correct a rounding-sized residual without changing an unsafe answer."""
+        if self.permissive or len(answer) != len(self.question_options):
+            return answer
+        if not answer or any(value < 0 for value in answer):
+            return answer
+
+        residual = float(self.budget_sum) - sum(answer)
+        tolerance = min(0.5, max(abs(float(self.budget_sum)) * 0.01, 1e-9))
+        if residual == 0 or abs(residual) > tolerance:
+            return answer
+
+        # Put the residual on the largest allocation. This is deterministic and
+        # avoids making a small or zero allocation negative due to rounding.
+        index = max(range(len(answer)), key=answer.__getitem__)
+        repaired = answer.copy()
+        repaired[index] += residual
+        if repaired[index] < 0:
+            return answer
+
+        # Eliminate any final binary-float residual used by the strict validator.
+        repaired[index] += float(self.budget_sum) - sum(repaired)
+        return repaired
 
     def _check_constraints(self, pydantic_edsl_answer: BaseModel):
         """Method preserved for compatibility, constraints handled in Pydantic model."""

--- a/edsl/questions/question_multiple_choice_with_other.py
+++ b/edsl/questions/question_multiple_choice_with_other.py
@@ -113,7 +113,13 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
             question_options.append("Other")
         self.question_options = question_options
 
-    def validate(self, response_dict, verbose=False):
+    def validate(
+        self,
+        response_dict,
+        fix=False,
+        verbose=False,
+        replacement_dict=None,
+    ):
         """
         Validate the response according to the schema.
 
@@ -154,7 +160,12 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
 
         # Try to validate with the parent validator
         try:
-            validated_response = super().validate(response_dict, verbose)
+            validated_response = super().validate(
+                response_dict,
+                fix=fix,
+                verbose=verbose,
+                replacement_dict=replacement_dict,
+            )
             return validated_response
         except Exception as _:
             # If validation fails but the answer matches our pattern, accept it anyway

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -177,7 +177,29 @@ class DirectAnswerRegistry:
                 entry.job_id, entry.interview_id
             )
 
-        kwargs = {"scenario": entry.scenario, "agent_traits": agent_traits}
+        # Functional/self-answering questions historically ran through
+        # InvigilatorFunctional, which enriched the scenario with answered
+        # Question objects.  Jinja piping relies on that object shape, e.g.
+        # ``{{ q0.answer }}``.  The direct-answer runner bypasses the
+        # invigilator, so reconstruct the same context here rather than passing
+        # only the original job scenario.
+        scenario = entry.scenario
+        if current_answers and self._job_service and entry.job_id:
+            survey_data = self._job_service._jobs.get_survey(entry.job_id)
+            if survey_data:
+                from ..surveys import Survey
+
+                answered_questions = Survey.from_dict(
+                    survey_data
+                ).question_names_to_questions()
+                for question_name, answer in current_answers.items():
+                    if question_name in answered_questions:
+                        answered_questions[question_name].answer = answer
+
+                agent_context = {"agent": agent_traits} if agent_traits else {}
+                scenario = scenario | answered_questions | agent_context
+
+        kwargs = {"scenario": scenario, "agent_traits": agent_traits}
         signature = inspect.signature(entry.question.answer_question_directly)
         if "current_answers" in signature.parameters:
             kwargs["current_answers"] = current_answers

--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -553,8 +553,18 @@ class ExecutionWorker:
 
         try:
             validated_dict = question._validate_answer(raw_answer_dict)
+            validated_answer = validated_dict.get("answer", answer)
+            # Match the legacy invigilator contract: validate the model's
+            # compact/code response first, then expose the translated answer
+            # to Results and downstream piping.  This is significant for
+            # QuestionBudget, whose validated response is a numeric list but
+            # whose public answer is a list of option-labelled allocations.
+            if getattr(question, "probabilistic_response", None) is None:
+                validated_answer = question._translate_answer_code_to_answer(
+                    validated_answer, scenario_data
+                )
             return (
-                validated_dict.get("answer", answer),
+                validated_answer,
                 validated_dict.get("comment", comment),
                 True,
                 validated_dict.get("distribution"),

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -1167,12 +1167,24 @@ class JobService:
                     frontier.extend(task_def.dependents)
 
         ordered_ids = list(blocked_ids)
-        self._tasks.set_statuses_batch(ordered_ids, TaskStatus.BLOCKED)
+        statuses = self._tasks.get_statuses_batch(ordered_ids)
+        terminal_statuses = {
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.SKIPPED,
+            TaskStatus.BLOCKED,
+        }
+        newly_blocked_ids = [
+            task_id
+            for task_id in ordered_ids
+            if statuses.get(task_id) not in terminal_statuses
+        ]
+        self._tasks.set_statuses_batch(newly_blocked_ids, TaskStatus.BLOCKED)
         self._tasks.set_errors_batch(
-            ordered_ids, "upstream_failure", "Blocked by failed dependency"
+            newly_blocked_ids, "upstream_failure", "Blocked by failed dependency"
         )
         self._interviews.mark_tasks_blocked(
-            job_id, interview_id, len(ordered_ids)
+            job_id, interview_id, len(newly_blocked_ids)
         )
 
     # =========================================================================

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -1140,18 +1140,40 @@ class JobService:
     def _propagate_failure(
         self, job_id: str, interview_id: str, dependent_ids: list[str]
     ) -> None:
-        """Recursively mark dependents as blocked."""
-        for dep_id in dependent_ids:
-            self._tasks.set_status(dep_id, TaskStatus.BLOCKED)
-            self._tasks.set_error(
-                dep_id, "upstream_failure", "Blocked by failed dependency"
-            )
-            self._interviews.mark_task_blocked(job_id, interview_id)
+        """Mark every downstream task blocked exactly once.
 
-            # Recurse
-            dep_def = self._tasks.get_definition(job_id, interview_id, dep_id)
-            if dep_def:
-                self._propagate_failure(job_id, interview_id, dep_def.dependents)
+        A dependency DAG can converge, so recursive path traversal revisits the
+        same task many times (exponentially in a dense graph), over-counts
+        blocked tasks, and repeatedly finalizes the interview.  Traverse by
+        unique task ID and batch state changes instead.
+        """
+        blocked_ids: set[str] = set()
+        frontier = list(dependent_ids)
+
+        while frontier:
+            current = list(dict.fromkeys(frontier))
+            frontier = []
+            unseen = [task_id for task_id in current if task_id not in blocked_ids]
+            if not unseen:
+                continue
+
+            blocked_ids.update(unseen)
+            definitions = self._tasks.get_definitions_batch(
+                job_id, interview_id, unseen
+            )
+            for task_id in unseen:
+                task_def = definitions.get(task_id)
+                if task_def:
+                    frontier.extend(task_def.dependents)
+
+        ordered_ids = list(blocked_ids)
+        self._tasks.set_statuses_batch(ordered_ids, TaskStatus.BLOCKED)
+        self._tasks.set_errors_batch(
+            ordered_ids, "upstream_failure", "Blocked by failed dependency"
+        )
+        self._interviews.mark_tasks_blocked(
+            job_id, interview_id, len(ordered_ids)
+        )
 
     # =========================================================================
     # Job Status & Results

--- a/edsl/runner/stores.py
+++ b/edsl/runner/stores.py
@@ -570,6 +570,17 @@ class InterviewStore:
         self.increment_blocked(interview_id)
         self._maybe_finalize(job_id, interview_id)
 
+    def mark_tasks_blocked(
+        self, job_id: str, interview_id: str, count: int
+    ) -> None:
+        """Record several blocked tasks and finalize the interview once."""
+        if count <= 0:
+            return
+        self._storage.increment_volatile(
+            f"interview:{interview_id}:blocked", count
+        )
+        self._maybe_finalize(job_id, interview_id)
+
     def _maybe_finalize(self, job_id: str, interview_id: str) -> None:
         """Check if interview is done and update state accordingly."""
         definition = self.get_definition(job_id, interview_id)
@@ -925,6 +936,16 @@ class TaskStore:
         if not task_ids:
             return
         items = {f"task:{task_id}:status": status.value for task_id in task_ids}
+        self._storage.batch_write_volatile(items)
+
+    def set_errors_batch(
+        self, task_ids: list[str], error_type: str, error_message: str
+    ) -> None:
+        """Set the same error on several tasks in one storage operation."""
+        if not task_ids:
+            return
+        error = {"type": error_type, "message": error_message}
+        items = {f"task:{task_id}:error": error for task_id in task_ids}
         self._storage.batch_write_volatile(items)
 
     # Ready task operations

--- a/tests/questions/test_QuestionBudget.py
+++ b/tests/questions/test_QuestionBudget.py
@@ -161,6 +161,33 @@ def test_QuestionBudget_repairs_small_rounding_residual():
     assert validated["answer"] == pytest.approx([33.4, 33.3, 33.3, 0])
 
 
+def test_QuestionBudget_repairs_single_labeled_allocation_string():
+    q = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+
+    validated = q.response_validator.validate(
+        {"answer": ["Product revenue %: 50, Advertising revenue %: 50"]}
+    )
+
+    assert validated["answer"] == [50, 50]
+
+
+def test_QuestionBudget_rejects_partial_labeled_allocation_string():
+    q = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": ["Product revenue %: 100"]})
+
+
 @pytest.mark.parametrize(
     "answer",
     [

--- a/tests/questions/test_QuestionBudget.py
+++ b/tests/questions/test_QuestionBudget.py
@@ -135,6 +135,54 @@ def test_QuestionBudget_answers():
         q._validate_answer(invalid_answer)
 
 
+def test_QuestionBudget_repairs_labeled_mapping_in_question_order():
+    q = QuestionBudget(**valid_question)
+
+    validated = q.response_validator.validate(
+        {
+            "answer": {
+                "Salad": 10,
+                "Pizza": 40,
+                "Burgers": 20,
+                "Ice Cream": 30,
+            }
+        }
+    )
+
+    assert validated["answer"] == [40, 30, 20, 10]
+
+
+def test_QuestionBudget_repairs_small_rounding_residual():
+    q = QuestionBudget(**valid_question)
+
+    validated = q.response_validator.validate({"answer": [33.3, 33.3, 33.3, 0]})
+
+    assert sum(validated["answer"]) == q.budget_sum
+    assert validated["answer"] == pytest.approx([33.4, 33.3, 33.3, 0])
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        [30, 30, 30, 0],  # discrepancy is too large to be rounding
+        [40, 30, -1, 31],  # repair must not mask a negative allocation
+        {"Pizza": 50, "unknown": 50},  # labels do not identify every option
+    ],
+)
+def test_QuestionBudget_does_not_repair_unsafe_answers(answer):
+    q = QuestionBudget(**valid_question)
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": answer})
+
+
+def test_QuestionBudget_regex_repair_preserves_negative_sign():
+    q = QuestionBudget(**valid_question)
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q.response_validator.validate({"answer": "40, 30, -1, 31"})
+
+
 def test_QuestionBudget_extras():
     """Test QuestionBudget's extra functionalities."""
     q = QuestionBudget(**valid_question)

--- a/tests/questions/test_QuestionMultipleChoiceWithOther.py
+++ b/tests/questions/test_QuestionMultipleChoiceWithOther.py
@@ -114,6 +114,22 @@ def test_validator_regular_answer():
     assert validated["answer"] == "Blue"
 
 
+def test_validator_repairs_long_option_with_trailing_punctuation():
+    long_option = (
+        "Share complete data with the selected partner and limited data with "
+        "the other non-selected partners"
+    )
+    q = QuestionMultipleChoiceWithOther(
+        question_name="sharing_policy",
+        question_text="Choose a sharing policy.",
+        question_options=["Do not share data", long_option, "Not sure"],
+    )
+
+    validated = q.response_validator.validate({"answer": f"{long_option}."})
+
+    assert validated["answer"] == long_option
+
+
 def test_validator_invalid_answer():
     """Test that invalid answers (not in options) are rejected."""
     # Create the question

--- a/tests/runner/test_budget_answer_translation.py
+++ b/tests/runner/test_budget_answer_translation.py
@@ -1,0 +1,32 @@
+from edsl import Agent, QuestionBudget, Survey
+from edsl.inference_services.services.test_service import TestService
+
+
+def test_budget_result_uses_labelled_public_answer_contract():
+    budget = QuestionBudget(
+        question_name="channel_budget",
+        question_text="Allocate channel spend.",
+        question_options=["Channel A", "Channel B", "Channel C"],
+        budget_sum=100,
+    )
+    model = TestService.create_model("test")(
+        skip_api_key_check=True,
+        func=lambda user_prompt, system_prompt, files_list: "[20,30,50]",
+    )
+
+    results = (
+        Survey([budget])
+        .by(Agent())
+        .by(model)
+        .run(
+            disable_remote_inference=True,
+            stop_on_exception=True,
+            cache=False,
+        )
+    )
+
+    assert results.select("answer.channel_budget").to_list()[0] == [
+        {"Channel A": 20.0},
+        {"Channel B": 30.0},
+        {"Channel C": 50.0},
+    ]

--- a/tests/runner/test_budget_response_repair.py
+++ b/tests/runner/test_budget_response_repair.py
@@ -25,3 +25,29 @@ def test_budget_rounding_repair_runs_through_local_job_runner():
     allocations = [next(iter(row.values())) for row in answer]
     assert sum(allocations) == 100
     assert allocations == pytest.approx([33.4, 33.3, 33.3, 0])
+
+
+def test_labeled_budget_string_repairs_through_local_job_runner():
+    question = QuestionBudget(
+        question_name="revenue_split",
+        question_text="Allocate revenue.",
+        question_options=["Product revenue %", "Advertising revenue %"],
+        budget_sum=100,
+    )
+    model = Model(
+        "test",
+        canned_response="[Product revenue %: 50, Advertising revenue %: 50]",
+    )
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    assert results.select("answer.revenue_split").to_list() == [
+        [
+            {"Product revenue %": 50.0},
+            {"Advertising revenue %": 50.0},
+        ]
+    ]

--- a/tests/runner/test_budget_response_repair.py
+++ b/tests/runner/test_budget_response_repair.py
@@ -1,0 +1,22 @@
+"""Regression coverage for budget repair using only the local test model."""
+
+from edsl import Model, QuestionBudget
+
+
+def test_budget_rounding_repair_runs_through_local_job_runner():
+    question = QuestionBudget(
+        question_name="allocation",
+        question_text="Allocate 100 points.",
+        question_options=["A", "B", "C", "D"],
+        budget_sum=100,
+    )
+    model = Model("test", canned_response="[33.3, 33.3, 33.3, 0]")
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    answer = results.select("answer.allocation").to_list()[0]
+    assert sum(answer) == 100

--- a/tests/runner/test_budget_response_repair.py
+++ b/tests/runner/test_budget_response_repair.py
@@ -1,5 +1,7 @@
 """Regression coverage for budget repair using only the local test model."""
 
+import pytest
+
 from edsl import Model, QuestionBudget
 
 
@@ -19,4 +21,7 @@ def test_budget_rounding_repair_runs_through_local_job_runner():
     )
 
     answer = results.select("answer.allocation").to_list()[0]
-    assert sum(answer) == 100
+    assert [list(row) for row in answer] == [["A"], ["B"], ["C"], ["D"]]
+    allocations = [next(iter(row.values())) for row in answer]
+    assert sum(allocations) == 100
+    assert allocations == pytest.approx([33.4, 33.3, 33.3, 0])

--- a/tests/runner/test_compute_piping_direct_answer.py
+++ b/tests/runner/test_compute_piping_direct_answer.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from edsl import (
+    Agent,
+    QuestionBudget,
+    QuestionCheckBox,
+    QuestionCompute,
+    QuestionFreeText,
+    Scenario,
+    Survey,
+)
+from edsl.inference_services.services.test_service import TestService
+from edsl.runner.direct_answer import DirectAnswerEntry, DirectAnswerRegistry
+
+
+@pytest.mark.asyncio
+async def test_compute_direct_answer_receives_prior_answer_piping_context():
+    prior = QuestionFreeText(question_name="channels", question_text="Channels?")
+    compute = QuestionCompute(
+        question_name="clean_channels",
+        question_text="{{ channels.answer }}",
+    )
+    survey = Survey([prior, compute])
+
+    service = SimpleNamespace(
+        _gather_current_answers=lambda job_id, interview_id: {
+            "channels": ["Channel A", "Channel B"],
+            "channels.answer": ["Channel A", "Channel B"],
+        },
+        _jobs=SimpleNamespace(get_survey=lambda job_id: survey.to_dict()),
+    )
+    registry = DirectAnswerRegistry(job_service=service)
+    entry = DirectAnswerEntry(
+        task_id="compute-task",
+        execution_type="functional",
+        agent=None,
+        question=compute,
+        scenario=Scenario(),
+        job_id="job",
+        interview_id="interview",
+    )
+    registry.register(entry.task_id, entry)
+
+    result = await registry.execute(entry.task_id)
+
+    assert result["answer"] == "['Channel A', 'Channel B']"
+
+
+def test_compute_answer_can_supply_dynamic_budget_options_without_memory():
+    channels = QuestionCheckBox(
+        question_name="channels",
+        question_text="Which channels are used?",
+        question_options=["Channel A", "Channel B", "Channel C", "Channel D"],
+        min_selections=2,
+    )
+    clean_channels = QuestionCompute(
+        question_name="clean_channels",
+        question_text="{{ channels.answer | map('trim') | list }}",
+    )
+    allocation = QuestionBudget(
+        question_name="allocation",
+        question_text="Allocate channel spend.",
+        question_options="{{ clean_channels.answer }}",
+        budget_sum=100,
+    )
+    survey = Survey([channels, clean_channels, allocation])
+
+    def scripted_response(user_prompt, system_prompt, files_list):
+        if "Allocate your budget" in user_prompt:
+            return "[20,24,28,28]"
+        return '["Channel A","Channel B","Channel C","Channel D"]'
+
+    model = TestService.create_model("test")(
+        skip_api_key_check=True,
+        func=scripted_response,
+    )
+
+    results = (
+        survey.by(Agent())
+        .by(model)
+        .run(
+            disable_remote_inference=True,
+            stop_on_exception=True,
+            cache=False,
+        )
+    )
+
+    row = results.select(
+        "answer.channels",
+        "answer.clean_channels",
+        "answer.allocation",
+    ).to_list()[0]
+    assert row == (
+        ["Channel A", "Channel B", "Channel C", "Channel D"],
+        "['Channel A', 'Channel B', 'Channel C', 'Channel D']",
+        [20.0, 24.0, 28.0, 28.0],
+    )

--- a/tests/runner/test_compute_piping_direct_answer.py
+++ b/tests/runner/test_compute_piping_direct_answer.py
@@ -95,5 +95,10 @@ def test_compute_answer_can_supply_dynamic_budget_options_without_memory():
     assert row == (
         ["Channel A", "Channel B", "Channel C", "Channel D"],
         "['Channel A', 'Channel B', 'Channel C', 'Channel D']",
-        [20.0, 24.0, 28.0, 28.0],
+        [
+            {"Channel A": 20.0},
+            {"Channel B": 24.0},
+            {"Channel C": 28.0},
+            {"Channel D": 28.0},
+        ],
     )

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -1,0 +1,53 @@
+from edsl import Agent, QuestionCompute, QuestionFreeText, Survey
+from edsl.inference_services.services.test_service import TestService
+from edsl.runner.models import InterviewState, TaskStatus
+from edsl.runner.service import JobService
+from edsl.runner.storage import InMemoryStorage
+
+
+def test_failure_propagation_blocks_converging_dag_nodes_once():
+    root = QuestionFreeText(question_name="root", question_text="Root?")
+    left = QuestionCompute(question_name="left", question_text="{{ root.answer }}")
+    right = QuestionCompute(
+        question_name="right", question_text="{{ root.answer }}"
+    )
+    join = QuestionCompute(
+        question_name="join",
+        question_text="{{ left.answer }} {{ right.answer }}",
+    )
+    survey = Survey([root, left, right, join])
+    model = TestService.create_model("test")(skip_api_key_check=True)
+    job = survey.to_jobs().by(Agent()).by(model)
+
+    service = JobService(InMemoryStorage())
+    job_id, _, _ = service.submit_job(job, job_id="job")
+    interview_id = service.jobs.get_definition(job_id).interview_ids[0]
+    interview = service.interviews.get_definition(job_id, interview_id)
+    tasks = {
+        service.tasks.get_definition(job_id, interview_id, task_id).question_name:
+        service.tasks.get_definition(job_id, interview_id, task_id)
+        for task_id in interview.task_ids
+    }
+
+    service.on_task_failed(
+        job_id,
+        interview_id,
+        tasks["root"].task_id,
+        "test_failure",
+        "boom",
+        force_permanent=True,
+    )
+
+    status = service.interviews.get_status(interview_id)
+    assert status.failed == 1
+    assert status.blocked == 3
+    assert service.interviews.get_state(interview_id) == (
+        InterviewState.COMPLETED_WITH_FAILURES
+    )
+    assert service.tasks.get_statuses_batch(
+        [tasks[name].task_id for name in ("left", "right", "join")]
+    ) == {
+        tasks["left"].task_id: TaskStatus.BLOCKED,
+        tasks["right"].task_id: TaskStatus.BLOCKED,
+        tasks["join"].task_id: TaskStatus.BLOCKED,
+    }

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -51,3 +51,50 @@ def test_failure_propagation_blocks_converging_dag_nodes_once():
         tasks["right"].task_id: TaskStatus.BLOCKED,
         tasks["join"].task_id: TaskStatus.BLOCKED,
     }
+
+
+def test_separate_failures_do_not_recount_shared_blocked_descendants():
+    left = QuestionFreeText(question_name="left", question_text="Left?")
+    right = QuestionFreeText(question_name="right", question_text="Right?")
+    join = QuestionCompute(
+        question_name="join",
+        question_text="{{ left.answer }} {{ right.answer }}",
+    )
+    leaf = QuestionCompute(question_name="leaf", question_text="{{ join.answer }}")
+    survey = Survey([left, right, join, leaf])
+    model = TestService.create_model("test")(skip_api_key_check=True)
+    job = survey.to_jobs().by(Agent()).by(model)
+
+    service = JobService(InMemoryStorage())
+    job_id, _, _ = service.submit_job(job, job_id="job")
+    interview_id = service.jobs.get_definition(job_id).interview_ids[0]
+    interview = service.interviews.get_definition(job_id, interview_id)
+    tasks = {
+        service.tasks.get_definition(job_id, interview_id, task_id).question_name:
+        service.tasks.get_definition(job_id, interview_id, task_id)
+        for task_id in interview.task_ids
+    }
+
+    for question_name in ("left", "right"):
+        service.on_task_failed(
+            job_id,
+            interview_id,
+            tasks[question_name].task_id,
+            "test_failure",
+            "boom",
+            force_permanent=True,
+        )
+
+    status = service.interviews.get_status(interview_id)
+    assert status.failed == 2
+    assert status.blocked == 2
+    assert status.finished_count == interview.total_tasks
+    assert service.interviews.get_state(interview_id) == (
+        InterviewState.COMPLETED_WITH_FAILURES
+    )
+    assert service.tasks.get_statuses_batch(
+        [tasks[name].task_id for name in ("join", "leaf")]
+    ) == {
+        tasks["join"].task_id: TaskStatus.BLOCKED,
+        tasks["leaf"].task_id: TaskStatus.BLOCKED,
+    }

--- a/tests/runner/test_with_other_repair_contract.py
+++ b/tests/runner/test_with_other_repair_contract.py
@@ -1,0 +1,25 @@
+"""Local runner coverage for with-other validator repair recursion."""
+
+from edsl import Model, QuestionMultipleChoiceWithOther
+
+
+def test_long_option_with_trailing_punctuation_repairs_locally():
+    long_option = (
+        "Share complete data with the selected partner and limited data with "
+        "the other non-selected partners"
+    )
+    question = QuestionMultipleChoiceWithOther(
+        question_name="sharing_policy",
+        question_text="Choose a sharing policy.",
+        question_options=["Do not share data", long_option, "Not sure"],
+    )
+    model = Model("test", canned_response=f"{long_option}.")
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    assert results.select("answer.sharing_policy").to_list() == [long_option]
+

--- a/tests/surveys/test_Survey.py
+++ b/tests/surveys/test_Survey.py
@@ -287,6 +287,31 @@ class TestSurvey(unittest.TestCase):
         for ordering in color_list:
             assert set(ordering) == {"Red", "Blue", "Green"}
 
+    def test_draw_preserves_unresolved_dynamic_options(self):
+        static = QuestionMultipleChoice(
+            question_name="static",
+            question_text="Pick one.",
+            question_options=["A", "B", "C"],
+        )
+        dynamic = QuestionMultipleChoice(
+            question_name="dynamic",
+            question_text="Pick a prior answer.",
+            question_options="{{ static.answer }}",
+        )
+        survey = Survey(
+            [static, dynamic],
+            questions_to_randomize=["static", "dynamic"],
+        )
+
+        drawn = survey.draw()
+
+        self.assertEqual(
+            sorted(drawn.questions[0].question_options), ["A", "B", "C"]
+        )
+        self.assertEqual(
+            drawn.questions[1].question_options, "{{ static.answer }}"
+        )
+
     @unittest.skip("Pre-existing bug: question_name_to_index cache not invalidated after rename")
     def test_with_renamed_question_basic(self):
         """Test basic question renaming functionality."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3989,6 +3989,80 @@ class TestRunValidation:
         loaded = Results.git.load(results_path)
         assert len(loaded) == 1
 
+    @pytest.mark.parametrize("survey_format", ["ep", "json.gz"])
+    def test_run_accepts_durable_survey_formats(self, tmp_path, survey_format):
+        import gzip
+
+        from edsl.questions import QuestionFreeText
+        from edsl.results import Results
+        from edsl.surveys import Survey
+
+        survey = Survey(
+            [QuestionFreeText(question_name="name", question_text="Say your name.")]
+        )
+        survey_path = tmp_path / f"survey.{survey_format}"
+        if survey_format == "ep":
+            survey.git.save(survey_path)
+        else:
+            with gzip.open(survey_path, "wt", encoding="utf-8") as f:
+                json.dump(survey.to_dict(), f)
+
+        results_path = tmp_path / "results.ep"
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "run",
+                "--survey",
+                str(survey_path),
+                "--model",
+                "test",
+                "--local",
+                "--output",
+                str(results_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["status"] == "ok"
+        assert Results.git.load(results_path).select("answer.name").to_list() == [
+            "Hello, world X"
+        ]
+
+    def test_run_accepts_agent_list_package_override(self, tmp_path):
+        from edsl import Agent, AgentList
+        from edsl.questions import QuestionFreeText
+        from edsl.results import Results
+        from edsl.surveys import Survey
+
+        survey_path = tmp_path / "survey.ep"
+        agents_path = tmp_path / "agents.ep"
+        results_path = tmp_path / "results.ep"
+        Survey(
+            [QuestionFreeText(question_name="name", question_text="Say your name.")]
+        ).git.save(survey_path)
+        AgentList([Agent(traits={"cohort": "package"})]).git.save(agents_path)
+
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "run",
+                "--survey",
+                str(survey_path),
+                "--agent_list",
+                str(agents_path),
+                "--model",
+                "test",
+                "--local",
+                "--output",
+                str(results_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert Results.git.load(results_path).select("agent.cohort").to_list() == [
+            "package"
+        ]
+
     def test_canned_jobs_run_results_are_queryable_and_exportable(self, tmp_path):
         from edsl import Agent, AgentList, Jobs, Model, ModelList, Scenario, ScenarioList
         from edsl.questions import QuestionFreeText

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1701,6 +1701,38 @@ class TestValidate:
             out = run_cli("validate", "--file", f.name)
             assert out["data"]["valid"] is True
 
+    @pytest.mark.parametrize("survey_format", ["json", "json.gz", "ep"])
+    def test_validate_survey_with_instruction(self, tmp_path, survey_format):
+        import gzip
+
+        from edsl.instructions import Instruction
+        from edsl.questions import QuestionFreeText
+        from edsl.surveys import Survey
+
+        survey = Survey(
+            [
+                Instruction(name="intro", text="Please answer carefully."),
+                QuestionFreeText(question_name="q0", question_text="Say hello."),
+            ]
+        )
+        survey_path = tmp_path / f"survey.{survey_format}"
+        if survey_format == "ep":
+            survey.git.save(survey_path)
+        elif survey_format == "json.gz":
+            with gzip.open(survey_path, "wt", encoding="utf-8") as f:
+                json.dump(survey.to_dict(), f)
+        else:
+            survey_path.write_text(json.dumps(survey.to_dict()), encoding="utf-8")
+
+        result = CliRunner().invoke(
+            cli_module.app, ["validate", "--file", str(survey_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["data"]["valid"] is True
+        assert out["data"]["object_type"] == "survey"
+
     def test_validate_from_stdin(self):
         q = json.dumps({"type": "free_text", "question_name": "q0", "question_text": "Hello?"})
         out = run_cli("validate", stdin_data=q)


### PR DESCRIPTION
## Summary
This integration branch combines the focused local adaptive-survey reliability fixes from #2562, #2564, #2565, #2566, #2569, #2570, and #2571:

- preserve prior answers for compute-question piping and bound failure propagation
- count shared blocked descendants only once across independent upstream failures
- preserve unresolved dynamic option templates during randomization
- restore translated public answer contracts in the local runner
- repair safe strict-budget formats, labeled allocations, and small rounding residuals
- load durable component packages and compressed JSON in CLI runs
- validate durable surveys containing instructions
- preserve the response-validator repair method contract

It also aligns cross-feature regression expectations with the translated budget-answer contract.

## Verification
- 35 runner tests passed, including both within-call and cross-call converging-DAG regressions
- focused validator and CLI regression suites passed during integration
- GitHub Actions passed across the supported test and build matrix before the final follow-up; the pushed follow-up triggers a fresh matrix
- regression tests use direct validators or scripted local test models; no real LLM or network calls
- long adaptive surveys with differentiated synthetic agents were exercised through local inference

## Source PRs
- #2562
- #2564
- #2565
- #2566
- #2569
- #2570
- #2571