### PR TITLE
Load durable CLI run components consistently

### DIFF
--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -18,6 +18,7 @@ from edsl.cli_shared import (
     EXIT_VALIDATION,
     error,
     jsonable,
+    load_any_object,
     output,
     raw_output_written,
     read_json_file,
@@ -145,27 +146,46 @@ def register(app: click.Group) -> None:
         # Step 3: Apply component overrides
         try:
             if agent_list:
-                data = read_json_file(agent_list)
+                agents_obj = load_any_object(
+                    agent_list, expected_object_type="AgentList"
+                )
+                if not isinstance(agents_obj, AgentListClass):
+                    raise TypeError(
+                        f"--agent_list requires AgentList, got {type(agents_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
-                    agents=AgentListClass.from_dict(data),
+                    agents=agents_obj,
                     models=job.models,
                     scenarios=job.scenarios,
                 )
             if scenario_list:
-                data = read_json_file(scenario_list)
+                scenarios_obj = load_any_object(
+                    scenario_list, expected_object_type="ScenarioList"
+                )
+                if not isinstance(scenarios_obj, ScenarioListClass):
+                    raise TypeError(
+                        "--scenario_list requires ScenarioList, "
+                        f"got {type(scenarios_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
                     agents=job.agents,
                     models=job.models,
-                    scenarios=ScenarioListClass.from_dict(data),
+                    scenarios=scenarios_obj,
                 )
             if model_list:
-                data = read_json_file(model_list)
+                models_obj = load_any_object(
+                    model_list, expected_object_type="ModelList"
+                )
+                if not isinstance(models_obj, ModelListClass):
+                    raise TypeError(
+                        f"--model_list requires ModelList, got {type(models_obj).__name__}"
+                    )
                 job = Jobs(
                     survey=job.survey,
                     agents=job.agents,
-                    models=ModelListClass.from_dict(data),
+                    models=models_obj,
                     scenarios=job.scenarios,
                 )
             if model:
@@ -395,8 +415,11 @@ def register(app: click.Group) -> None:
             return _load_jobs_from_path(jobs_path)
 
         if input_mode == "survey":
-            data = read_json_file(survey_path)
-            sv = SurveyClass.from_dict(data)
+            sv = load_any_object(survey_path, expected_object_type="Survey")
+            if not isinstance(sv, SurveyClass):
+                raise TypeError(
+                    f"--survey requires Survey, got {type(sv).__name__}"
+                )
             return Jobs(survey=sv)
 
         if input_mode in ("json", "stdin"):
@@ -430,15 +453,12 @@ def register(app: click.Group) -> None:
 
 
     def _load_jobs_from_path(path: str):
-        path_obj = Path(path)
-        if path_obj.suffix == ".ep":
-            from edsl.jobs import Jobs
-
-            return Jobs.git.load(path_obj)
-        data = read_json_file(path)
         from edsl.jobs import Jobs
 
-        return Jobs.from_dict(data)
+        job = load_any_object(path, expected_object_type="Jobs")
+        if not isinstance(job, Jobs):
+            raise TypeError(f"Jobs input requires Jobs, got {type(job).__name__}")
+        return job
 
 
     def _build_job_from_json(data: dict):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3989,6 +3989,80 @@ class TestRunValidation:
         loaded = Results.git.load(results_path)
         assert len(loaded) == 1
 
+    @pytest.mark.parametrize("survey_format", ["ep", "json.gz"])
+    def test_run_accepts_durable_survey_formats(self, tmp_path, survey_format):
+        import gzip
+
+        from edsl.questions import QuestionFreeText
+        from edsl.results import Results
+        from edsl.surveys import Survey
+
+        survey = Survey(
+            [QuestionFreeText(question_name="name", question_text="Say your name.")]
+        )
+        survey_path = tmp_path / f"survey.{survey_format}"
+        if survey_format == "ep":
+            survey.git.save(survey_path)
+        else:
+            with gzip.open(survey_path, "wt", encoding="utf-8") as f:
+                json.dump(survey.to_dict(), f)
+
+        results_path = tmp_path / "results.ep"
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "run",
+                "--survey",
+                str(survey_path),
+                "--model",
+                "test",
+                "--local",
+                "--output",
+                str(results_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["status"] == "ok"
+        assert Results.git.load(results_path).select("answer.name").to_list() == [
+            "Hello, world X"
+        ]
+
+    def test_run_accepts_agent_list_package_override(self, tmp_path):
+        from edsl import Agent, AgentList
+        from edsl.questions import QuestionFreeText
+        from edsl.results import Results
+        from edsl.surveys import Survey
+
+        survey_path = tmp_path / "survey.ep"
+        agents_path = tmp_path / "agents.ep"
+        results_path = tmp_path / "results.ep"
+        Survey(
+            [QuestionFreeText(question_name="name", question_text="Say your name.")]
+        ).git.save(survey_path)
+        AgentList([Agent(traits={"cohort": "package"})]).git.save(agents_path)
+
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "run",
+                "--survey",
+                str(survey_path),
+                "--agent_list",
+                str(agents_path),
+                "--model",
+                "test",
+                "--local",
+                "--output",
+                str(results_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert Results.git.load(results_path).select("agent.cohort").to_list() == [
+            "package"
+        ]
+
     def test_canned_jobs_run_results_are_queryable_and_exportable(self, tmp_path):
         from edsl import Agent, AgentList, Jobs, Model, ModelList, Scenario, ScenarioList
         from edsl.questions import QuestionFreeText


### PR DESCRIPTION
## Summary
- route `ep run --survey` through the shared object loader
- support Survey `.ep`, `.json`, and `.json.gz` inputs consistently
- apply the same loader and type checks to Jobs and component override packages
- return clear type errors when a component path contains the wrong EDSL object

## Verification
- focused CLI tests: 4 passed
- covers Survey `.ep`, Survey `.json.gz`, AgentList `.ep`, and Jobs `.ep`
- local scripted test model only; no API or network calls

Follow-up to integration PR #2568.