### PR TITLE
Preserve validation failures across execution and persistence

### DIFF
--- a/edsl/interviews/answering_function.py
+++ b/edsl/interviews/answering_function.py
@@ -435,9 +435,7 @@ class AnswerQuestionFunctionConstructor:
 
             except QuestionAnswerValidationError as e:
                 self._handle_exception(e, invigilator, task)
-                return invigilator.get_failed_task_result(
-                    failure_reason="Question answer validation failed."
-                )
+                return response._replace(comment="Question answer validation failed.")
 
             except asyncio.TimeoutError:
                 # Don't record exception yet - will retry

--- a/edsl/interviews/answering_function.py
+++ b/edsl/interviews/answering_function.py
@@ -381,6 +381,7 @@ class AnswerQuestionFunctionConstructor:
                 )
 
             had_language_model_no_response_error = False
+            response = None
             try:
                 import time
 
@@ -435,7 +436,13 @@ class AnswerQuestionFunctionConstructor:
 
             except QuestionAnswerValidationError as e:
                 self._handle_exception(e, invigilator, task)
-                return response._replace(comment="Question answer validation failed.")
+                if response is not None:
+                    return response._replace(
+                        comment="Question answer validation failed."
+                    )
+                return invigilator.get_failed_task_result(
+                    failure_reason="Question answer validation failed."
+                )
 
             except asyncio.TimeoutError:
                 # Don't record exception yet - will retry

--- a/edsl/interviews/exception_tracking.py
+++ b/edsl/interviews/exception_tracking.py
@@ -17,12 +17,14 @@ class InterviewExceptionEntry:
         traceback_format="text",
         answers=None,
         time=None,  # Added time parameter for deserialization
+        additional_data=None,
     ):
         self.time = time or datetime.datetime.now().isoformat()
         self.exception = exception
         self.invigilator = invigilator
         self.traceback_format = traceback_format
         self.answers = answers
+        self.additional_data = additional_data or {}
 
     @property
     def exception_type(self) -> str:
@@ -252,7 +254,7 @@ class InterviewExceptionEntry:
             "time": self.time,
             "traceback": self.traceback,
             "invigilator": invigilator,
-            "additional_data": {},
+            "additional_data": dict(self.additional_data),
         }
 
         if isinstance(self.exception, QuestionAnswerValidationError):
@@ -281,7 +283,12 @@ class InterviewExceptionEntry:
         # Use the original timestamp from serialization
         time = data.get("time")
 
-        return cls(exception=exception, invigilator=invigilator, time=time)
+        return cls(
+            exception=exception,
+            invigilator=invigilator,
+            time=time,
+            additional_data=data.get("additional_data"),
+        )
 
 
 class InterviewExceptionCollection(UserDict):

--- a/edsl/results/results_serializer.py
+++ b/edsl/results/results_serializer.py
@@ -6,9 +6,10 @@ object reconstruction, shelve operations, and disk persistence.
 
 Inline JSONL format:
   - Line 1: header (``__header__: true``, class name, version, format)
-  - Line 2: manifest (created_columns, name, n_survey_lines)
+  - Line 2: manifest (metadata and section line counts)
   - Lines 3..S+2: Survey JSONL lines (inline)
-  - Lines S+3..: Result rows (one Result.to_dict() per line, appendable)
+  - Task-history metadata and interview rows
+  - Result rows (one Result.to_dict() per line, appendable)
 """
 
 import json
@@ -212,12 +213,26 @@ class ResultsSerializer:
           - Line 1: header
           - Line 2: manifest (line counts + metadata)
           - Survey lines (from Survey.to_jsonl_rows())
+          - Task-history metadata and interview rows
           - Result rows (one Result.to_dict() per line)
         """
         from .. import __version__
 
         # Collect survey rows first to get count
         survey_rows = list(self.results.survey.to_jsonl_rows(blob_writer=blob_writer))
+        task_history = self.results.task_history.to_dict(offload_content=True)
+        task_history_rows = [
+            json.dumps(
+                {
+                    "__task_history__": True,
+                    "include_traceback": task_history.get("include_traceback", False),
+                }
+            )
+        ]
+        task_history_rows.extend(
+            json.dumps({"interview": interview})
+            for interview in task_history.get("interviews", [])
+        )
 
         # Header
         yield json.dumps({
@@ -225,6 +240,7 @@ class ResultsSerializer:
             "edsl_class_name": "Results",
             "edsl_version": __version__,
             "format": "inline",
+            "format_version": 2,
         })
 
         # Manifest
@@ -232,10 +248,15 @@ class ResultsSerializer:
             "created_columns": self.results.created_columns,
             "name": self.results.name,
             "n_survey_lines": len(survey_rows),
+            "n_task_history_lines": len(task_history_rows),
         })
 
         # Survey lines
         yield from survey_rows
+
+        # Task-history lines.  The metadata row is always present, including
+        # when the authoritative history is empty.
+        yield from task_history_rows
 
         # Result rows
         for result in self.results.data:
@@ -252,6 +273,7 @@ class ResultsSerializer:
           - Line 1: header
           - Line 2: manifest (line counts + metadata)
           - Survey lines inline
+          - Task-history metadata and interview rows
           - Result rows
         """
         content = "\n".join(self.to_jsonl_rows()) + "\n"
@@ -268,7 +290,7 @@ class ResultsSerializer:
     ) -> "Results":
         """Create a Results instance from an inline JSONL source.
 
-        Reads the manifest to determine line counts for Survey and Cache
+        Reads the manifest to determine line counts for Survey and TaskHistory
         sections, then parses each section from the inline content.
         """
         from .results import Results
@@ -277,7 +299,7 @@ class ResultsSerializer:
         from ..caching import Cache
         from ..tasks import TaskHistory
 
-        lines = [l.rstrip("\n") for l in _open_lines(source) if l.strip()]
+        lines = [line.rstrip("\n") for line in _open_lines(source) if line.strip()]
 
         _header = json.loads(lines[0])
         manifest = json.loads(lines[1])
@@ -293,8 +315,30 @@ class ResultsSerializer:
         created_columns = manifest.get("created_columns", [])
         name = manifest.get("name", None)
 
+        # Task-history section.  Older inline packages have no count and retain
+        # the legacy empty-history behavior.
+        task_history_start = 2 + n_survey
+        n_task_history = manifest.get("n_task_history_lines", 0)
+        task_history_lines = lines[
+            task_history_start : task_history_start + n_task_history
+        ]
+        if task_history_lines:
+            task_history_metadata = json.loads(task_history_lines[0])
+            task_history_data = {
+                "include_traceback": task_history_metadata.get(
+                    "include_traceback", False
+                ),
+                "interviews": [
+                    json.loads(line)["interview"]
+                    for line in task_history_lines[1:]
+                ],
+            }
+            task_history = TaskHistory.from_dict(task_history_data)
+        else:
+            task_history = TaskHistory(interviews=[])
+
         # Result rows
-        result_start = 2 + n_survey
+        result_start = task_history_start + n_task_history
         results_data = [
             Result.from_dict(json.loads(line))
             for line in lines[result_start:]
@@ -306,11 +350,10 @@ class ResultsSerializer:
             data=[],
             created_columns=created_columns,
             cache=cache,
-            task_history=TaskHistory(interviews=[]),
+            task_history=task_history,
             name=name,
         )
         for result in results_data:
             results.append(result)
 
         return results
-

--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -196,6 +196,20 @@ class ExecutionWorker:
                         task_id=result.task_id,
                         error_type=result.error_type or "unknown",
                         error_message=result.error_message or "Unknown error",
+                        comment=result.comment,
+                        input_tokens=result.input_tokens,
+                        output_tokens=result.output_tokens,
+                        raw_model_response=result.raw_model_response,
+                        generated_tokens=result.generated_tokens,
+                        cached=result.cached,
+                        system_prompt=result.system_prompt,
+                        user_prompt=result.user_prompt,
+                        input_price_per_million_tokens=result.input_price_per_million_tokens,
+                        output_price_per_million_tokens=result.output_price_per_million_tokens,
+                        thinking_tokens=result.thinking_tokens,
+                        cache_key=result.cache_key,
+                        validated=result.validated,
+                        reasoning_summary=result.reasoning_summary,
                     )
         finally:
             # Unregister on shutdown
@@ -236,6 +250,12 @@ class ExecutionWorker:
         """Execute a single task using the actual model object."""
         task = assignment.task
 
+        response_received = False
+        answer = comment = generated_tokens = reasoning_summary = None
+        input_tokens = output_tokens = thinking_tokens = None
+        raw_response = cache_key = input_price = output_price = None
+        cached = False
+
         try:
             # Reconstruct the model object from stored data
             model = self._job_service.get_model_for_task(task.job_id, task.model_id)
@@ -274,6 +294,7 @@ class ExecutionWorker:
             # Response is an AgentResponseDict with edsl_dict and model_outputs
             edsl_dict = response.edsl_dict
             model_outputs = response.model_outputs
+            response_received = True
 
             # From edsl_dict (EDSLOutput)
             answer = edsl_dict.answer if hasattr(edsl_dict, "answer") else None
@@ -289,6 +310,18 @@ class ExecutionWorker:
                 else None
             )
 
+            # Capture provider context before validation, which may raise.
+            input_tokens = getattr(model_outputs, "input_tokens", None)
+            output_tokens = getattr(model_outputs, "output_tokens", None)
+            raw_response = getattr(model_outputs, "response", None)
+            cached = getattr(model_outputs, "cache_used", False)
+            cache_key = getattr(model_outputs, "cache_key", None)
+            input_price = getattr(model_outputs, "input_price_per_million_tokens", None)
+            output_price = getattr(
+                model_outputs, "output_price_per_million_tokens", None
+            )
+            thinking_tokens = getattr(model_outputs, "thinking_tokens", None)
+
             # Validate answer through question's validator (handles repair/fix)
             (
                 answer,
@@ -300,44 +333,6 @@ class ExecutionWorker:
                 resolution_method,
             ) = self._validate_answer(
                 task, answer, comment, generated_tokens
-            )
-
-            # From model_outputs (ModelResponse)
-            input_tokens = (
-                model_outputs.input_tokens
-                if hasattr(model_outputs, "input_tokens")
-                else None
-            )
-            output_tokens = (
-                model_outputs.output_tokens
-                if hasattr(model_outputs, "output_tokens")
-                else None
-            )
-            raw_response = (
-                model_outputs.response if hasattr(model_outputs, "response") else None
-            )
-            cached = (
-                model_outputs.cache_used
-                if hasattr(model_outputs, "cache_used")
-                else False
-            )
-            cache_key = (
-                model_outputs.cache_key if hasattr(model_outputs, "cache_key") else None
-            )
-            input_price = (
-                model_outputs.input_price_per_million_tokens
-                if hasattr(model_outputs, "input_price_per_million_tokens")
-                else None
-            )
-            output_price = (
-                model_outputs.output_price_per_million_tokens
-                if hasattr(model_outputs, "output_price_per_million_tokens")
-                else None
-            )
-            thinking_tokens = (
-                model_outputs.thinking_tokens
-                if hasattr(model_outputs, "thinking_tokens")
-                else None
             )
 
             return ExecutionResult(
@@ -377,6 +372,21 @@ class ExecutionWorker:
                 job_id=task.job_id,
                 interview_id=task.interview_id,
                 success=False,
+                answer=None,
+                comment=comment,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                raw_model_response=raw_response,
+                generated_tokens=generated_tokens,
+                cached=cached,
+                system_prompt=task.system_prompt if response_received else None,
+                user_prompt=task.user_prompt if response_received else None,
+                input_price_per_million_tokens=input_price,
+                output_price_per_million_tokens=output_price,
+                thinking_tokens=thinking_tokens,
+                cache_key=cache_key,
+                validated=False if response_received else None,
+                reasoning_summary=reasoning_summary,
                 error_type=error_type,
                 error_message=str(e),
             )

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -1104,11 +1104,55 @@ class JobService:
         error_type: str,
         error_message: str,
         force_permanent: bool = False,
+        comment: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        raw_model_response: dict | None = None,
+        generated_tokens: str | None = None,
+        cached: bool = False,
+        system_prompt: str | None = None,
+        user_prompt: str | None = None,
+        input_price_per_million_tokens: float | None = None,
+        output_price_per_million_tokens: float | None = None,
+        thinking_tokens: int | None = None,
+        cache_key: str | None = None,
+        validated: bool | None = None,
+        reasoning_summary: str | None = None,
     ) -> None:
         """Called when a task fails. Retries if policy allows, otherwise marks as permanent failure."""
         task_def = self._tasks.get_definition(job_id, interview_id, task_id)
         if task_def is None:
             raise ValueError(f"Task {task_id} not found")
+
+        if (
+            validated is False
+            or raw_model_response is not None
+            or generated_tokens is not None
+        ):
+            self._answers.store(
+                Answer(
+                    job_id=job_id,
+                    interview_id=interview_id,
+                    question_name=task_def.question_name,
+                    answer=None,
+                    created_at=datetime.utcnow(),
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    comment=comment or error_message,
+                    cached=cached,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    thinking_tokens=thinking_tokens,
+                    raw_model_response=raw_model_response,
+                    generated_tokens=generated_tokens,
+                    model_id=task_def.model_id,
+                    input_price_per_million_tokens=input_price_per_million_tokens,
+                    output_price_per_million_tokens=output_price_per_million_tokens,
+                    cache_key=cache_key,
+                    validated=validated,
+                    reasoning_summary=reasoning_summary,
+                )
+            )
 
         # Check retry policy before marking as permanently failed
         # Skip retries if stop_on_exception is set for this job
@@ -1702,6 +1746,19 @@ class JobService:
                         "error_message": state.last_error_message or "Unknown error",
                         "attempts": state.attempts,
                     }
+
+                    if task_def is not None:
+                        failed_answer = self._answers.get(
+                            job_id, interview_id, task_def.question_name
+                        )
+                        if failed_answer is not None:
+                            error_info["response_context"] = {
+                                "raw_model_response": failed_answer.raw_model_response,
+                                "generated_tokens": failed_answer.generated_tokens,
+                                "system_prompt": failed_answer.system_prompt,
+                                "user_prompt": failed_answer.user_prompt,
+                                "validated": failed_answer.validated,
+                            }
 
                     errors.append(error_info)
 
@@ -2299,10 +2356,42 @@ class JobService:
 
         # Create the Results object
         _t = _time.time()
-        results = Results(
-            survey=survey,
-            data=result_list,
+        from ..tasks import TaskHistory
+
+        errors_by_interview: dict[str, dict[str, list[dict]]] = {}
+        for error in self.get_error_details(job_id):
+            question_name = error.get("question_name") or "unknown"
+            exception_entry = {
+                "exception": {
+                    "type": error.get("error_type") or "Exception",
+                    "module": "edsl.runner",
+                    "message": error.get("error_message") or "Unknown error",
+                    "traceback": f"Exception: {error.get('error_message') or 'Unknown error'}",
+                },
+                "invigilator": None,
+                "additional_data": {
+                    "attempts": error.get("attempts", {}),
+                    "response_context": error.get("response_context"),
+                },
+            }
+            errors_by_interview.setdefault(error["interview_id"], {}).setdefault(
+                question_name, []
+            ).append(exception_entry)
+
+        task_history = TaskHistory.from_dict(
+            {
+                "interviews": [
+                    {
+                        "id": interview_id,
+                        "type": "InterviewReference",
+                        "exceptions": exceptions,
+                        "task_status_logs": {},
+                    }
+                    for interview_id, exceptions in errors_by_interview.items()
+                ]
+            }
         )
+        results = Results(survey=survey, data=result_list, task_history=task_history)
         if _timing is not None:
             _timing["create_results_object"] = (_time.time() - _t) * 1000
 

--- a/edsl/tasks/task_history.py
+++ b/edsl/tasks/task_history.py
@@ -168,6 +168,9 @@ class TaskHistory(RepresentationMixin):
                         name: log.to_dict() if hasattr(log, "to_dict") else {}
                         for name, log in self.task_status_logs.items()
                     },
+                    "fixed_questions": sorted(
+                        getattr(self.exceptions, "fixed", set())
+                    ),
                 }
 
                 # Add model and survey info if they have to_dict methods
@@ -333,6 +336,7 @@ class TaskHistory(RepresentationMixin):
                     if exceptions_data
                     else InterviewExceptionCollection()
                 )
+                self.exceptions.fixed.update(data.get("fixed_questions", []))
 
                 # Store other fields
                 self.task_status_logs = data.get("task_status_logs", {})
@@ -360,6 +364,9 @@ class TaskHistory(RepresentationMixin):
                         )
                     ),
                     "task_status_logs": self.task_status_logs,
+                    "fixed_questions": sorted(
+                        getattr(self.exceptions, "fixed", set())
+                    ),
                     "model": self._model_data,
                     "survey": self._survey_data,
                 }

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -9,6 +9,7 @@ import pytest
 from edsl.results import Results, ResultsGitError, ResultsGitNestedRepoWarning
 from edsl.results.exceptions import ResultsError
 from edsl.base.base_exception import BaseException as EDSLBaseException
+from edsl.tasks import TaskHistory
 
 
 pytestmark = pytest.mark.skipif(
@@ -24,6 +25,39 @@ def _package_json(package_path: Path, member: str):
 def _package_names(package_path: Path) -> set[str]:
     with zipfile.ZipFile(package_path) as archive:
         return set(archive.namelist())
+
+
+def _results_with_task_history(*, fixed=False):
+    results = Results.example().sample(1)
+    history = TaskHistory.from_dict(
+        {
+            "include_traceback": True,
+            "interviews": [
+                {
+                    "id": "interview-1",
+                    "type": "InterviewReference",
+                    "exceptions": {
+                        "q0": [
+                            {
+                                "exception": {
+                                    "type": "ValidationError",
+                                    "module": "edsl.runner",
+                                    "message": "invalid answer",
+                                    "traceback": "Exception: invalid answer",
+                                },
+                                "invigilator": None,
+                                "additional_data": {"attempts": 3},
+                            }
+                        ]
+                    },
+                    "fixed_questions": ["q0"] if fixed else [],
+                    "task_status_logs": {},
+                }
+            ],
+        }
+    )
+    results.task_history = history
+    return results
 
 
 def test_results_git_error_uses_results_exception_hierarchy():
@@ -63,6 +97,71 @@ def test_results_git_save_default_path_and_load_round_trip(tmp_path, monkeypatch
     assert loaded == results
     assert loaded.git.path == package_path
     assert loaded.git.validate() == {"status": "ok", "errors": []}
+
+
+def test_results_jsonl_round_trip_preserves_task_history():
+    results = _results_with_task_history()
+
+    loaded = Results.from_jsonl(results.to_jsonl())
+
+    assert loaded.has_unfixed_exceptions
+    assert len(loaded.task_history.exceptions) == 1
+    entry = loaded.task_history.to_dict()["interviews"][0]["exceptions"]["q0"][0]
+    assert entry["exception"]["message"] == "invalid answer"
+    assert entry["additional_data"]["attempts"] == 3
+
+
+def test_results_jsonl_records_authoritative_empty_task_history():
+    results = Results.example().sample(1)
+    lines = results.to_jsonl().splitlines()
+
+    assert json.loads(lines[0])["format_version"] == 2
+    assert json.loads(lines[1])["n_task_history_lines"] == 1
+    loaded = Results.from_jsonl("\n".join(lines))
+    assert loaded.task_history.total_interviews == []
+    assert not loaded.has_unfixed_exceptions
+
+
+def test_results_jsonl_round_trip_preserves_fixed_history():
+    results = _results_with_task_history(fixed=True)
+    assert not results.has_unfixed_exceptions
+
+    loaded = Results.from_jsonl(results.to_jsonl())
+
+    assert len(loaded.task_history.exceptions) == 1
+    assert not loaded.has_unfixed_exceptions
+    assert loaded.task_history.to_dict()["interviews"][0]["fixed_questions"] == [
+        "q0"
+    ]
+
+
+def test_results_git_round_trip_preserves_task_history(tmp_path):
+    results = _results_with_task_history()
+    package_path = tmp_path / "failed-results.ep"
+
+    results.git.save(package_path)
+    loaded = Results.git.load(package_path)
+
+    assert loaded.has_unfixed_exceptions
+    assert len(loaded.task_history.exceptions) == 1
+
+
+def test_results_jsonl_loads_legacy_format_without_task_history():
+    results = Results.example().sample(1)
+    lines = results.to_jsonl().splitlines()
+    manifest = json.loads(lines[1])
+    n_survey = manifest["n_survey_lines"]
+    n_history = manifest.pop("n_task_history_lines")
+    legacy_lines = (
+        [lines[0], json.dumps(manifest)]
+        + lines[2 : 2 + n_survey]
+        + lines[2 + n_survey + n_history :]
+    )
+
+    loaded = Results.from_jsonl("\n".join(legacy_lines))
+
+    assert len(loaded) == len(results)
+    assert loaded.task_history.total_interviews == []
 
 
 def test_results_git_save_is_immutable_by_default(tmp_path):

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -1,17 +1,71 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
 from edsl import (
     Agent,
     Model,
     QuestionBudget,
     QuestionCompute,
     QuestionFreeText,
+    QuestionFunctional,
     Results,
+    Scenario,
     Survey,
 )
+from edsl.interviews.answering_function import AnswerQuestionFunctionConstructor
+from edsl.interviews.interview import Interview
+from edsl.questions.exceptions import QuestionAnswerValidationError
 from edsl.inference_services.services.test_service import TestService
 from edsl.runner.models import InterviewState, TaskStatus
 from edsl.runner.runner import Runner
 from edsl.runner.service import JobService
 from edsl.runner.storage import InMemoryStorage
+
+
+def _functional_answer(scenario, agent_traits):
+    return 1
+
+
+def test_validation_error_before_response_uses_no_response_failure_result():
+    question = QuestionFunctional(
+        question_name="functional",
+        func=_functional_answer,
+        unsafe=True,
+    )
+    interview = Interview(
+        agent=Agent(),
+        survey=Survey([question]),
+        scenario=Scenario(),
+        model=Model("test"),
+        raise_validation_errors=False,
+    )
+    interview.skip_flags = {}
+    error = QuestionAnswerValidationError(
+        message="invalid functional answer",
+        data={"answer": None},
+        model=Mock(model_json_schema=Mock(return_value={})),
+        pydantic_error=Mock(),
+    )
+    failed_result = object()
+    invigilator = SimpleNamespace(
+        question=question,
+        async_answer_question=AsyncMock(side_effect=error),
+        get_failed_task_result=Mock(return_value=failed_result),
+    )
+    constructor = AnswerQuestionFunctionConstructor(interview, key_lookup=None)
+    constructor.invigilator_fetcher = Mock(return_value=invigilator)
+
+    result = asyncio.run(
+        constructor.answer_question_and_record_task(question=question)
+    )
+
+    assert result is failed_result
+    invigilator.get_failed_task_result.assert_called_once_with(
+        failure_reason="Question answer validation failed."
+    )
+    assert len(interview.exceptions[question.question_name]) == 1
+    assert interview.exceptions[question.question_name][0].exception is error
 
 
 def test_validation_failure_preserves_response_and_task_history(tmp_path):

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -1,8 +1,48 @@
-from edsl import Agent, QuestionCompute, QuestionFreeText, Survey
+from edsl import (
+    Agent,
+    Model,
+    QuestionBudget,
+    QuestionCompute,
+    QuestionFreeText,
+    Results,
+    Survey,
+)
 from edsl.inference_services.services.test_service import TestService
 from edsl.runner.models import InterviewState, TaskStatus
+from edsl.runner.runner import Runner
 from edsl.runner.service import JobService
 from edsl.runner.storage import InMemoryStorage
+
+
+def test_validation_failure_preserves_response_and_task_history():
+    question = QuestionBudget(
+        question_name="budget",
+        question_text="Allocate the budget.",
+        question_options=["item", "other_or_unspent"],
+        budget_sum=100,
+    )
+
+    job = question.by(Model("test", canned_response="[60,30]"))
+    results = Runner().submit(job, cache=False).results()
+
+    result = results[0]
+    assert result.answer["budget"] is None
+    assert result["generated_tokens"]["budget_generated_tokens"] == "[60,30]"
+    assert result["raw_model_response"]["budget_raw_model_response"] is not None
+    assert result["prompt"]["budget_user_prompt"].text
+    assert result["validated_dict"]["budget_validated"] is False
+    assert results.has_unfixed_exceptions
+    history_dict = results.task_history.to_dict()
+    response_context = history_dict["interviews"][0]["exceptions"]["budget"][0][
+        "additional_data"
+    ]["response_context"]
+    assert response_context["generated_tokens"] == "[60,30]"
+    assert response_context["raw_model_response"] is not None
+
+    round_tripped = Results.from_dict(results.to_dict())
+    assert round_tripped[0]["generated_tokens"] == result["generated_tokens"]
+    assert round_tripped[0]["raw_model_response"] == result["raw_model_response"]
+    assert round_tripped.has_unfixed_exceptions
 
 
 def test_failure_propagation_blocks_converging_dag_nodes_once():

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -14,7 +14,7 @@ from edsl.runner.service import JobService
 from edsl.runner.storage import InMemoryStorage
 
 
-def test_validation_failure_preserves_response_and_task_history():
+def test_validation_failure_preserves_response_and_task_history(tmp_path):
     question = QuestionBudget(
         question_name="budget",
         question_text="Allocate the budget.",
@@ -43,6 +43,17 @@ def test_validation_failure_preserves_response_and_task_history():
     assert round_tripped[0]["generated_tokens"] == result["generated_tokens"]
     assert round_tripped[0]["raw_model_response"] == result["raw_model_response"]
     assert round_tripped.has_unfixed_exceptions
+
+    package_path = tmp_path / "validation-failure-results.ep"
+    results.git.save(package_path)
+    package_round_tripped = Results.git.load(package_path)
+    assert package_round_tripped.has_unfixed_exceptions
+    assert len(package_round_tripped.task_history.exceptions) == 1
+    assert package_round_tripped[0]["generated_tokens"] == result["generated_tokens"]
+    assert package_round_tripped[0]["raw_model_response"] == result[
+        "raw_model_response"
+    ]
+    assert package_round_tripped[0]["validated_dict"]["budget_validated"] is False
 
 
 def test_failure_propagation_blocks_converging_dag_nodes_once():


### PR DESCRIPTION
Fixes #2598
Fixes #2600

## Summary
- capture provider response metadata before question validation
- persist metadata-bearing failed answers with `validated=False`
- reconstruct Runner failures into `Results.task_history` for accurate CLI status
- retain metadata-bearing validation results in the legacy interview path
- implement #2600 Option A: add a counted task-history section to Results inline JSONL
- preserve exception details, response context, and fixed/unfixed state across JSONL and `.ep` round trips
- keep older JSONL/`.ep` packages without task-history sections loadable
- mark the evolved inline format as version 2 and explicitly encode empty histories

## Tests
- `pytest -q --confcutdir=tests/results tests/results/test_results_git.py tests/runner/test_failure_propagation.py` (15 passed)
- focused Ruff checks passed
- `python -m compileall -q edsl/results edsl/tasks`
- `git diff --check`