### PR TITLE
Honor repair recursion for with-other choice validation

### DIFF
--- a/edsl/questions/question_multiple_choice_with_other.py
+++ b/edsl/questions/question_multiple_choice_with_other.py
@@ -113,7 +113,13 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
             question_options.append("Other")
         self.question_options = question_options
 
-    def validate(self, response_dict, verbose=False):
+    def validate(
+        self,
+        response_dict,
+        fix=False,
+        verbose=False,
+        replacement_dict=None,
+    ):
         """
         Validate the response according to the schema.
 
@@ -154,7 +160,12 @@ class MultipleChoiceWithOtherResponseValidator(MultipleChoiceResponseValidator):
 
         # Try to validate with the parent validator
         try:
-            validated_response = super().validate(response_dict, verbose)
+            validated_response = super().validate(
+                response_dict,
+                fix=fix,
+                verbose=verbose,
+                replacement_dict=replacement_dict,
+            )
             return validated_response
         except Exception as _:
             # If validation fails but the answer matches our pattern, accept it anyway

--- a/tests/questions/test_QuestionMultipleChoiceWithOther.py
+++ b/tests/questions/test_QuestionMultipleChoiceWithOther.py
@@ -114,6 +114,22 @@ def test_validator_regular_answer():
     assert validated["answer"] == "Blue"
 
 
+def test_validator_repairs_long_option_with_trailing_punctuation():
+    long_option = (
+        "Share complete data with the selected partner and limited data with "
+        "the other non-selected partners"
+    )
+    q = QuestionMultipleChoiceWithOther(
+        question_name="sharing_policy",
+        question_text="Choose a sharing policy.",
+        question_options=["Do not share data", long_option, "Not sure"],
+    )
+
+    validated = q.response_validator.validate({"answer": f"{long_option}."})
+
+    assert validated["answer"] == long_option
+
+
 def test_validator_invalid_answer():
     """Test that invalid answers (not in options) are rejected."""
     # Create the question

--- a/tests/runner/test_with_other_repair_contract.py
+++ b/tests/runner/test_with_other_repair_contract.py
@@ -1,0 +1,25 @@
+"""Local runner coverage for with-other validator repair recursion."""
+
+from edsl import Model, QuestionMultipleChoiceWithOther
+
+
+def test_long_option_with_trailing_punctuation_repairs_locally():
+    long_option = (
+        "Share complete data with the selected partner and limited data with "
+        "the other non-selected partners"
+    )
+    question = QuestionMultipleChoiceWithOther(
+        question_name="sharing_policy",
+        question_text="Choose a sharing policy.",
+        question_options=["Do not share data", long_option, "Not sure"],
+    )
+    model = Model("test", canned_response=f"{long_option}.")
+
+    results = question.by(model).run(
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+    )
+
+    assert results.select("answer.sharing_policy").to_list() == [long_option]
+


### PR DESCRIPTION
## Summary
- align `MultipleChoiceWithOtherResponseValidator.validate` with the base validator method contract
- forward `fix`, `verbose`, and `replacement_dict` explicitly
- allow the existing one-shot repair path to revalidate normalized listed options
- avoid changes to permissive mapping-valued answers

## Root cause
The base validator retries repaired data with `validate(..., fix=True)`. The override did not accept the `fix` keyword, so successful normalization was discarded and the original validation error was raised.

## Verification
- 11 focused tests passed
- includes a scripted local-runner regression for a long listed option with trailing punctuation and the word `other`
- no real LLM or network calls

Replaces the closed #2567 approach and follows integration PR #2568.