### PR TITLE
Default Git-backed objects to ep persistence

### DIFF
--- a/edsl/base/base_class.py
+++ b/edsl/base/base_class.py
@@ -15,6 +15,7 @@ JSON/YAML serialization, file persistence, pretty printing, and object compariso
 from abc import ABC, abstractmethod, ABCMeta
 import gzip
 import json
+import os
 from typing import Any, Optional, Union, TYPE_CHECKING, Callable
 from uuid import UUID
 import difflib
@@ -674,8 +675,45 @@ class PersistenceMixin:
         except Exception as e:
             print(f"Failed to copy to clipboard: {e}")
 
-    def save(self, filename: Optional[str] = None, compress: bool = True):
-        """Save the object to a file as JSON with optional compression.
+    def save(
+        self,
+        filename: Optional[str] = None,
+        compress: Optional[bool] = None,
+        **kwargs,
+    ):
+        """Save the object, choosing the format from the filename.
+
+        Objects with a Git-backed ``git`` accessor use the ``.ep`` package
+        format by default. An explicit ``.json`` or ``.json.gz`` filename, or
+        an explicit ``compress`` value, retains the legacy JSON behavior.
+        Other :class:`Base` subclasses continue to use JSON.
+
+        Use :meth:`save_json` when JSON persistence is required regardless of
+        the object type.
+        """
+        filename_text = os.fspath(filename) if filename is not None else None
+        has_git_accessor = hasattr(type(self), "git")
+        json_requested = compress is not None or (
+            filename_text is not None
+            and (filename_text.endswith(".json") or filename_text.endswith(".json.gz"))
+        )
+
+        if has_git_accessor and not json_requested:
+            return self.git.save(filename, **kwargs)
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"Unexpected keyword argument(s) for JSON save: {unexpected}"
+            )
+        json_compress = compress
+        if json_compress is None:
+            json_compress = not (
+                filename_text is not None and filename_text.endswith(".json")
+            )
+        return self.save_json(filename, compress=json_compress)
+
+    def save_json(self, filename: Optional[str] = None, compress: bool = True):
+        """Save the object to legacy JSON with optional compression.
 
         Serializes the object to JSON and writes it to the specified file.
         By default, the file will be compressed using gzip. File extensions
@@ -695,6 +733,7 @@ class PersistenceMixin:
 
         if filename is None:
             filename = f"{self.__class__.__name__}_{str(hash(self))}.json"
+        filename = os.fspath(filename)
 
         logger.debug(f"Saving {self.__class__.__name__} to file: {filename}")
 
@@ -755,7 +794,34 @@ class PersistenceMixin:
 
     @classmethod
     def load(cls, filename):
-        """Load the object from a JSON file (compressed or uncompressed).
+        """Load an object, choosing the format from the filename.
+
+        ``.ep`` packages are loaded through the class's Git accessor. For
+        Git-backed classes an extensionless path prefers an existing ``.ep``
+        package, then falls back to the legacy JSON filename lookup.
+        """
+        filename = os.fspath(filename)
+
+        from edsl.base.git_package import ARCHIVE_PACKAGE_SUFFIX
+
+        if hasattr(cls, "git"):
+            if filename.endswith(ARCHIVE_PACKAGE_SUFFIX):
+                return cls.git.load(filename)
+            if not filename.endswith((".json", ".json.gz")):
+                ep_path = filename + ARCHIVE_PACKAGE_SUFFIX
+                if os.path.exists(ep_path):
+                    return cls.git.load(ep_path)
+        elif filename.endswith(ARCHIVE_PACKAGE_SUFFIX):
+            raise ValueError(
+                f"{filename!r} is an EDSL git package but {cls.__name__} has no "
+                f"git accessor; it cannot be loaded with .load()."
+            )
+
+        return cls.load_json(filename)
+
+    @classmethod
+    def load_json(cls, filename):
+        """Load an object from legacy JSON (compressed or uncompressed).
 
         This method deserializes an object from a file, automatically detecting
         whether the file is compressed with gzip or not.
@@ -769,19 +835,8 @@ class PersistenceMixin:
         Raises:
             Various exceptions may be raised if the file doesn't exist or contains invalid data
         """
-        logger.debug(f"Loading {cls.__name__} from file: {filename}")
-
-        # Git-backed ".ep" archive packages are not flat JSON; delegate to the
-        # git accessor so ``Results.load('x.ep')`` works like ``Results.git.load``.
-        from edsl.base.git_package import ARCHIVE_PACKAGE_SUFFIX
-
-        if str(filename).endswith(ARCHIVE_PACKAGE_SUFFIX):
-            if hasattr(cls, "git"):
-                return cls.git.load(filename)
-            raise ValueError(
-                f"{filename!r} is an EDSL git package but {cls.__name__} has no "
-                f"git accessor; it cannot be loaded with .load()."
-            )
+        filename = os.fspath(filename)
+        logger.debug(f"Loading {cls.__name__} from JSON file: {filename}")
 
         try:
             if filename.endswith("json.gz"):

--- a/tests/base/test_base_persistence_formats.py
+++ b/tests/base/test_base_persistence_formats.py
@@ -1,0 +1,73 @@
+import pytest
+
+from edsl import AgentList, Jobs, ModelList, Results, ScenarioList, Survey
+from edsl.questions import QuestionFreeText
+
+
+GIT_BACKED_EXAMPLES = [
+    Survey.example,
+    AgentList.example,
+    ScenarioList.example,
+    ModelList.example,
+    Jobs.example,
+    Results.example,
+]
+
+
+@pytest.mark.parametrize("example", GIT_BACKED_EXAMPLES)
+def test_git_backed_save_and_load_use_ep_for_extensionless_path(tmp_path, example):
+    obj = example()
+    path = tmp_path / type(obj).__name__.lower()
+
+    info = obj.save(path)
+
+    package_path = path.with_suffix(".ep")
+    assert package_path.exists()
+    assert info["path"] == str(package_path)
+    assert type(obj).load(path) == obj
+
+
+@pytest.mark.parametrize("example", GIT_BACKED_EXAMPLES)
+def test_git_backed_objects_preserve_explicit_json_formats(tmp_path, example):
+    obj = example()
+    json_path = tmp_path / f"{type(obj).__name__.lower()}.json"
+    gzip_path = tmp_path / f"{type(obj).__name__.lower()}.json.gz"
+
+    obj.save(json_path)
+    obj.save(gzip_path)
+
+    assert json_path.exists()
+    assert gzip_path.exists()
+    assert type(obj).load(json_path) == obj
+    assert type(obj).load(gzip_path) == obj
+
+
+def test_save_json_and_load_json_are_explicit_legacy_api(tmp_path):
+    survey = Survey.example()
+    path = tmp_path / "survey.json"
+
+    survey.save_json(path, compress=False)
+
+    assert Survey.load_json(path) == survey
+
+
+def test_git_backed_save_without_filename_uses_default_ep_path(tmp_path, monkeypatch):
+    survey = Survey.example()
+    monkeypatch.chdir(tmp_path)
+
+    info = survey.save()
+
+    assert (tmp_path / "survey.ep").exists()
+    assert info["path"] == "survey.ep"
+    assert Survey.load("survey") == survey
+
+
+def test_non_git_backed_base_objects_keep_json_default(tmp_path):
+    question = QuestionFreeText.example()
+    path = tmp_path / "question"
+
+    question.save(path)
+
+    json_path = tmp_path / "question.json.gz"
+    assert json_path.exists()
+    assert QuestionFreeText.load(path) == question


### PR DESCRIPTION
## Summary

- add explicit `save_json()` and `load_json()` compatibility APIs to `Base` objects
- make `save()` choose `.ep` for Git-backed aggregate objects unless JSON is explicitly requested
- make extensionless `load()` prefer an existing `.ep` package before legacy JSON lookup
- preserve JSON defaults for Base subclasses without a Git accessor
- preserve explicit `.json`, `.json.gz`, and `compress=` behavior

Git-backed defaults apply to Survey, AgentList, ScenarioList, ModelList, Jobs, and Results.

## Tests

- `pytest -q tests/base/test_base_persistence_formats.py tests/base/test_Base.py` (61 passed)
- serialization and six existing Git-package suites (92 passed, 5 skipped)
- final persistence contract suite (15 passed)