### PR TITLE
Fix QuestionDict fenced JSON recovery

### DIFF
--- a/edsl/questions/question_dict.py
+++ b/edsl/questions/question_dict.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel, Field, create_model, ConfigDict
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from pathlib import Path
 import ast
+import json
+import re
 
 from .question_base import QuestionBase
 from .descriptors import (
@@ -129,61 +131,63 @@ class DictResponseValidator(ResponseValidatorABC):
     def _recover_from_generated_tokens(self, text, verbose=False):
         """Recover a dict answer from the raw generated text.
 
-        The model typically emits a JSON object followed by an optional
-        one-line comment. We try, in order:
-
-        1. Parse the whole string as JSON (clean answer, no comment).
-        2. Peel off the last line as the comment and parse the rest as JSON
-           (the model's usual ``{...}\\n<comment>`` shape).
-        3. Fall back to ``repair_json`` on the whole string for malformed JSON.
+        The model typically emits a JSON object, optionally wrapped in a
+        Markdown fence and followed by commentary. Decode the first complete
+        object, preserve later prose as the comment, and fall back to
+        ``repair_json`` for malformed JSON.
 
         Returns a ``{"answer", "comment", "generated_tokens"}`` dict on success,
         or ``None`` if nothing parsed to a dict.
         """
-        import json
-
         if not isinstance(text, str) or not text.strip():
             return None
 
-        def _strict(s):
-            s = s.strip()
-            if not s:
-                return None
-            try:
-                parsed = json.loads(s)
-            except (ValueError, TypeError):
-                return None
-            return parsed if isinstance(parsed, dict) else None
+        candidate = text.strip()
+        candidate = re.sub(
+            r"^```(?:json)?[ \t]*(?:\r?\n)?",
+            "",
+            candidate,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        object_start = candidate.find("{")
+        if object_start < 0:
+            return None
 
-        # 1) Whole string is clean JSON — no trailing comment.
-        parsed = _strict(text)
-        if parsed is not None:
-            return {"answer": parsed, "comment": None, "generated_tokens": text}
-
-        # 2) JSON is everything but the last line; last line is the comment.
-        lines = text.rstrip("\n").split("\n")
-        if len(lines) >= 2:
-            head = "\n".join(lines[:-1])
-            parsed = _strict(head)
-            if parsed is not None:
-                comment = lines[-1].strip().lstrip("#").strip() or None
-                if verbose:
-                    print(
-                        f"[QDICT fix]   split JSON from trailing comment line: {comment!r}"
-                    )
-                return {"answer": parsed, "comment": comment, "generated_tokens": text}
-
-        # 3) Last resort: let json_repair try to salvage a malformed object.
+        parsed = None
+        object_end = None
         try:
-            from json_repair import repair_json
+            parsed, consumed = json.JSONDecoder().raw_decode(candidate[object_start:])
+            object_end = object_start + consumed
+        except (ValueError, TypeError):
+            # Retain support for malformed, otherwise recoverable model JSON.
+            try:
+                from json_repair import repair_json
 
-            repaired = json.loads(repair_json(text.strip()))
-            if isinstance(repaired, dict):
-                return {"answer": repaired, "comment": None, "generated_tokens": text}
+                parsed = json.loads(repair_json(candidate[object_start:]))
+                object_end = len(candidate)
+            except Exception:
+                return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        remainder = candidate[object_end:].strip()
+        remainder = re.sub(r"^```[ \t]*(?:\r?\n|$)", "", remainder, count=1).strip()
+        comment = remainder.lstrip("#").strip() or None
+        recovered = {
+            "answer": parsed,
+            "comment": comment,
+            "generated_tokens": text,
+        }
+        try:
+            self.response_model.model_validate(recovered)
         except Exception:
-            pass
+            return None
 
-        return None
+        if verbose:
+            print(f"[QDICT fix] recovered JSON with comment: {comment!r}")
+        return recovered
 
     def fix(self, response, verbose=False):
         """
@@ -246,21 +250,24 @@ class DictResponseValidator(ResponseValidatorABC):
             >>> validator.fix(response)
             'not a dictionary'
         """
-        # Recovery for the common case where the model returns multi-line JSON
-        # followed by a trailing comment line. The upstream parser splits on the
-        # first newline, leaving `answer` empty ({}) while the full text survives
-        # in `generated_tokens`. Re-parse it here: JSON is everything but the last
-        # line, and the last line becomes the comment.
-        if isinstance(response, dict) and not response.get("answer"):
+        # Validation normally happens before fix() is called, but fix() is also a
+        # public hook. Preserve an already valid response before considering the
+        # raw generated text.
+        if isinstance(response, dict):
+            try:
+                self.response_model.model_validate(response)
+                return response
+            except Exception:
+                pass
+
+        # The upstream parser may leave an invalid first line in `answer` while
+        # preserving the complete response in `generated_tokens`.
+        if isinstance(response, dict) and response.get("generated_tokens"):
             recovered = self._recover_from_generated_tokens(
                 response.get("generated_tokens"), verbose=verbose
             )
             if recovered is not None:
-                try:
-                    self.response_model.model_validate(recovered)
-                    return recovered
-                except Exception as e:
-                    pass
+                return recovered
 
         # First try to separate dictionary from trailing comment if they're on the same line
         original_response = response

--- a/edsl/questions/question_dict.py
+++ b/edsl/questions/question_dict.py
@@ -255,7 +255,13 @@ class DictResponseValidator(ResponseValidatorABC):
         # raw generated text.
         if isinstance(response, dict):
             try:
-                self.response_model.model_validate(response)
+                validated = self.response_model.model_validate(response)
+                validated_answer = validated.model_dump()["answer"]
+                # Pydantic may accept the input by coercing values (for example,
+                # ``"23"`` to ``23``).  In that case return the normalized model
+                # output; otherwise retain the original object and its shape.
+                if validated_answer != response.get("answer"):
+                    return validated.model_dump()
                 return response
             except Exception:
                 pass

--- a/tests/questions/test_QuestionDict.py
+++ b/tests/questions/test_QuestionDict.py
@@ -9,7 +9,11 @@ valid_question = {
     "question_text": "Please provide a detailed recipe for basic hot chocolate. Include all ingredients and steps.",
     "answer_keys": ["recipe_name", "ingredients", "num_ingredients"],
     "value_types": ["str", "list[str]", "int"],
-    "value_descriptions": ["The name of the recipe.", "List of ingredients.", "The number of ingredients."],
+    "value_descriptions": [
+        "The name of the recipe.",
+        "List of ingredients.",
+        "The number of ingredients.",
+    ],
 }
 
 
@@ -28,7 +32,7 @@ def test_QuestionDict_construction():
     minimal_question = {
         "question_name": "recipe",
         "question_text": valid_question["question_text"],
-        "answer_keys": valid_question["answer_keys"]
+        "answer_keys": valid_question["answer_keys"],
     }
     q = QuestionDict(**minimal_question)
     assert q.value_types is None
@@ -53,9 +57,9 @@ def test_QuestionDict_validation():
     # Valid answer
     valid_answer = {
         "answer": {
-            "recipe_name": "Basic Hot Chocolate", 
-            "ingredients": ["Steamed milk", "Chocolate flakes"], 
-            "num_ingredients": 2
+            "recipe_name": "Basic Hot Chocolate",
+            "ingredients": ["Steamed milk", "Chocolate flakes"],
+            "num_ingredients": 2,
         }
     }
     q._validate_answer(valid_answer)
@@ -69,6 +73,84 @@ def test_QuestionDict_validation():
 
     with pytest.raises(QuestionAnswerValidationError):
         q._validate_answer({"answer": {"num_ingredients": "2"}})  # Should be an int
+
+
+def test_QuestionDict_recovers_fenced_generated_tokens():
+    q = QuestionDict(
+        question_name="x",
+        question_text="x",
+        answer_keys=["assumption", "node_ids"],
+        value_types=["str", "list[str]"],
+    )
+    generated_tokens = """```json
+{"assumption":"test", "node_ids":["n1"]}
+```
+Extra explanation"""
+
+    result = q._validate_answer(
+        {"answer": "```json", "generated_tokens": generated_tokens}
+    )
+
+    assert result == {
+        "answer": {"assumption": "test", "node_ids": ["n1"]},
+        "comment": "Extra explanation",
+        "generated_tokens": generated_tokens,
+    }
+
+
+def test_QuestionDict_recovers_multiline_json_and_complex_strings():
+    q = QuestionDict(
+        question_name="x",
+        question_text="x",
+        answer_keys=["text", "node_ids"],
+        value_types=["str", "list[str]"],
+    )
+    generated_tokens = """```
+{
+  "text": "A {brace} and an escaped quote: \\"yes\\"",
+  "node_ids": ["n1"]
+}
+```
+First paragraph.
+
+Second paragraph."""
+
+    result = q._validate_answer({"answer": "```", "generated_tokens": generated_tokens})
+
+    assert result["answer"]["text"] == 'A {brace} and an escaped quote: "yes"'
+    assert result["comment"] == "First paragraph.\n\nSecond paragraph."
+    assert result["generated_tokens"] == generated_tokens
+
+
+def test_QuestionDict_generated_token_recovery_is_schema_aware():
+    q = QuestionDict(
+        question_name="x",
+        question_text="x",
+        answer_keys=["assumption", "node_ids"],
+        value_types=["str", "list[str]"],
+    )
+
+    with pytest.raises(QuestionAnswerValidationError):
+        q._validate_answer(
+            {
+                "answer": "```json",
+                "generated_tokens": '```json\n{"assumption": "test", "node_ids": 1}\n```',
+            }
+        )
+
+
+def test_QuestionDict_fix_preserves_valid_answer():
+    q = QuestionDict(**valid_question)
+    response = {
+        "answer": {
+            "recipe_name": "Cocoa",
+            "ingredients": ["milk"],
+            "num_ingredients": 1,
+        },
+        "generated_tokens": "not relevant",
+    }
+
+    assert q.response_validator.fix(response) is response
 
 
 def test_QuestionDict_serialization():
@@ -90,7 +172,7 @@ def test_QuestionDict_presentation():
     """Test question presentation template rendering."""
     q = QuestionDict(**valid_question)
     presentation = q.question_presentation
-    
+
     assert presentation is not None
     assert isinstance(presentation, str)
     assert valid_question["question_text"] in presentation

--- a/tests/questions/test_QuestionDict.py
+++ b/tests/questions/test_QuestionDict.py
@@ -153,6 +153,22 @@ def test_QuestionDict_fix_preserves_valid_answer():
     assert q.response_validator.fix(response) is response
 
 
+def test_QuestionDict_fix_returns_coerced_answer():
+    q = QuestionDict(**valid_question)
+
+    fixed = q.response_validator.fix(
+        {
+            "answer": {
+                "recipe_name": "Cocoa",
+                "ingredients": ["milk"],
+                "num_ingredients": "1",
+            }
+        }
+    )
+
+    assert fixed["answer"]["num_ingredients"] == 1
+
+
 def test_QuestionDict_serialization():
     """Test serialization."""
     q = QuestionDict(**valid_question)


### PR DESCRIPTION
## Summary
- recover valid dictionary answers from generated_tokens when the parsed answer is truthy but invalid
- unwrap optional Markdown fences and preserve trailing prose as the response comment
- validate recovered objects against the dynamic QuestionDict response schema
- retain generated_tokens for auditing

## Tests
- direct execution of all 10 tests in tests/questions/test_QuestionDict.py
- ruff check edsl/questions/question_dict.py tests/questions/test_QuestionDict.py
- black --check edsl/questions/question_dict.py tests/questions/test_QuestionDict.py
- git diff --check

The normal pytest harness could not start locally because Docker was already listening on ports 8001 and 8002.

Closes #2595