### PR TITLE
Add matrix row randomization

### DIFF
--- a/edsl/invigilators/question_instructions_prompt_builder.py
+++ b/edsl/invigilators/question_instructions_prompt_builder.py
@@ -256,9 +256,9 @@ class QuestionInstructionPromptBuilder:
         Returns:
             Dict: Enriched prompt data
         """
-        if getattr(self.question, "_matrix_items_randomized", False):
-            prompt_data["data"]["question_items"] = self.question.question_items
-            prompt_data["data"]["randomize_items"] = False
+        item_seed = getattr(self.question, "_item_randomization_seed", None)
+        if item_seed is not None:
+            prompt_data["data"]["item_randomization_seed"] = item_seed
 
         prompt_data["data"] = (
             QuestionInstructionPromptBuilder._process_question_options(
@@ -266,15 +266,6 @@ class QuestionInstructionPromptBuilder:
             )
         )
 
-        # Preserve the exact matrix row order used to build the prompt. This makes
-        # it stable if prompts are requested again and exposes it in Results.
-        if (
-            getattr(self.question, "question_type", None) == "matrix"
-            and "question_items" in prompt_data["data"]
-        ):
-            self.question.question_items = prompt_data["data"]["question_items"]
-            if getattr(self.question, "randomize_items", False):
-                self.question._matrix_items_randomized = True
         return prompt_data
 
     def _render_prompt(self, prompt_data: Dict) -> "Prompt":

--- a/edsl/invigilators/question_instructions_prompt_builder.py
+++ b/edsl/invigilators/question_instructions_prompt_builder.py
@@ -243,9 +243,8 @@ class QuestionInstructionPromptBuilder:
 
         return question_data
 
-    @staticmethod
     def _enrich_with_question_options(
-        prompt_data: Dict, scenario: "Scenario", prior_answers_dict: Dict
+        self, prompt_data: Dict, scenario: "Scenario", prior_answers_dict: Dict
     ) -> Dict:
         """Enriches the prompt data with processed question options if they exist.
 
@@ -257,11 +256,25 @@ class QuestionInstructionPromptBuilder:
         Returns:
             Dict: Enriched prompt data
         """
+        if getattr(self.question, "_matrix_items_randomized", False):
+            prompt_data["data"]["question_items"] = self.question.question_items
+            prompt_data["data"]["randomize_items"] = False
+
         prompt_data["data"] = (
             QuestionInstructionPromptBuilder._process_question_options(
                 prompt_data["data"], scenario, prior_answers_dict
             )
         )
+
+        # Preserve the exact matrix row order used to build the prompt. This makes
+        # it stable if prompts are requested again and exposes it in Results.
+        if (
+            getattr(self.question, "question_type", None) == "matrix"
+            and "question_items" in prompt_data["data"]
+        ):
+            self.question.question_items = prompt_data["data"]["question_items"]
+            if getattr(self.question, "randomize_items", False):
+                self.question._matrix_items_randomized = True
         return prompt_data
 
     def _render_prompt(self, prompt_data: Dict) -> "Prompt":

--- a/edsl/invigilators/question_item_processor.py
+++ b/edsl/invigilators/question_item_processor.py
@@ -167,7 +167,9 @@ class QuestionItemProcessor(QuestionAttributeProcessor):
         pinned_values = question_data.get("items_to_pin") or []
         pinned = {i: value for i, value in enumerate(items) if value in pinned_values}
         movable = [value for value in items if value not in pinned_values]
-        shuffled = random.sample(movable, len(movable))
+        seed = question_data.get("item_randomization_seed")
+        rng = random.Random(seed) if seed is not None else random
+        shuffled = rng.sample(movable, len(movable))
         result = [None] * len(items)
         for index, value in pinned.items():
             result[index] = value

--- a/edsl/invigilators/question_item_processor.py
+++ b/edsl/invigilators/question_item_processor.py
@@ -1,3 +1,4 @@
+import random
 from typing import Union, TYPE_CHECKING
 
 from .question_attribute_processor import QuestionAttributeProcessor
@@ -116,6 +117,21 @@ class QuestionItemProcessor(QuestionAttributeProcessor):
         >>> question_data = {"question_items": {"from": "{{ q0.answer }}", "add": ["Item 3", "Item 4"]}}
         >>> processor.get_question_items(question_data)
         ['Item 1', 'Item 2', 'Item 3', 'Item 4']
+
+        Randomization is applied only after a template resolves to a list:
+
+        >>> import random
+        >>> random.seed(1)
+        >>> question_data = {"question_items": "{{ q0.answer }}", "randomize_items": True}
+        >>> sorted(processor.get_question_items(question_data))
+        ['Item 1', 'Item 2']
+
+        Pinned rows retain their original positions:
+
+        >>> random.seed(1)
+        >>> question_data = {"question_items": ["A", "B", "Other"], "randomize_items": True, "items_to_pin": ["Other"]}
+        >>> processor.get_question_items(question_data)[-1]
+        'Other'
         """
         items_entry = question_data.get("question_items")
 
@@ -127,16 +143,39 @@ class QuestionItemProcessor(QuestionAttributeProcessor):
             base_items = self._get_items_from_template(from_template)
 
             if base_items and base_items != self._get_default_items():
-                return base_items + additional_items
+                items = base_items + additional_items
+                return self._maybe_randomize(items, question_data)
 
-            return additional_items if additional_items else self._get_default_items()
+            items = additional_items if additional_items else self._get_default_items()
+            return self._maybe_randomize(items, question_data)
 
         # If not a template string or dict, return as is or default
         if not isinstance(items_entry, str):
-            return items_entry if items_entry else self._get_default_items()
+            items = items_entry if items_entry else self._get_default_items()
+            return self._maybe_randomize(items, question_data)
 
         # Handle simple template string
-        return self._get_items_from_template(items_entry)
+        items = self._get_items_from_template(items_entry)
+        return self._maybe_randomize(items, question_data)
+
+    @staticmethod
+    def _maybe_randomize(items: list, question_data: dict) -> list:
+        """Shuffle resolved matrix rows while leaving requested positions pinned."""
+        if not question_data.get("randomize_items") or len(items) < 2:
+            return items
+
+        pinned_values = question_data.get("items_to_pin") or []
+        pinned = {i: value for i, value in enumerate(items) if value in pinned_values}
+        movable = [value for value in items if value not in pinned_values]
+        shuffled = random.sample(movable, len(movable))
+        result = [None] * len(items)
+        for index, value in pinned.items():
+            result[index] = value
+        movable_iter = iter(shuffled)
+        for index, value in enumerate(result):
+            if value is None:
+                result[index] = next(movable_iter)
+        return result
 
     def _get_items_from_template(self, template_string: str) -> list:
         """

--- a/edsl/questions/question_base.py
+++ b/edsl/questions/question_base.py
@@ -467,7 +467,7 @@ class QuestionBase(
             "_system_prompt",  # serialized via _thinking_system_prompt
             "_is_thinking_question",  # serialized via from_dict detection
             "_probabilistic_seed_context",  # runtime-only resolution identity
-            "_matrix_items_randomized",  # runtime-only row randomization marker
+            "_item_randomization_seed",  # runtime-only row randomization seed
         ]
         only_if_not_na_list = [
             "_answering_instructions",

--- a/edsl/questions/question_base.py
+++ b/edsl/questions/question_base.py
@@ -467,6 +467,7 @@ class QuestionBase(
             "_system_prompt",  # serialized via _thinking_system_prompt
             "_is_thinking_question",  # serialized via from_dict detection
             "_probabilistic_seed_context",  # runtime-only resolution identity
+            "_matrix_items_randomized",  # runtime-only row randomization marker
         ]
         only_if_not_na_list = [
             "_answering_instructions",

--- a/edsl/questions/question_base_gen_mixin.py
+++ b/edsl/questions/question_base_gen_mixin.py
@@ -463,6 +463,17 @@ class QuestionBaseGenMixin:
             except Exception:
                 pass
 
+        original_question_items = self.data.get("question_items")
+        if isinstance(original_question_items, str):
+            try:
+                native_question_items = render_native(original_question_items)
+                if isinstance(native_question_items, tuple):
+                    native_question_items = list(native_question_items)
+                if isinstance(native_question_items, list):
+                    rendered_dict["question_items"] = native_question_items
+            except Exception:
+                pass
+
         if return_dict:
             return rendered_dict
         else:

--- a/edsl/questions/question_matrix.py
+++ b/edsl/questions/question_matrix.py
@@ -797,6 +797,8 @@ class QuestionMatrix(QuestionBase):
         answering_instructions: Optional[str] = None,
         question_presentation: Optional[str] = None,
         permissive: bool = False,
+        randomize_items: bool = False,
+        items_to_pin: Optional[List[str]] = None,
     ):
         """
         Initialize a matrix question.
@@ -811,6 +813,8 @@ class QuestionMatrix(QuestionBase):
             answering_instructions: Custom instructions template
             question_presentation: Custom presentation template
             permissive: Whether to allow any values & extra items instead of strictly checking
+            randomize_items: Whether to randomize the matrix rows for each interview
+            items_to_pin: Row values that should remain in their declared positions
         """
         self.question_name = question_name
 
@@ -829,6 +833,20 @@ class QuestionMatrix(QuestionBase):
         self.answering_instructions = answering_instructions
         self.question_presentation = question_presentation
         self.permissive = permissive
+        if randomize_items:
+            self._randomize_items = True
+        if items_to_pin:
+            self._items_to_pin = items_to_pin
+
+    @property
+    def randomize_items(self) -> bool:
+        """Whether matrix rows should be randomized after they are resolved."""
+        return getattr(self, "_randomize_items", False)
+
+    @property
+    def items_to_pin(self) -> List[str]:
+        """Rows that retain their declared positions during randomization."""
+        return getattr(self, "_items_to_pin", [])
 
     def create_response_model(self) -> Type[BaseModel]:
         """

--- a/edsl/results/result.py
+++ b/edsl/results/result.py
@@ -644,7 +644,7 @@ class Result(Base, UserDict):
             data_type: The category of data to retrieve from. Valid options include:
                 "agent", "scenario", "model", "answer", "prompt", "comment",
                 "generated_tokens", "raw_model_response", "question_text",
-                "question_options", "question_type", "cache_used", "cache_keys".
+                "question_options", "question_items", "question_type", "cache_used", "cache_keys".
             key: The specific attribute name within that data type.
 
         Returns:
@@ -755,9 +755,11 @@ class Result(Base, UserDict):
         """Return display sections as (title, Dataset) pairs."""
         from edsl.dataset import Dataset
 
-        model_name = getattr(
-            self.model, "model", getattr(self.model, "_model_", "unknown")
-        ) if self.model else "none"
+        model_name = (
+            getattr(self.model, "model", getattr(self.model, "_model_", "unknown"))
+            if self.model
+            else "none"
+        )
         service = getattr(self.model, "_inference_service_", "") if self.model else ""
 
         fields = []
@@ -791,9 +793,11 @@ class Result(Base, UserDict):
         """Generate a summary representation of the Result as a Rich table."""
         from ..utilities.summary_table import ColumnDef, render_summary_table
 
-        model_name = getattr(
-            self.model, "model", getattr(self.model, "_model_", "unknown")
-        ) if self.model else "none"
+        model_name = (
+            getattr(self.model, "model", getattr(self.model, "_model_", "unknown"))
+            if self.model
+            else "none"
+        )
         service = getattr(self.model, "_inference_service_", "") if self.model else ""
 
         answers = self.answer or {}

--- a/edsl/results/result_builder.py
+++ b/edsl/results/result_builder.py
@@ -16,11 +16,17 @@ class QuestionFields:
 
     TEXT = "question_text"
     OPTIONS = "question_options"
+    ITEMS = "question_items"
     TYPE = "question_type"
 
 
 # List of all question fields for iteration
-QUESTION_FIELDS = [QuestionFields.TEXT, QuestionFields.OPTIONS, QuestionFields.TYPE]
+QUESTION_FIELDS = [
+    QuestionFields.TEXT,
+    QuestionFields.OPTIONS,
+    QuestionFields.ITEMS,
+    QuestionFields.TYPE,
+]
 
 
 class AgentNamer:
@@ -178,9 +184,11 @@ class ResultBuilder:
             if question_name in self.data["question_to_attributes"]:
                 for field_name in question_attribute_maps:
                     new_key = f"{question_name}_{field_name}"
-                    question_attribute_maps[field_name][new_key] = self.data[
-                        "question_to_attributes"
-                    ][question_name][field_name]
+                    attributes = self.data["question_to_attributes"][question_name]
+                    if field_name in attributes:
+                        question_attribute_maps[field_name][new_key] = attributes[
+                            field_name
+                        ]
         return question_attribute_maps
 
     def _build_cache_components(self) -> dict:

--- a/edsl/results/result_from_interview.py
+++ b/edsl/results/result_from_interview.py
@@ -186,7 +186,8 @@ class ResultFromInterview:
         return {
             question_name: value
             for question_name in answer_key_names
-            if (value := getattr(question_results[question_name], field, None)) is not None
+            if (value := getattr(question_results[question_name], field, None))
+            is not None
         }
 
     def _get_cache_keys(self, model_response_objects) -> Dict[str, bool]:
@@ -283,12 +284,12 @@ class ResultFromInterview:
         """Create dictionary of prompts for each question."""
         prompt_dictionary = {}
         for answer_key_name in answer_key_names:
-            prompt_dictionary[
-                answer_key_name + "_user_prompt"
-            ] = question_name_to_prompts[answer_key_name]["user_prompt"]
-            prompt_dictionary[
-                answer_key_name + "_system_prompt"
-            ] = question_name_to_prompts[answer_key_name]["system_prompt"]
+            prompt_dictionary[answer_key_name + "_user_prompt"] = (
+                question_name_to_prompts[answer_key_name]["user_prompt"]
+            )
+            prompt_dictionary[answer_key_name + "_system_prompt"] = (
+                question_name_to_prompts[answer_key_name]["system_prompt"]
+            )
         return prompt_dictionary
 
     def _get_raw_model_results_and_cache_used_dictionary(self, model_response_objects):
@@ -297,15 +298,15 @@ class ResultFromInterview:
         cache_used_dictionary = {}
         for result in model_response_objects:
             question_name = result.question_name
-            raw_model_results_dictionary[
-                question_name + "_raw_model_response"
-            ] = result.raw_model_response
-            raw_model_results_dictionary[
-                question_name + "_input_tokens"
-            ] = result.input_tokens
-            raw_model_results_dictionary[
-                question_name + "_output_tokens"
-            ] = result.output_tokens
+            raw_model_results_dictionary[question_name + "_raw_model_response"] = (
+                result.raw_model_response
+            )
+            raw_model_results_dictionary[question_name + "_input_tokens"] = (
+                result.input_tokens
+            )
+            raw_model_results_dictionary[question_name + "_output_tokens"] = (
+                result.output_tokens
+            )
             raw_model_results_dictionary[question_name + "_thinking_tokens"] = getattr(
                 result, "thinking_tokens", None
             )
@@ -356,6 +357,11 @@ class ResultFromInterview:
                 "question_type": q.question_type,
                 "question_options": (
                     None if not hasattr(q, "question_options") else q.question_options
+                ),
+                **(
+                    {"question_items": q.question_items}
+                    if hasattr(q, "question_items")
+                    else {}
                 ),
             }
             for q in survey.questions

--- a/edsl/results/result_transformer.py
+++ b/edsl/results/result_transformer.py
@@ -168,7 +168,12 @@ class ValidatedDict(ResultComponentPrependedKeys):
 
 class ResultComponentNested(ResultComponentDict):
     name = "question_to_attributes"
-    special_keys = ["question_text", "question_options", "question_type"]
+    special_keys = [
+        "question_text",
+        "question_options",
+        "question_items",
+        "question_type",
+    ]
 
     def generate_by_question_dict(self):
         d = defaultdict(dict)

--- a/edsl/results/results.py
+++ b/edsl/results/results.py
@@ -147,6 +147,7 @@ class Results(MutableSequence, ResultsOperationsMixin, Base):
         "iteration",
         "question_text",
         "question_options",
+        "question_items",
         "question_type",
         "comment",
         "generated_tokens",
@@ -214,6 +215,7 @@ class Results(MutableSequence, ResultsOperationsMixin, Base):
 
         from ..caching import Cache
         from ..tasks import TaskHistory
+
         self.survey = survey
         self.created_columns = created_columns or []
         self._job_uuid = job_uuid
@@ -479,9 +481,7 @@ class Results(MutableSequence, ResultsOperationsMixin, Base):
         # Models
         model_names = []
         for m in set(self.models):
-            model_names.append(
-                getattr(m, "model", getattr(m, "_model_", "unknown"))
-            )
+            model_names.append(getattr(m, "model", getattr(m, "_model_", "unknown")))
         components.append("Models")
         counts.append(str(num_models))
         details.append(", ".join(sorted(set(model_names))))
@@ -1285,6 +1285,7 @@ class Results(MutableSequence, ResultsOperationsMixin, Base):
             >>> r.insert_sorted(new_result)
         """
         return self._container.insert_sorted(item)
+
 
 def main():  # pragma: no cover
     """Run example operations on a Results object.

--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -25,6 +25,7 @@ class DirectAnswerEntry:
     scenario: Any  # EDSL Scenario object
     job_id: str | None = None
     interview_id: str | None = None
+    item_randomization_seed: int | None = None
 
 
 class DirectAnswerRegistry:
@@ -135,8 +136,9 @@ class DirectAnswerRegistry:
         that returns either the answer directly or a dict with "answer" and
         optional "comment" keys.
         """
+        question = self._question_for_interview(entry)
         result = await self._maybe_await(
-            entry.agent.answer_question_directly(entry.question, entry.scenario)
+            entry.agent.answer_question_directly(question, entry.scenario)
         )
         # Handle dicts with answer and comment keys - this is used for humanize
         # to turn responses into results
@@ -155,6 +157,25 @@ class DirectAnswerRegistry:
             "input_tokens": 0,
             "output_tokens": 0,
         }
+
+    def _question_for_interview(self, entry: DirectAnswerEntry):
+        """Return an isolated question with this interview's resolved row order."""
+        if not self._job_service or not entry.job_id or not entry.interview_id:
+            return entry.question
+        question = entry.question.duplicate()
+        current_answers = self._job_service._gather_current_answers(
+            entry.job_id, entry.interview_id
+        )
+        question_data = question.to_dict(add_edsl_version=False)
+        items = self._job_service._resolve_question_items(
+            question_data,
+            current_answers,
+            entry.scenario,
+            entry.item_randomization_seed,
+        )
+        if isinstance(items, list) and hasattr(question, "question_items"):
+            question.question_items = items
+        return question
 
     async def _execute_functional(self, entry: DirectAnswerEntry) -> dict:
         """

--- a/edsl/runner/models.py
+++ b/edsl/runner/models.py
@@ -271,8 +271,7 @@ class InterviewDefinition:
     # Randomized question options per question (question_name -> permuted options list)
     # Only populated for questions in survey.questions_to_randomize
     question_option_permutations: dict[str, list] = field(default_factory=dict)
-    # Exact randomized matrix row order served in this interview.
-    question_item_permutations: dict[str, list] = field(default_factory=dict)
+    question_item_randomization_seeds: dict[str, int] = field(default_factory=dict)
 
     def storage_key(self) -> str:
         return f"job:{self.job_id}:interview:{self.interview_id}"
@@ -286,7 +285,7 @@ class InterviewDefinition:
             "task_ids": self.task_ids,
             "iteration": self.iteration,
             "question_option_permutations": self.question_option_permutations,
-            "question_item_permutations": self.question_item_permutations,
+            "question_item_randomization_seeds": self.question_item_randomization_seeds,
         }
 
     @classmethod
@@ -303,7 +302,9 @@ class InterviewDefinition:
             task_ids=data["task_ids"],
             iteration=data.get("iteration", 0),
             question_option_permutations=data.get("question_option_permutations", {}),
-            question_item_permutations=data.get("question_item_permutations", {}),
+            question_item_randomization_seeds=data.get(
+                "question_item_randomization_seeds", {}
+            ),
         )
 
 

--- a/edsl/runner/models.py
+++ b/edsl/runner/models.py
@@ -271,6 +271,8 @@ class InterviewDefinition:
     # Randomized question options per question (question_name -> permuted options list)
     # Only populated for questions in survey.questions_to_randomize
     question_option_permutations: dict[str, list] = field(default_factory=dict)
+    # Exact randomized matrix row order served in this interview.
+    question_item_permutations: dict[str, list] = field(default_factory=dict)
 
     def storage_key(self) -> str:
         return f"job:{self.job_id}:interview:{self.interview_id}"
@@ -284,6 +286,7 @@ class InterviewDefinition:
             "task_ids": self.task_ids,
             "iteration": self.iteration,
             "question_option_permutations": self.question_option_permutations,
+            "question_item_permutations": self.question_item_permutations,
         }
 
     @classmethod
@@ -300,6 +303,7 @@ class InterviewDefinition:
             task_ids=data["task_ids"],
             iteration=data.get("iteration", 0),
             question_option_permutations=data.get("question_option_permutations", {}),
+            question_item_permutations=data.get("question_item_permutations", {}),
         )
 
 

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -194,21 +194,6 @@ class RenderService:
         modified["question_options"] = permutations[question_name]
         return modified
 
-    def _apply_item_permutation(
-        self, question_data: dict, question_name: str, permutations: dict[str, list]
-    ) -> dict:
-        """Apply a stored matrix-row permutation to question data."""
-        if (
-            not permutations
-            or question_name not in permutations
-            or question_data is None
-        ):
-            return question_data
-        modified = question_data.copy()
-        modified["question_items"] = permutations[question_name]
-        modified["randomize_items"] = False
-        return modified
-
     def render_task(
         self, job_id: str, interview_id: str, task_id: str
     ) -> RenderedPrompt:
@@ -230,14 +215,11 @@ class RenderService:
             task_def.question_name,
             interview_def.question_option_permutations,
         )
-        question_data = self._apply_item_permutation(
-            question_data,
-            task_def.question_name,
-            interview_def.question_item_permutations,
-        )
-
         # Get current answers for memory/piping
         current_answers = self._get_current_answers(job_id, interview_id, task_def)
+        item_randomization_seed = interview_def.question_item_randomization_seeds.get(
+            task_def.question_name
+        )
 
         # Render using EDSL
         prompts = self._render_with_edsl(
@@ -246,6 +228,7 @@ class RenderService:
             model_data=model_data,
             question_data=question_data,
             current_answers=current_answers,
+            item_randomization_seed=item_randomization_seed,
         )
 
         # Compute cache key and estimate tokens
@@ -320,6 +303,7 @@ class RenderService:
         model_data: dict,
         question_data: dict,
         current_answers: dict[str, Any],
+        item_randomization_seed: int | None = None,
     ) -> dict[str, str]:
         """Use EDSL's PromptConstructor to render the prompts."""
         import time as _t
@@ -361,6 +345,7 @@ class RenderService:
 
         _t0 = _t.time()
         question = QuestionBase.from_dict(question_data)
+        question._item_randomization_seed = item_randomization_seed
         self._profile_times["question_from_dict"] = self._profile_times.get(
             "question_from_dict", 0
         ) + (_t.time() - _t0)
@@ -1064,16 +1049,18 @@ class RenderWorker:
                 if interview_def
                 else None
             )
-            item_perms = (
-                interview_def.question_item_permutations.get(task_def.question_name)
+            item_seed = (
+                interview_def.question_item_randomization_seeds.get(
+                    task_def.question_name
+                )
                 if interview_def
                 else None
             )
-            if option_perms or item_perms:
+            if option_perms or item_seed is not None:
                 _perm_key = (
                     task_def.question_id,
                     tuple(str(o) for o in option_perms or []),
-                    tuple(str(item) for item in item_perms or []),
+                    item_seed,
                 )
                 if _perm_key not in _permuted_questions:
                     q_data = questions.get(task_def.question_id)
@@ -1082,13 +1069,15 @@ class RenderWorker:
                         task_def.question_name,
                         interview_def.question_option_permutations,
                     )
-                    q_data = self._render_service._apply_item_permutation(
-                        q_data,
-                        task_def.question_name,
-                        interview_def.question_item_permutations,
-                    )
                     _permuted_questions[_perm_key] = QuestionBase.from_dict(q_data)
                 question = _permuted_questions[_perm_key]
+
+            if interview_def:
+                question._item_randomization_seed = (
+                    interview_def.question_item_randomization_seeds.get(
+                        task_def.question_name
+                    )
+                )
 
             # Get current answers from cache
             current_answers = answers_cache.get(interview_id, {})

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -194,6 +194,21 @@ class RenderService:
         modified["question_options"] = permutations[question_name]
         return modified
 
+    def _apply_item_permutation(
+        self, question_data: dict, question_name: str, permutations: dict[str, list]
+    ) -> dict:
+        """Apply a stored matrix-row permutation to question data."""
+        if (
+            not permutations
+            or question_name not in permutations
+            or question_data is None
+        ):
+            return question_data
+        modified = question_data.copy()
+        modified["question_items"] = permutations[question_name]
+        modified["randomize_items"] = False
+        return modified
+
     def render_task(
         self, job_id: str, interview_id: str, task_id: str
     ) -> RenderedPrompt:
@@ -214,6 +229,11 @@ class RenderService:
             question_data,
             task_def.question_name,
             interview_def.question_option_permutations,
+        )
+        question_data = self._apply_item_permutation(
+            question_data,
+            task_def.question_name,
+            interview_def.question_item_permutations,
         )
 
         # Get current answers for memory/piping
@@ -283,9 +303,9 @@ class RenderService:
                     current_answers[other_task.question_name] = answer.answer
                     # Include comment for piping ({{ qname.comment }})
                     if answer.comment:
-                        current_answers[
-                            f"{other_task.question_name}_comment"
-                        ] = answer.comment
+                        current_answers[f"{other_task.question_name}_comment"] = (
+                            answer.comment
+                        )
 
         return current_answers
 
@@ -898,14 +918,14 @@ class RenderWorker:
         # Instead of checking ALL interview tasks, only fetch answers for actual dependencies
         # This reduces O(n) to O(d) where d = number of dependencies (usually small)
         _t0 = _time.time()
-        answers_cache: dict[
-            str, dict[str, Any]
-        ] = {}  # interview_id -> {question_name -> answer}
+        answers_cache: dict[str, dict[str, Any]] = (
+            {}
+        )  # interview_id -> {question_name -> answer}
 
         # Collect all dependency task IDs from tasks being rendered
-        dep_task_ids_by_interview: dict[
-            str, set[str]
-        ] = {}  # interview_id -> set of dependency task_ids
+        dep_task_ids_by_interview: dict[str, set[str]] = (
+            {}
+        )  # interview_id -> set of dependency task_ids
         for task_id in tasks_to_render:
             task_def = all_task_defs.get(task_id)
             if task_def and task_def.depends_on:
@@ -1009,9 +1029,9 @@ class RenderWorker:
         # Caches for objects that depend on per-task context
         _permuted_questions: dict[tuple, "QuestionBase"] = {}
         _survey_cache: dict[tuple, tuple] = {}
-        _prompt_cache: dict[
-            tuple, dict
-        ] = {}  # Cache rendered prompts by input combination
+        _prompt_cache: dict[tuple, dict] = (
+            {}
+        )  # Cache rendered prompts by input combination
 
         from ..questions import QuestionFreeText as _QuestionFreeText
 
@@ -1039,21 +1059,33 @@ class RenderWorker:
 
             # Track permutation key for prompt caching
             _perm_key = None
-            if (
-                interview_def
-                and interview_def.question_option_permutations
-                and task_def.question_name in interview_def.question_option_permutations
-            ):
-                perms = interview_def.question_option_permutations[
-                    task_def.question_name
-                ]
-                _perm_key = (task_def.question_id, tuple(str(o) for o in perms))
+            option_perms = (
+                interview_def.question_option_permutations.get(task_def.question_name)
+                if interview_def
+                else None
+            )
+            item_perms = (
+                interview_def.question_item_permutations.get(task_def.question_name)
+                if interview_def
+                else None
+            )
+            if option_perms or item_perms:
+                _perm_key = (
+                    task_def.question_id,
+                    tuple(str(o) for o in option_perms or []),
+                    tuple(str(item) for item in item_perms or []),
+                )
                 if _perm_key not in _permuted_questions:
                     q_data = questions.get(task_def.question_id)
                     q_data = self._render_service._apply_option_permutation(
                         q_data,
                         task_def.question_name,
                         interview_def.question_option_permutations,
+                    )
+                    q_data = self._render_service._apply_item_permutation(
+                        q_data,
+                        task_def.question_name,
+                        interview_def.question_item_permutations,
                     )
                     _permuted_questions[_perm_key] = QuestionBase.from_dict(q_data)
                 question = _permuted_questions[_perm_key]

--- a/edsl/runner/runner.py
+++ b/edsl/runner/runner.py
@@ -473,6 +473,7 @@ class Runner:
                 scenario=info["scenario"],
                 job_id=job_id,
                 interview_id=info.get("interview_id"),
+                item_randomization_seed=info.get("item_randomization_seed"),
             )
             self._direct_registry.register(info["task_id"], entry)
 

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -72,15 +72,15 @@ class JobService:
         self._tasks = TaskStore(storage)
         self._answers = AnswerStore(storage)
         self._job_stop_on_exception: dict[str, bool] = {}  # job_id -> stop_on_exception
-        self._original_models: dict[
-            str, dict[str, Any]
-        ] = {}  # job_id -> {model_id -> model_obj}
-        self._original_key_lookups: dict[
-            str, Any
-        ] = {}  # job_id -> run_config.environment.key_lookup
-        self._interview_callbacks: dict[
-            str, Any
-        ] = {}  # job_id -> callable(job_id, interview_id)
+        self._original_models: dict[str, dict[str, Any]] = (
+            {}
+        )  # job_id -> {model_id -> model_obj}
+        self._original_key_lookups: dict[str, Any] = (
+            {}
+        )  # job_id -> run_config.environment.key_lookup
+        self._interview_callbacks: dict[str, Any] = (
+            {}
+        )  # job_id -> callable(job_id, interview_id)
 
     @property
     def jobs(self) -> JobStore:
@@ -208,9 +208,9 @@ class JobService:
         # Register those models in the model store and build a mapping
         # from question_name -> model_id so tasks use the question's model.
         question_model_overrides: dict[str, str] = {}  # q_name -> model_id
-        extra_models: dict[
-            str, Any
-        ] = {}  # model_id -> model obj (NOT in cross-product)
+        extra_models: dict[str, Any] = (
+            {}
+        )  # model_id -> model obj (NOT in cross-product)
         extra_models_batch: dict[str, dict] = {}
         for q in questions:
             if hasattr(q, "_model"):
@@ -326,6 +326,7 @@ class JobService:
                 question_option_permutations = self._generate_question_permutations(
                     questions, questions_to_randomize
                 )
+                question_item_permutations = self._generate_item_permutations(questions)
 
                 # Create tasks for this interview
                 # Pass agent and scenario objects for direct answer detection
@@ -373,6 +374,7 @@ class JobService:
                     task_ids=task_ids,
                     iteration=iteration,
                     question_option_permutations=question_option_permutations,
+                    question_item_permutations=question_item_permutations,
                 )
                 interview_definitions.append(interview_def)
 
@@ -1878,13 +1880,13 @@ class JobService:
         # Build raw_model_response dict (matches EDSL's raw_model_results_dictionary)
         raw_model_response_dict = {}
         for a in answers:
-            raw_model_response_dict[
-                f"{a.question_name}_raw_model_response"
-            ] = a.raw_model_response
+            raw_model_response_dict[f"{a.question_name}_raw_model_response"] = (
+                a.raw_model_response
+            )
             raw_model_response_dict[f"{a.question_name}_input_tokens"] = a.input_tokens
-            raw_model_response_dict[
-                f"{a.question_name}_output_tokens"
-            ] = a.output_tokens
+            raw_model_response_dict[f"{a.question_name}_output_tokens"] = (
+                a.output_tokens
+            )
             raw_model_response_dict[f"{a.question_name}_thinking_tokens"] = getattr(
                 a, "thinking_tokens", None
             )
@@ -1913,9 +1915,9 @@ class JobService:
         # Build generated_tokens dict (matches EDSL's generated_tokens_dict)
         generated_tokens_dict = {}
         for a in answers:
-            generated_tokens_dict[
-                f"{a.question_name}_generated_tokens"
-            ] = a.generated_tokens
+            generated_tokens_dict[f"{a.question_name}_generated_tokens"] = (
+                a.generated_tokens
+            )
 
         # Build comments dict (matches EDSL's comments_dict)
         comments_dict = {}
@@ -1925,9 +1927,9 @@ class JobService:
         # Build reasoning_summaries dict (matches EDSL's reasoning_summaries_dict)
         reasoning_summaries_dict = {}
         for a in answers:
-            reasoning_summaries_dict[
-                f"{a.question_name}_reasoning_summary"
-            ] = a.reasoning_summary
+            reasoning_summaries_dict[f"{a.question_name}_reasoning_summary"] = (
+                a.reasoning_summary
+            )
 
         # Build cache_used dict (matches EDSL's cache_used_dictionary)
         cache_used_dict = {a.question_name: a.cached for a in answers}
@@ -2002,6 +2004,11 @@ class JobService:
             if interview_def and hasattr(interview_def, "question_option_permutations")
             else {}
         )
+        item_permutations = (
+            interview_def.question_item_permutations
+            if interview_def and hasattr(interview_def, "question_item_permutations")
+            else {}
+        )
         if job_def and job_def.question_ids and questions_data:
             for q_id in job_def.question_ids:
                 q_data = questions_data.get(q_id)
@@ -2019,6 +2026,15 @@ class JobService:
                         "question_text": q_data.get("question_text", ""),
                         "question_type": q_data.get("question_type", ""),
                         "question_options": q_options,
+                        **(
+                            {
+                                "question_items": item_permutations.get(
+                                    q_name, q_data.get("question_items")
+                                )
+                            }
+                            if "question_items" in q_data
+                            else {}
+                        ),
                     }
         if _timing is not None:
             _timing["build_question_attrs"] = (
@@ -2061,15 +2077,21 @@ class JobService:
         from edsl.utilities.utilities import dict_hash
 
         hash_data = {
-            "agent": agent.to_dict(add_edsl_version=False)
-            if hasattr(agent, "to_dict")
-            else {},
-            "scenario": scenario.to_dict(add_edsl_version=False)
-            if hasattr(scenario, "to_dict")
-            else {},
-            "model": model.to_dict(add_edsl_version=False)
-            if model and hasattr(model, "to_dict")
-            else {},
+            "agent": (
+                agent.to_dict(add_edsl_version=False)
+                if hasattr(agent, "to_dict")
+                else {}
+            ),
+            "scenario": (
+                scenario.to_dict(add_edsl_version=False)
+                if hasattr(scenario, "to_dict")
+                else {}
+            ),
+            "model": (
+                model.to_dict(add_edsl_version=False)
+                if model and hasattr(model, "to_dict")
+                else {}
+            ),
             "iteration": iteration,
         }
         result.interview_hash = dict_hash(hash_data)
@@ -2490,6 +2512,34 @@ class JobService:
                 permutations[q_name] = random.sample(options, len(options))
 
         return permutations
+
+    def _generate_item_permutations(self, questions: list) -> dict[str, list]:
+        """Generate and retain per-interview permutations for static matrix rows."""
+        import random
+
+        permutations = {}
+        for question in questions:
+            data = self._to_dict(question)
+            items = data.get("question_items")
+            if not data.get("randomize_items") or not isinstance(items, list):
+                continue
+            permutations[data["question_name"]] = self._shuffle_pinned(
+                items, data.get("items_to_pin") or [], random
+            )
+        return permutations
+
+    @staticmethod
+    def _shuffle_pinned(items: list, pinned_values: list, rng) -> list:
+        pinned = {i: value for i, value in enumerate(items) if value in pinned_values}
+        movable = rng.sample(
+            [value for value in items if value not in pinned_values],
+            len(items) - len(pinned),
+        )
+        result = [None] * len(items)
+        for index, value in pinned.items():
+            result[index] = value
+        movable_iter = iter(movable)
+        return [next(movable_iter) if value is None else value for value in result]
 
     # =========================================================================
     # FileStore Blob Handling

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 from typing import Any, TYPE_CHECKING
 import itertools
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -326,7 +327,11 @@ class JobService:
                 question_option_permutations = self._generate_question_permutations(
                     questions, questions_to_randomize
                 )
-                question_item_permutations = self._generate_item_permutations(questions)
+                question_item_randomization_seeds = {
+                    self._get_question_name(question): random.getrandbits(64)
+                    for question in questions
+                    if self._to_dict(question).get("randomize_items")
+                }
 
                 # Create tasks for this interview
                 # Pass agent and scenario objects for direct answer detection
@@ -360,6 +365,11 @@ class JobService:
                             "agent": agent_obj,
                             "scenario": scenario_obj,
                             "question": questions[info["question_index"]],
+                            "item_randomization_seed": question_item_randomization_seeds.get(
+                                self._get_question_name(
+                                    questions[info["question_index"]]
+                                )
+                            ),
                         }
                     )
 
@@ -374,7 +384,7 @@ class JobService:
                     task_ids=task_ids,
                     iteration=iteration,
                     question_option_permutations=question_option_permutations,
-                    question_item_permutations=question_item_permutations,
+                    question_item_randomization_seeds=question_item_randomization_seeds,
                 )
                 interview_definitions.append(interview_def)
 
@@ -2004,9 +2014,10 @@ class JobService:
             if interview_def and hasattr(interview_def, "question_option_permutations")
             else {}
         )
-        item_permutations = (
-            interview_def.question_item_permutations
-            if interview_def and hasattr(interview_def, "question_item_permutations")
+        item_randomization_seeds = (
+            interview_def.question_item_randomization_seeds
+            if interview_def
+            and hasattr(interview_def, "question_item_randomization_seeds")
             else {}
         )
         if job_def and job_def.question_ids and questions_data:
@@ -2028,8 +2039,11 @@ class JobService:
                         "question_options": q_options,
                         **(
                             {
-                                "question_items": item_permutations.get(
-                                    q_name, q_data.get("question_items")
+                                "question_items": self._resolve_question_items(
+                                    q_data,
+                                    answer_dict,
+                                    scenario,
+                                    item_randomization_seeds.get(q_name),
                                 )
                             }
                             if "question_items" in q_data
@@ -2513,20 +2527,26 @@ class JobService:
 
         return permutations
 
-    def _generate_item_permutations(self, questions: list) -> dict[str, list]:
-        """Generate and retain per-interview permutations for static matrix rows."""
-        import random
-
-        permutations = {}
-        for question in questions:
-            data = self._to_dict(question)
-            items = data.get("question_items")
-            if not data.get("randomize_items") or not isinstance(items, list):
-                continue
-            permutations[data["question_name"]] = self._shuffle_pinned(
-                items, data.get("items_to_pin") or [], random
-            )
-        return permutations
+    @staticmethod
+    def _resolve_question_items(
+        question_data: dict,
+        answer_dict: dict,
+        scenario: Any,
+        randomization_seed: int | None = None,
+    ) -> Any:
+        """Resolve matrix rows and reproduce their per-interview randomization."""
+        items = JobService._resolve_question_options(
+            question_data.get("question_items"), answer_dict, scenario
+        )
+        if not isinstance(items, list):
+            return items
+        if not question_data.get("randomize_items") or randomization_seed is None:
+            return items
+        return JobService._shuffle_pinned(
+            items,
+            question_data.get("items_to_pin") or [],
+            random.Random(randomization_seed),
+        )
 
     @staticmethod
     def _shuffle_pinned(items: list, pinned_values: list, rng) -> list:

--- a/edsl/surveys/survey.py
+++ b/edsl/surveys/survey.py
@@ -73,7 +73,6 @@ from .exceptions import (
 )
 
 
-
 class Survey(Base):
     """A collection of questions with logic for navigating between them.
 
@@ -595,6 +594,11 @@ class Survey(Base):
                 "question_options": (
                     None if not hasattr(q, "question_options") else q.question_options
                 ),
+                **(
+                    {"question_items": q.question_items}
+                    if hasattr(q, "question_items")
+                    else {}
+                ),
             }
             for q in self.questions
         }
@@ -900,6 +904,7 @@ class Survey(Base):
 
     def to_jsonl_rows(self, blob_writer=None):
         from .survey_serializer import SurveySerializer
+
         return SurveySerializer(self).to_jsonl_rows()
 
     @classmethod
@@ -3389,9 +3394,7 @@ class Survey(Base):
                 elif isinstance(val, list):
                     columns[key].append(", ".join(str(o) for o in val))
                 elif isinstance(val, dict):
-                    columns[key].append(
-                        ", ".join(f"{k}: {v}" for k, v in val.items())
-                    )
+                    columns[key].append(", ".join(f"{k}: {v}" for k, v in val.items()))
                 else:
                     columns[key].append(str(val))
 

--- a/tests/questions/test_QuestionMatrix.py
+++ b/tests/questions/test_QuestionMatrix.py
@@ -24,6 +24,26 @@ def test_QuestionMatrix_construction():
     assert q.question_options == valid_question["question_options"]
     assert q.option_labels == valid_question["option_labels"]
 
+
+def test_matrix_row_randomization_configuration_roundtrip():
+    q = QuestionMatrix(
+        **valid_question,
+        randomize_items=True,
+        items_to_pin=["3 or more children"],
+    )
+
+    restored = QuestionMatrix.from_dict(q.to_dict())
+
+    assert restored.randomize_items is True
+    assert restored.items_to_pin == ["3 or more children"]
+
+
+def test_default_matrix_serialization_is_unchanged():
+    q = QuestionMatrix(**valid_question)
+
+    assert "randomize_items" not in q.to_dict()
+    assert "items_to_pin" not in q.to_dict()
+
     # Construction without labels
     q = QuestionMatrix(
         **{k: v for k, v in valid_question.items() if k != "option_labels"}
@@ -37,7 +57,7 @@ def test_QuestionMatrix_construction():
     ):
         QuestionMatrix(
             question_name="",
-            **{k: v for k, v in valid_question.items() if k != "question_name"}
+            **{k: v for k, v in valid_question.items() if k != "question_name"},
         )
 
     with pytest.raises(
@@ -46,7 +66,7 @@ def test_QuestionMatrix_construction():
     ):
         QuestionMatrix(
             question_text="",
-            **{k: v for k, v in valid_question.items() if k != "question_text"}
+            **{k: v for k, v in valid_question.items() if k != "question_text"},
         )
 
     with pytest.raises(
@@ -54,7 +74,7 @@ def test_QuestionMatrix_construction():
     ):
         QuestionMatrix(
             question_items=[],
-            **{k: v for k, v in valid_question.items() if k != "question_items"}
+            **{k: v for k, v in valid_question.items() if k != "question_items"},
         )
 
     with pytest.raises(
@@ -62,7 +82,7 @@ def test_QuestionMatrix_construction():
     ):
         QuestionMatrix(
             question_options=[],
-            **{k: v for k, v in valid_question.items() if k != "question_options"}
+            **{k: v for k, v in valid_question.items() if k != "question_options"},
         )
 
 
@@ -157,43 +177,55 @@ def test_QuestionMatrix_numeric_key_fix():
         question_name="test_numeric_keys",
         question_text="How often do you use each of the following?",
         question_items=["Use TikTok", "Use Instagram", "Use BlueSky"],
-        question_options=["Never", "Rarely", "Now and then", "Quite regularly", "Very regularly"],
-        permissive=True
+        question_options=[
+            "Never",
+            "Rarely",
+            "Now and then",
+            "Quite regularly",
+            "Very regularly",
+        ],
+        permissive=True,
     )
 
     # This is the format that caused the validation error in production
     numeric_response = {
         "answer": {"0": 1, "1": 3, "2": 0},
         "comment": "I rarely use TikTok, quite regularly use Instagram, and never use BlueSky.",
-        "generated_tokens": '{"0": 1, "1": 3, "2": 0}\n\nI rarely use TikTok, quite regularly use Instagram, and never use BlueSky.'
+        "generated_tokens": '{"0": 1, "1": 3, "2": 0}\n\nI rarely use TikTok, quite regularly use Instagram, and never use BlueSky.',
     }
 
     # First test the direct fix method to see if it correctly converts the response
     fixed_response = q.response_validator.fix(numeric_response, verbose=True)
-    
+
     # Assert each item is in the fixed response
     assert "Use TikTok" in fixed_response["answer"]
     assert "Use Instagram" in fixed_response["answer"]
     assert "Use BlueSky" in fixed_response["answer"]
-    
+
     # Check that all items are present
     assert len(fixed_response["answer"]) == len(q.question_items)
-    
+
     # Now create a production-like test with string options
     q2 = QuestionMatrix(
         question_name="test_numeric_keys_string_options",
         question_text="How often do you use each of the following?",
         question_items=["Use TikTok", "Use Instagram", "Use BlueSky"],
-        question_options=["Never", "Rarely", "Now and then", "Quite regularly", "Very regularly"],
+        question_options=[
+            "Never",
+            "Rarely",
+            "Now and then",
+            "Quite regularly",
+            "Very regularly",
+        ],
     )
-    
+
     # Set up generated tokens with the JSON format that's causing the issue
     response_with_json = {
         "answer": {"0": 1, "1": 3, "2": 0},
         "comment": "I rarely use TikTok, quite regularly use Instagram, and never use BlueSky.",
-        "generated_tokens": '{"0": 1, "1": 3, "2": 0}'
+        "generated_tokens": '{"0": 1, "1": 3, "2": 0}',
     }
-    
+
     # This should now work because our fix properly maps numeric keys to item names and values to option strings
     try:
         fixed_data = q2.response_validator.fix(response_with_json, verbose=True)

--- a/tests/runner/test_matrix_row_randomization.py
+++ b/tests/runner/test_matrix_row_randomization.py
@@ -1,0 +1,55 @@
+from edsl import Agent, QuestionMatrix, ScenarioList, Survey
+
+
+def test_dynamic_matrix_rows_are_isolated_recorded_and_used_by_direct_answers():
+    """Each interview uses and records its own reproducible resolved row order."""
+    seen_rows = []
+
+    def answer_question_directly(self, question, scenario):
+        seen_rows.append((scenario["respondent"], list(question.question_items)))
+        return {item: "Never" for item in question.question_items}
+
+    agent = Agent()
+    agent.add_direct_question_answering_method(answer_question_directly)
+    question = QuestionMatrix(
+        question_name="ratings",
+        question_text="Rate each item.",
+        question_items="{{ scenario.rows }}",
+        question_options=["Never", "Often"],
+        randomize_items=True,
+        items_to_pin=["Other"],
+    )
+    scenarios = ScenarioList.from_list(
+        "rows",
+        [["A", "B", "Other"], ["X", "Y", "Other"]],
+    )
+    scenarios[0]["respondent"] = "first"
+    scenarios[1]["respondent"] = "second"
+
+    results = (
+        Survey([question])
+        .by(scenarios)
+        .by(agent)
+        .run(
+            disable_remote_inference=True,
+            disable_remote_cache=True,
+        )
+    )
+
+    recorded_rows = dict(
+        results.select(
+            "scenario.respondent", "question_items.ratings_question_items"
+        ).to_list()
+    )
+    direct_rows = dict(seen_rows)
+
+    assert recorded_rows == direct_rows
+    assert {frozenset(rows) for rows in recorded_rows.values()} == {
+        frozenset(["A", "B", "Other"]),
+        frozenset(["X", "Y", "Other"]),
+    }
+    assert all(rows[-1] == "Other" for rows in recorded_rows.values())
+    assert results.select("question_options.ratings_question_options").to_list() == [
+        ["Never", "Often"],
+        ["Never", "Often"],
+    ]


### PR DESCRIPTION
## Summary

- add `randomize_items=True` and `items_to_pin=[...]` to `QuestionMatrix`
- randomize rows independently from answer options, including rows resolved from templates and prior answers
- persist per-interview static row permutations so retries/resumes render the same order
- expose the served order through the `question_items` Results data type
- preserve existing `questions_to_randomize` option behavior and default serialization

## Testing

- `pytest -q tests/questions/test_QuestionMatrix.py tests/invigilators tests/results tests/runner --doctest-modules edsl/invigilators/question_item_processor.py edsl/invigilators/question_instructions_prompt_builder.py edsl/questions/question_base_gen_mixin.py` (179 passed, 2 skipped)
- `pytest -q tests/surveys/test_Survey.py tests/surveys/test_survey_git.py tests/serialization` (42 passed, 10 skipped)
- local end-to-end 4-interview test verified differing row orders, pinned final row, unchanged answer scale, and recoverable `question_items` result metadata

Closes #2587