### PR TITLE
Validate durable Surveys containing Instructions

### DIFF
--- a/edsl/cli_commands/validate.py
+++ b/edsl/cli_commands/validate.py
@@ -8,7 +8,14 @@ from typing import Optional
 
 import click
 
-from edsl.cli_shared import EXIT_USAGE, EXIT_VALIDATION, error, output, read_json_file
+from edsl.cli_shared import (
+    EXIT_USAGE,
+    EXIT_VALIDATION,
+    error,
+    load_any_object,
+    output,
+    read_serialized_object,
+)
 
 
 def register(app: click.Group) -> None:
@@ -23,8 +30,17 @@ def register(app: click.Group) -> None:
     def validate(file_path, json_data, force_type):
         """Validate a question, survey, or job spec without executing."""
         raw = None
+        loaded_type = None
         if file_path:
-            raw = read_json_file(file_path)
+            from pathlib import Path
+
+            path = Path(file_path)
+            if path.is_dir() or path.suffix == ".ep":
+                loaded = load_any_object(file_path)
+                loaded_type = loaded.__class__.__name__
+                raw = loaded.to_dict()
+            else:
+                raw = read_serialized_object(path)
         elif json_data:
             try:
                 raw = json.loads(json_data)
@@ -50,7 +66,16 @@ def register(app: click.Group) -> None:
         # Detect object type
         obj_type = force_type
         if not obj_type:
-            if "survey" in raw and isinstance(raw.get("survey"), dict):
+            class_name = loaded_type or raw.get("edsl_class_name")
+            serialized_types = {
+                "Survey": "survey",
+                "Jobs": "job",
+                "AgentList": "agent_list",
+                "ScenarioList": "scenario_list",
+            }
+            if class_name in serialized_types:
+                obj_type = serialized_types[class_name]
+            elif "survey" in raw and isinstance(raw.get("survey"), dict):
                 obj_type = "job"
             elif "questions" in raw and isinstance(raw.get("questions"), list):
                 obj_type = "job_lightweight"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1701,6 +1701,38 @@ class TestValidate:
             out = run_cli("validate", "--file", f.name)
             assert out["data"]["valid"] is True
 
+    @pytest.mark.parametrize("survey_format", ["json", "json.gz", "ep"])
+    def test_validate_survey_with_instruction(self, tmp_path, survey_format):
+        import gzip
+
+        from edsl.instructions import Instruction
+        from edsl.questions import QuestionFreeText
+        from edsl.surveys import Survey
+
+        survey = Survey(
+            [
+                Instruction(name="intro", text="Please answer carefully."),
+                QuestionFreeText(question_name="q0", question_text="Say hello."),
+            ]
+        )
+        survey_path = tmp_path / f"survey.{survey_format}"
+        if survey_format == "ep":
+            survey.git.save(survey_path)
+        elif survey_format == "json.gz":
+            with gzip.open(survey_path, "wt", encoding="utf-8") as f:
+                json.dump(survey.to_dict(), f)
+        else:
+            survey_path.write_text(json.dumps(survey.to_dict()), encoding="utf-8")
+
+        result = CliRunner().invoke(
+            cli_module.app, ["validate", "--file", str(survey_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["data"]["valid"] is True
+        assert out["data"]["object_type"] == "survey"
+
     def test_validate_from_stdin(self):
         q = json.dumps({"type": "free_text", "question_name": "q0", "question_text": "Hello?"})
         out = run_cli("validate", stdin_data=q)


### PR DESCRIPTION
## Summary
- validate `.ep` packages through the shared durable-object loader
- read `.json.gz` inputs with the existing serialized-object reader
- honor `edsl_class_name` before classifying a `questions` array as a lightweight job
- validate serialized Surveys containing `Instruction` items through `Survey.from_dict`

## Verification
- full CLI validation test class: 13 passed
- covers Survey JSON, `.json.gz`, and `.ep` with a leading Instruction
- verified against a 131-question adaptive Survey in both `.ep` and `.json.gz` formats
- no LLM or network calls

Follow-up to integration PR #2568.