### PR TITLE
Add respondent transcript view to Results HTML

### DIFF
--- a/edsl/base/collection_html_renderer.py
+++ b/edsl/base/collection_html_renderer.py
@@ -60,6 +60,17 @@ EXTRA_CSS = """
 .context-fields { display: grid; grid-template-columns: max-content minmax(140px, 1fr); gap: 5px 14px; }
 .context-key { color: var(--muted); font-size: 12px; font-weight: 700; }
 .context-value { white-space: pre-wrap; overflow-wrap: anywhere; }
+.scenario-token { padding: 1px 4px; border-radius: 4px; background: #fff0d9; color: #8a4b08; }
+th.column-agent { background: #eef6ff; color: #245b91; }
+th.column-scenario { background: #fff4e5; color: #8a4b08; }
+td.column-agent { background: #f8fbff; }
+td.column-scenario { background: #fffbf5; }
+.interview-link { border: 1px solid var(--line); border-radius: 999px; padding: 5px 9px; background: var(--panel); color: var(--accent); cursor: pointer; white-space: nowrap; }
+.dimension-nav { display: flex; align-items: center; gap: 5px; padding: 5px; border: 1px solid var(--line); border-radius: 9px; background: var(--panel); }
+.dimension-label { margin: 0 4px; color: var(--muted); font-size: 11px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.dimension-value { min-width: 90px; max-width: 210px; overflow: hidden; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
+.dimension-nav.agent { border-color: #bfd8f2; background: #f8fbff; }
+.dimension-nav.scenario { border-color: #efd5aa; background: #fffbf5; }
 .transcript-question { padding: 18px; margin-bottom: 14px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
 .transcript-question-name { color: var(--muted); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
 .transcript-question-text { margin: 5px 0 14px; font-size: 17px; font-weight: 700; }
@@ -138,12 +149,7 @@ BODY_HTML = f"""
   </section>
 
   <section class="transcript-panel" id="transcript-panel" hidden>
-    <div class="transcript-toolbar">
-      <button class="btn" id="transcript-prev" type="button">Previous</button>
-      <select id="transcript-select" aria-label="Choose a result"></select>
-      <span class="transcript-counter" id="transcript-counter"></span>
-      <button class="btn" id="transcript-next" type="button">Next</button>
-    </div>
+    <div class="transcript-toolbar" id="transcript-toolbar"></div>
     <div id="transcript-content"></div>
   </section>
 
@@ -193,10 +199,6 @@ function renderFacts() {
 function initTranscript() {
   if (!Array.isArray(DATA.transcript_rows)) return;
   document.getElementById("view-tabs").hidden = false;
-  const select = document.getElementById("transcript-select");
-  select.innerHTML = DATA.transcript_rows.map((row, index) =>
-    `<option value="${index}">${escapeHtml(row.index)} · ${escapeHtml(row.label)}</option>`
-  ).join("");
   renderTranscript();
 }
 
@@ -213,20 +215,91 @@ function renderTranscript() {
   const content = document.getElementById("transcript-content");
   if (!rows.length) {
     content.innerHTML = '<div class="empty">No results.</div>';
-    document.getElementById("transcript-counter").textContent = "0 of 0";
+    document.getElementById("transcript-toolbar").innerHTML = "0 results";
     return;
   }
   const row = rows[state.transcriptIndex];
-  document.getElementById("transcript-select").value = String(state.transcriptIndex);
-  document.getElementById("transcript-counter").textContent = `${state.transcriptIndex + 1} of ${rows.length}`;
-  document.getElementById("transcript-prev").disabled = state.transcriptIndex === 0;
-  document.getElementById("transcript-next").disabled = state.transcriptIndex === rows.length - 1;
+  renderTranscriptToolbar(row);
   content.innerHTML = `${metadataHtml(row)}${(row.questions || []).map(question => `
     <article class="transcript-question">
       <div class="transcript-question-name">${escapeHtml(question.name)}</div>
-      <div class="transcript-question-text">${escapeHtml(question.text || question.name)}</div>
+      <div class="transcript-question-text">${questionTextHtml(question.text || question.name, row.scenario)}</div>
       <div class="transcript-answer">${answerHtml(question.answer)}</div>
     </article>`).join("") || '<div class="empty">No answers.</div>'}`;
+}
+
+function renderTranscriptToolbar(row) {
+  const dimensions = [
+    ["agent", row.label],
+    ["scenario", contextLabel(row.scenario, `Scenario ${row.index}`)],
+    ["model", row.model || "NA"],
+    ["response", `${state.transcriptIndex + 1} of ${(DATA.transcript_rows || []).length}`],
+  ];
+  document.getElementById("transcript-toolbar").innerHTML = dimensions.map(([field, value]) => `
+    <div class="dimension-nav ${field}">
+      <span class="dimension-label">${field}</span>
+      <button class="btn" type="button" data-dimension="${field}" data-direction="-1" aria-label="Previous ${field}">‹</button>
+      <span class="dimension-value" title="${escapeHtml(value)}">${escapeHtml(value)}</span>
+      <button class="btn" type="button" data-dimension="${field}" data-direction="1" aria-label="Next ${field}">›</button>
+    </div>`).join("");
+}
+
+function contextLabel(value, fallback) {
+  if (!value || typeof value !== "object") return text(value) || fallback;
+  return text(value.name || value.title || value.product || value.label) || fallback;
+}
+
+function dimensionKey(row, field) {
+  if (field === "response") return String(row.index);
+  if (field === "agent") return JSON.stringify(row.agent);
+  return JSON.stringify(row[field]);
+}
+
+function navigateDimension(field, direction) {
+  const rows = DATA.transcript_rows || [];
+  if (!rows.length) return;
+  if (field === "response") {
+    state.transcriptIndex = (state.transcriptIndex + direction + rows.length) % rows.length;
+    renderTranscript();
+    return;
+  }
+  const unique = [];
+  rows.forEach(row => {
+    const key = dimensionKey(row, field);
+    if (!unique.includes(key)) unique.push(key);
+  });
+  const current = dimensionKey(rows[state.transcriptIndex], field);
+  const target = unique[(unique.indexOf(current) + direction + unique.length) % unique.length];
+  const otherFields = ["agent", "scenario", "model"].filter(item => item !== field);
+  const currentRow = rows[state.transcriptIndex];
+  let bestScore = -1;
+  let next = -1;
+  rows.forEach((row, index) => {
+    if (dimensionKey(row, field) !== target) return;
+    const score = otherFields.filter(item => dimensionKey(row, item) === dimensionKey(currentRow, item)).length;
+    if (score > bestScore) {
+      bestScore = score;
+      next = index;
+    }
+  });
+  if (next >= 0) state.transcriptIndex = next;
+  renderTranscript();
+}
+
+function questionTextHtml(questionText, scenario) {
+  const source = String(questionText || "");
+  const pattern = /{{\s*scenario\.([\w.-]+)\s*}}/g;
+  let html = "";
+  let cursor = 0;
+  for (const match of source.matchAll(pattern)) {
+    html += escapeHtml(source.slice(cursor, match.index));
+    const value = match[1].split(".").reduce((item, key) => item?.[key], scenario);
+    html += value === undefined
+      ? escapeHtml(match[0])
+      : `<span class="scenario-token">${escapeHtml(text(value))}</span>`;
+    cursor = match.index + match[0].length;
+  }
+  return html + escapeHtml(source.slice(cursor));
 }
 
 function metadataHtml(row) {
@@ -325,9 +398,9 @@ function renderTable() {
     return;
   }
   table.innerHTML = `
-    <thead><tr>${DATA.columns.map(col => `<th data-sort="${escapeHtml(col)}">${escapeHtml(col)}${sortArrow(col)}</th>`).join("")}</tr></thead>
+    <thead><tr>${DATA.columns.map(col => `<th class="${columnClass(col)}" data-sort="${escapeHtml(col)}">${escapeHtml(col)}${sortArrow(col)}</th>`).join("")}</tr></thead>
     <tbody>
-      ${rows.length ? rows.map(row => `<tr>${DATA.columns.map(col => cell(row[col])).join("")}</tr>`).join("") : "<tr><td class='empty' colspan='99'>No rows.</td></tr>"}
+      ${rows.length ? rows.map(row => `<tr>${DATA.columns.map(col => cell(row[col], col, row)).join("")}</tr>`).join("") : "<tr><td class='empty' colspan='99'>No rows.</td></tr>"}
     </tbody>
   `;
 }
@@ -337,12 +410,23 @@ function sortArrow(col) {
   return state.sortDir === 1 ? " ↑" : " ↓";
 }
 
-function cell(value) {
-  if (value === null || value === undefined || value === "") return "<td><span class='missing'>NA</span></td>";
-  if (hasInterviewAnswer(value)) return `<td>${answersHtml(value)}</td>`;
-  if (typeof value === "object") return `<td><div class="cell-json">${escapeHtml(JSON.stringify(value, null, 2))}</div></td>`;
-  const className = String(value).length > 80 ? "cell-json" : "value";
-  return `<td><div class="${className}">${escapeHtml(value)}</div></td>`;
+function columnClass(column) {
+  if (column.startsWith("agent.")) return "column-agent";
+  if (column.startsWith("scenario.")) return "column-scenario";
+  return "";
+}
+
+function cell(value, column, row) {
+  const groupClass = columnClass(column);
+  if (value === null || value === undefined || value === "") return `<td class="${groupClass}"><span class='missing'>NA</span></td>`;
+  if (value?.__edsl_cell_type === "interview_transcript") {
+    const count = (value.turns || []).length;
+    return `<td><button class="interview-link" type="button" data-open-transcript="${escapeHtml(row["#"])}">${fmt.format(count)}-turn interview →</button></td>`;
+  }
+  if (hasInterviewAnswer(value)) return `<td class="${groupClass}">${answersHtml(value)}</td>`;
+  if (typeof value === "object") return `<td class="${groupClass}"><div class="cell-json">${escapeHtml(JSON.stringify(value, null, 2))}</div></td>`;
+  const valueClass = String(value).length > 80 ? "cell-json" : "value";
+  return `<td class="${groupClass}"><div class="${valueClass}">${escapeHtml(value)}</div></td>`;
 }
 
 function hasInterviewAnswer(value) {
@@ -380,6 +464,14 @@ function bindEvents() {
     renderTable();
   });
   document.getElementById("collection-table").addEventListener("click", event => {
+    const transcriptLink = event.target.closest("[data-open-transcript]");
+    if (transcriptLink) {
+      const index = (DATA.transcript_rows || []).findIndex(row => String(row.index) === transcriptLink.dataset.openTranscript);
+      if (index >= 0) state.transcriptIndex = index;
+      activateView("transcript");
+      renderTranscript();
+      return;
+    }
     const th = event.target.closest("th[data-sort]");
     if (!th) return;
     const key = th.dataset.sort;
@@ -393,17 +485,10 @@ function bindEvents() {
   document.getElementById("copy-json").addEventListener("click", copyJson);
   document.getElementById("table-tab").addEventListener("click", () => activateView("table"));
   document.getElementById("transcript-tab").addEventListener("click", () => activateView("transcript"));
-  document.getElementById("transcript-select").addEventListener("change", event => {
-    state.transcriptIndex = Number(event.target.value);
-    renderTranscript();
-  });
-  document.getElementById("transcript-prev").addEventListener("click", () => {
-    state.transcriptIndex = Math.max(0, state.transcriptIndex - 1);
-    renderTranscript();
-  });
-  document.getElementById("transcript-next").addEventListener("click", () => {
-    state.transcriptIndex = Math.min((DATA.transcript_rows || []).length - 1, state.transcriptIndex + 1);
-    renderTranscript();
+  document.getElementById("transcript-toolbar").addEventListener("click", event => {
+    const button = event.target.closest("[data-dimension]");
+    if (!button) return;
+    navigateDimension(button.dataset.dimension, Number(button.dataset.direction));
   });
   document.getElementById("download-json").addEventListener("click", downloadJson);
   document.getElementById("remote-summary").addEventListener("click", event => {

--- a/edsl/base/collection_html_renderer.py
+++ b/edsl/base/collection_html_renderer.py
@@ -240,7 +240,7 @@ function renderTranscript() {
     <article class="transcript-question">
       <div class="transcript-question-name">${escapeHtml(question.name)}</div>
       <div class="transcript-question-text">${questionTextHtml(question.text || question.name, row.scenario)}</div>
-      <div class="transcript-answer">${answerHtml(question.answer)}</div>
+      <div class="transcript-answer">${answerHtml(question.answer, question.interview_turns)}</div>
     </article>`).join("") || '<div class="empty">No answers.</div>'}`;
 }
 
@@ -337,8 +337,8 @@ function contextHtml(value) {
   `).join("")}</div>`;
 }
 
-function answerHtml(answer) {
-  if (answer?.__edsl_cell_type === "interview_transcript") return interviewHtml(answer.turns || []);
+function answerHtml(answer, interviewTurns) {
+  if (Array.isArray(interviewTurns)) return interviewHtml(interviewTurns);
   if (answer === null || answer === undefined || answer === "") return '<span class="missing">NA</span>';
   return escapeHtml(typeof answer === "string" ? answer : JSON.stringify(answer, null, 2));
 }
@@ -432,10 +432,12 @@ function renderColumnPicker() {
   </label>`).join("")}`;
 }
 
-function csvCell(value) {
+function csvCell(value, column, row) {
   let output = value;
-  if (value?.__edsl_cell_type === "interview_transcript") {
-    output = (value.turns || []).map(turn => `${turn.role}: ${turn.text || ""}`).join("\n");
+  const questionName = column.startsWith("answer.") ? column.slice(7) : "";
+  const interviewTurns = row.__interview_transcripts?.[questionName];
+  if (Array.isArray(interviewTurns)) {
+    output = interviewTurns.map(turn => `${turn.role}: ${turn.text || ""}`).join("\n");
   } else if (typeof value === "object" && value !== null) output = JSON.stringify(value);
   const string = output === null || output === undefined ? "" : String(output);
   return `"${string.replaceAll('"', '""')}"`;
@@ -443,9 +445,11 @@ function csvCell(value) {
 
 function shownCsv() {
   const columns = DATA.columns.filter(column => state.visibleColumns.has(column));
-  return [columns, ...filteredRows().map(row => columns.map(column => row[column]))]
-    .map(row => row.map(csvCell).join(","))
-    .join("\n");
+  const header = columns.map(value => csvCell(value, "", {})).join(",");
+  const body = filteredRows().map(row =>
+    columns.map(column => csvCell(row[column], column, row)).join(",")
+  );
+  return [header, ...body].join("\n");
 }
 
 function sortArrow(col) {
@@ -462,30 +466,15 @@ function columnClass(column) {
 function cell(value, column, row) {
   const groupClass = columnClass(column);
   if (value === null || value === undefined || value === "") return `<td class="${groupClass}"><span class='missing'>NA</span></td>`;
-  if (value?.__edsl_cell_type === "interview_transcript") {
-    const count = (value.turns || []).length;
+  const questionName = column.startsWith("answer.") ? column.slice(7) : "";
+  const interviewTurns = row.__interview_transcripts?.[questionName];
+  if (Array.isArray(interviewTurns)) {
+    const count = interviewTurns.length;
     return `<td><button class="interview-link" type="button" data-open-transcript="${escapeHtml(row["#"])}">${fmt.format(count)}-turn interview →</button></td>`;
   }
-  if (hasInterviewAnswer(value)) return `<td class="${groupClass}">${answersHtml(value)}</td>`;
   if (typeof value === "object") return `<td class="${groupClass}"><div class="cell-json">${escapeHtml(JSON.stringify(value, null, 2))}</div></td>`;
   const valueClass = String(value).length > 80 ? "cell-json" : "value";
   return `<td class="${groupClass}"><div class="${valueClass}">${escapeHtml(value)}</div></td>`;
-}
-
-function hasInterviewAnswer(value) {
-  return value && typeof value === "object" && !Array.isArray(value)
-    && Object.values(value).some(answer => answer?.__edsl_cell_type === "interview_transcript");
-}
-
-function answersHtml(answers) {
-  return `<div class="results-answers">${Object.entries(answers).map(([name, answer]) => `
-    <section class="results-answer">
-      <div class="results-answer-name">${escapeHtml(name)}</div>
-      ${answer?.__edsl_cell_type === "interview_transcript"
-        ? interviewHtml(answer.turns || [])
-        : `<div class="cell-json">${escapeHtml(text(answer))}</div>`}
-    </section>
-  `).join("")}</div>`;
 }
 
 function interviewHtml(turns) {

--- a/edsl/base/collection_html_renderer.py
+++ b/edsl/base/collection_html_renderer.py
@@ -57,6 +57,9 @@ EXTRA_CSS = """
 .transcript-counter { color: var(--muted); font-size: 13px; }
 .transcript-meta { width: auto; margin-bottom: 18px; }
 .transcript-meta th { color: var(--muted); text-align: left; }
+.context-fields { display: grid; grid-template-columns: max-content minmax(140px, 1fr); gap: 5px 14px; }
+.context-key { color: var(--muted); font-size: 12px; font-weight: 700; }
+.context-value { white-space: pre-wrap; overflow-wrap: anywhere; }
 .transcript-question { padding: 18px; margin-bottom: 14px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
 .transcript-question-name { color: var(--muted); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
 .transcript-question-text { margin: 5px 0 14px; font-size: 17px; font-weight: 700; }
@@ -229,7 +232,21 @@ function renderTranscript() {
 function metadataHtml(row) {
   const values = [["Agent", row.agent], ["Model", row.model], ["Scenario", row.scenario], ["Iteration", row.iteration]];
   return `<table class="transcript-meta"><tbody>${values.map(([label, value]) =>
-    `<tr><th>${label}</th><td>${escapeHtml(text(value) || "NA")}</td></tr>`).join("")}</tbody></table>`;
+    `<tr><th>${label}</th><td>${contextHtml(value)}</td></tr>`).join("")}</tbody></table>`;
+}
+
+function contextHtml(value) {
+  if (value === null || value === undefined || value === "") return '<span class="missing">NA</span>';
+  if (!value || typeof value !== "object" || Array.isArray(value)) return escapeHtml(text(value));
+  const fields = value.traits && typeof value.traits === "object"
+    ? {...value.traits, ...(value.name ? {name: value.name} : {})}
+    : value;
+  const entries = Object.entries(fields);
+  if (!entries.length) return '<span class="missing">None</span>';
+  return `<div class="context-fields">${entries.map(([key, field]) => `
+    <div class="context-key">${escapeHtml(key)}</div>
+    <div class="context-value">${escapeHtml(typeof field === "string" ? field : JSON.stringify(field, null, 2))}</div>
+  `).join("")}</div>`;
 }
 
 function answerHtml(answer) {

--- a/edsl/base/collection_html_renderer.py
+++ b/edsl/base/collection_html_renderer.py
@@ -17,6 +17,8 @@ def render_collection_html(
     raw: Any,
     search_placeholder: str = "Search",
     remote_context: dict[str, Any] | None = None,
+    facts_layout: str = "cards",
+    transcript_rows: list[dict[str, Any]] | None = None,
 ) -> str:
     """Render a searchable table artifact using the shared Expected Parrot shell."""
     data = {
@@ -28,6 +30,8 @@ def render_collection_html(
         "raw": raw,
         "search_placeholder": search_placeholder,
         "remote_context": remote_context,
+        "facts_layout": facts_layout,
+        "transcript_rows": transcript_rows,
     }
     return render_standalone_html(
         title=title,
@@ -42,6 +46,21 @@ def render_collection_html(
 EXTRA_CSS = """
 .collection-panel { margin-top: 16px; }
 .collection-json { margin-top: 14px; }
+.facts-table { width: auto; margin-top: 18px; }
+.facts-table th, .facts-table td { min-width: 110px; padding: 8px 14px; text-align: center; }
+.view-tabs { display: flex; gap: 4px; margin-top: 18px; border-bottom: 1px solid var(--line); }
+.view-tab { border: 0; border-bottom: 2px solid transparent; padding: 9px 14px; background: transparent; color: var(--muted); cursor: pointer; font-weight: 700; }
+.view-tab.active { color: var(--text); border-bottom-color: var(--accent); }
+.transcript-panel { margin-top: 16px; }
+.transcript-toolbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 14px; }
+.transcript-toolbar select { min-width: 220px; padding: 8px 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--text); }
+.transcript-counter { color: var(--muted); font-size: 13px; }
+.transcript-meta { width: auto; margin-bottom: 18px; }
+.transcript-meta th { color: var(--muted); text-align: left; }
+.transcript-question { padding: 18px; margin-bottom: 14px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
+.transcript-question-name { color: var(--muted); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
+.transcript-question-text { margin: 5px 0 14px; font-size: 17px; font-weight: 700; }
+.transcript-answer { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cell-code { font-family: var(--font-mono); font-size: 12px; }
 .cell-json {
   max-width: 520px;
@@ -50,6 +69,36 @@ EXTRA_CSS = """
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+.results-answers { min-width: 320px; display: grid; gap: 12px; }
+.results-answer-name {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+.interview-transcript { display: grid; gap: 8px; }
+.interview-turn {
+  max-width: 88%;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+}
+.interview-turn.respondent {
+  justify-self: end;
+  background: var(--accent-soft);
+  border-color: var(--line-strong);
+}
+.interview-role {
+  margin-bottom: 3px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.interview-text { white-space: pre-wrap; overflow-wrap: anywhere; }
 """
 
 
@@ -69,9 +118,13 @@ BODY_HTML = f"""
     </div>
     <div class="facts" id="facts"></div>
     <div class="notice" id="remote-summary"></div>
+    <nav class="view-tabs" id="view-tabs" hidden>
+      <button class="view-tab active" id="table-tab" type="button">Table</button>
+      <button class="view-tab" id="transcript-tab" type="button">Transcript</button>
+    </nav>
   </header>
 
-  <section class="panel collection-panel">
+  <section class="panel collection-panel" id="table-panel">
     <div class="toolbar">
       <input class="search" id="search" type="search">
       <span class="muted" id="visible-count"></span>
@@ -79,6 +132,16 @@ BODY_HTML = f"""
     <div class="table-wrap">
       <table id="collection-table"></table>
     </div>
+  </section>
+
+  <section class="transcript-panel" id="transcript-panel" hidden>
+    <div class="transcript-toolbar">
+      <button class="btn" id="transcript-prev" type="button">Previous</button>
+      <select id="transcript-select" aria-label="Choose a result"></select>
+      <span class="transcript-counter" id="transcript-counter"></span>
+      <button class="btn" id="transcript-next" type="button">Next</button>
+    </div>
+    <div id="transcript-content"></div>
   </section>
 
   <details class="collection-json">
@@ -91,7 +154,7 @@ BODY_HTML = f"""
 
 
 SCRIPT = r"""
-const state = { query: "", sortKey: DATA.columns[0] || "", sortDir: 1 };
+const state = { query: "", sortKey: DATA.columns[0] || "", sortDir: 1, transcriptIndex: 0 };
 const fmt = new Intl.NumberFormat();
 const escapeHtml = value => String(value)
   .replaceAll("&", "&amp;")
@@ -109,13 +172,70 @@ function init() {
   document.getElementById("title").textContent = DATA.title;
   document.getElementById("subtitle").textContent = DATA.subtitle || "";
   document.getElementById("search").placeholder = DATA.search_placeholder || "Search";
-  document.getElementById("facts").innerHTML = DATA.facts.map(fact => `
-    <span class="fact"><strong>${escapeHtml(fact.value)}</strong>${escapeHtml(fact.label)}</span>
-  `).join("");
+  renderFacts();
   document.getElementById("raw-json").textContent = JSON.stringify(DATA.raw, null, 2);
   renderRemoteSummary();
   bindEvents();
   renderTable();
+  initTranscript();
+}
+
+function renderFacts() {
+  const facts = DATA.facts || [];
+  document.getElementById("facts").innerHTML = DATA.facts_layout === "table"
+    ? `<table class="facts-table"><thead><tr>${facts.map(f => `<th>${escapeHtml(f.label)}</th>`).join("")}</tr></thead><tbody><tr>${facts.map(f => `<td>${escapeHtml(f.value)}</td>`).join("")}</tr></tbody></table>`
+    : facts.map(fact => `<span class="fact"><strong>${escapeHtml(fact.value)}</strong>${escapeHtml(fact.label)}</span>`).join("");
+}
+
+function initTranscript() {
+  if (!Array.isArray(DATA.transcript_rows)) return;
+  document.getElementById("view-tabs").hidden = false;
+  const select = document.getElementById("transcript-select");
+  select.innerHTML = DATA.transcript_rows.map((row, index) =>
+    `<option value="${index}">${escapeHtml(row.index)} · ${escapeHtml(row.label)}</option>`
+  ).join("");
+  renderTranscript();
+}
+
+function activateView(view) {
+  const transcript = view === "transcript";
+  document.getElementById("table-panel").hidden = transcript;
+  document.getElementById("transcript-panel").hidden = !transcript;
+  document.getElementById("table-tab").classList.toggle("active", !transcript);
+  document.getElementById("transcript-tab").classList.toggle("active", transcript);
+}
+
+function renderTranscript() {
+  const rows = DATA.transcript_rows || [];
+  const content = document.getElementById("transcript-content");
+  if (!rows.length) {
+    content.innerHTML = '<div class="empty">No results.</div>';
+    document.getElementById("transcript-counter").textContent = "0 of 0";
+    return;
+  }
+  const row = rows[state.transcriptIndex];
+  document.getElementById("transcript-select").value = String(state.transcriptIndex);
+  document.getElementById("transcript-counter").textContent = `${state.transcriptIndex + 1} of ${rows.length}`;
+  document.getElementById("transcript-prev").disabled = state.transcriptIndex === 0;
+  document.getElementById("transcript-next").disabled = state.transcriptIndex === rows.length - 1;
+  content.innerHTML = `${metadataHtml(row)}${(row.questions || []).map(question => `
+    <article class="transcript-question">
+      <div class="transcript-question-name">${escapeHtml(question.name)}</div>
+      <div class="transcript-question-text">${escapeHtml(question.text || question.name)}</div>
+      <div class="transcript-answer">${answerHtml(question.answer)}</div>
+    </article>`).join("") || '<div class="empty">No answers.</div>'}`;
+}
+
+function metadataHtml(row) {
+  const values = [["Agent", row.agent], ["Model", row.model], ["Scenario", row.scenario], ["Iteration", row.iteration]];
+  return `<table class="transcript-meta"><tbody>${values.map(([label, value]) =>
+    `<tr><th>${label}</th><td>${escapeHtml(text(value) || "NA")}</td></tr>`).join("")}</tbody></table>`;
+}
+
+function answerHtml(answer) {
+  if (answer?.__edsl_cell_type === "interview_transcript") return interviewHtml(answer.turns || []);
+  if (answer === null || answer === undefined || answer === "") return '<span class="missing">NA</span>';
+  return escapeHtml(typeof answer === "string" ? answer : JSON.stringify(answer, null, 2));
 }
 
 function renderRemoteSummary() {
@@ -202,9 +322,39 @@ function sortArrow(col) {
 
 function cell(value) {
   if (value === null || value === undefined || value === "") return "<td><span class='missing'>NA</span></td>";
+  if (hasInterviewAnswer(value)) return `<td>${answersHtml(value)}</td>`;
   if (typeof value === "object") return `<td><div class="cell-json">${escapeHtml(JSON.stringify(value, null, 2))}</div></td>`;
   const className = String(value).length > 80 ? "cell-json" : "value";
   return `<td><div class="${className}">${escapeHtml(value)}</div></td>`;
+}
+
+function hasInterviewAnswer(value) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    && Object.values(value).some(answer => answer?.__edsl_cell_type === "interview_transcript");
+}
+
+function answersHtml(answers) {
+  return `<div class="results-answers">${Object.entries(answers).map(([name, answer]) => `
+    <section class="results-answer">
+      <div class="results-answer-name">${escapeHtml(name)}</div>
+      ${answer?.__edsl_cell_type === "interview_transcript"
+        ? interviewHtml(answer.turns || [])
+        : `<div class="cell-json">${escapeHtml(text(answer))}</div>`}
+    </section>
+  `).join("")}</div>`;
+}
+
+function interviewHtml(turns) {
+  if (!turns.length) return '<span class="missing">No transcript turns</span>';
+  return `<div class="interview-transcript">${turns.map(turn => {
+    const role = turn.role === "respondent" ? "respondent" : "interviewer";
+    const label = turn.role || "unknown";
+    const message = turn.text || "(non-text content)";
+    return `<div class="interview-turn ${role}">
+      <div class="interview-role">${escapeHtml(label)}</div>
+      <div class="interview-text">${escapeHtml(message)}</div>
+    </div>`;
+  }).join("")}</div>`;
 }
 
 function bindEvents() {
@@ -224,6 +374,20 @@ function bindEvents() {
     renderTable();
   });
   document.getElementById("copy-json").addEventListener("click", copyJson);
+  document.getElementById("table-tab").addEventListener("click", () => activateView("table"));
+  document.getElementById("transcript-tab").addEventListener("click", () => activateView("transcript"));
+  document.getElementById("transcript-select").addEventListener("change", event => {
+    state.transcriptIndex = Number(event.target.value);
+    renderTranscript();
+  });
+  document.getElementById("transcript-prev").addEventListener("click", () => {
+    state.transcriptIndex = Math.max(0, state.transcriptIndex - 1);
+    renderTranscript();
+  });
+  document.getElementById("transcript-next").addEventListener("click", () => {
+    state.transcriptIndex = Math.min((DATA.transcript_rows || []).length - 1, state.transcriptIndex + 1);
+    renderTranscript();
+  });
   document.getElementById("download-json").addEventListener("click", downloadJson);
   document.getElementById("remote-summary").addEventListener("click", event => {
     const button = event.target.closest("[data-copy]");

--- a/edsl/base/collection_html_renderer.py
+++ b/edsl/base/collection_html_renderer.py
@@ -71,6 +71,10 @@ td.column-scenario { background: #fffbf5; }
 .dimension-value { min-width: 90px; max-width: 210px; overflow: hidden; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
 .dimension-nav.agent { border-color: #bfd8f2; background: #f8fbff; }
 .dimension-nav.scenario { border-color: #efd5aa; background: #fffbf5; }
+.column-picker { position: relative; }
+.column-picker-panel { position: absolute; z-index: 10; right: 0; top: calc(100% + 6px); width: 270px; max-height: 360px; overflow: auto; padding: 10px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); box-shadow: 0 10px 30px rgba(0,0,0,.12); }
+.column-picker-actions { display: flex; gap: 6px; margin-bottom: 8px; }
+.column-option { display: flex; align-items: center; gap: 8px; padding: 5px 3px; font-family: var(--font-mono); font-size: 12px; }
 .transcript-question { padding: 18px; margin-bottom: 14px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
 .transcript-question-name { color: var(--muted); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
 .transcript-question-text { margin: 5px 0 14px; font-size: 17px; font-weight: 700; }
@@ -142,6 +146,11 @@ BODY_HTML = f"""
     <div class="toolbar">
       <input class="search" id="search" type="search">
       <span class="muted" id="visible-count"></span>
+      <div class="column-picker">
+        <button class="btn" id="columns-button" type="button">Columns</button>
+        <div class="column-picker-panel" id="columns-panel" hidden></div>
+      </div>
+      <button class="btn" id="copy-csv" type="button">Copy shown CSV</button>
     </div>
     <div class="table-wrap">
       <table id="collection-table"></table>
@@ -163,7 +172,13 @@ BODY_HTML = f"""
 
 
 SCRIPT = r"""
-const state = { query: "", sortKey: DATA.columns[0] || "", sortDir: 1, transcriptIndex: 0 };
+const state = {
+  query: "",
+  sortKey: DATA.columns[0] || "",
+  sortDir: 1,
+  transcriptIndex: 0,
+  visibleColumns: new Set(DATA.columns || []),
+};
 const fmt = new Intl.NumberFormat();
 const escapeHtml = value => String(value)
   .replaceAll("&", "&amp;")
@@ -186,6 +201,7 @@ function init() {
   renderRemoteSummary();
   bindEvents();
   renderTable();
+  renderColumnPicker();
   initTranscript();
 }
 
@@ -233,13 +249,13 @@ function renderTranscriptToolbar(row) {
     ["agent", row.label],
     ["scenario", contextLabel(row.scenario, `Scenario ${row.index}`)],
     ["model", row.model || "NA"],
-    ["response", `${state.transcriptIndex + 1} of ${(DATA.transcript_rows || []).length}`],
+    ["iteration", String(row.iteration ?? 0)],
   ];
   document.getElementById("transcript-toolbar").innerHTML = dimensions.map(([field, value]) => `
     <div class="dimension-nav ${field}">
       <span class="dimension-label">${field}</span>
       <button class="btn" type="button" data-dimension="${field}" data-direction="-1" aria-label="Previous ${field}">‹</button>
-      <span class="dimension-value" title="${escapeHtml(value)}">${escapeHtml(value)}</span>
+      <span class="dimension-value" title="${escapeHtml(value)}">${escapeHtml(value)} <span class="muted">${dimensionPosition(row, field)}</span></span>
       <button class="btn" type="button" data-dimension="${field}" data-direction="1" aria-label="Next ${field}">›</button>
     </div>`).join("");
 }
@@ -250,38 +266,37 @@ function contextLabel(value, fallback) {
 }
 
 function dimensionKey(row, field) {
-  if (field === "response") return String(row.index);
   if (field === "agent") return JSON.stringify(row.agent);
   return JSON.stringify(row[field]);
+}
+
+function dimensionValues(field) {
+  const unique = [];
+  (DATA.transcript_rows || []).forEach(row => {
+    const key = dimensionKey(row, field);
+    if (!unique.includes(key)) unique.push(key);
+  });
+  return unique;
+}
+
+function dimensionPosition(row, field) {
+  const values = dimensionValues(field);
+  return `${values.indexOf(dimensionKey(row, field)) + 1}/${values.length}`;
 }
 
 function navigateDimension(field, direction) {
   const rows = DATA.transcript_rows || [];
   if (!rows.length) return;
-  if (field === "response") {
-    state.transcriptIndex = (state.transcriptIndex + direction + rows.length) % rows.length;
-    renderTranscript();
-    return;
-  }
-  const unique = [];
-  rows.forEach(row => {
-    const key = dimensionKey(row, field);
-    if (!unique.includes(key)) unique.push(key);
-  });
+  const unique = dimensionValues(field);
   const current = dimensionKey(rows[state.transcriptIndex], field);
   const target = unique[(unique.indexOf(current) + direction + unique.length) % unique.length];
   const otherFields = ["agent", "scenario", "model"].filter(item => item !== field);
+  if (field !== "iteration") otherFields.push("iteration");
   const currentRow = rows[state.transcriptIndex];
-  let bestScore = -1;
-  let next = -1;
-  rows.forEach((row, index) => {
-    if (dimensionKey(row, field) !== target) return;
-    const score = otherFields.filter(item => dimensionKey(row, item) === dimensionKey(currentRow, item)).length;
-    if (score > bestScore) {
-      bestScore = score;
-      next = index;
-    }
-  });
+  const next = rows.findIndex(row =>
+    dimensionKey(row, field) === target
+    && otherFields.every(item => dimensionKey(row, item) === dimensionKey(currentRow, item))
+  );
   if (next >= 0) state.transcriptIndex = next;
   renderTranscript();
 }
@@ -392,17 +407,45 @@ function filteredRows() {
 function renderTable() {
   const table = document.getElementById("collection-table");
   const rows = filteredRows();
+  const columns = DATA.columns.filter(column => state.visibleColumns.has(column));
   document.getElementById("visible-count").textContent = `${fmt.format(rows.length)} of ${fmt.format((DATA.rows || []).length)} visible`;
-  if (!DATA.columns.length) {
+  if (!columns.length) {
     table.innerHTML = "<tbody><tr><td class='empty'>No columns.</td></tr></tbody>";
     return;
   }
   table.innerHTML = `
-    <thead><tr>${DATA.columns.map(col => `<th class="${columnClass(col)}" data-sort="${escapeHtml(col)}">${escapeHtml(col)}${sortArrow(col)}</th>`).join("")}</tr></thead>
+    <thead><tr>${columns.map(col => `<th class="${columnClass(col)}" data-sort="${escapeHtml(col)}">${escapeHtml(col)}${sortArrow(col)}</th>`).join("")}</tr></thead>
     <tbody>
-      ${rows.length ? rows.map(row => `<tr>${DATA.columns.map(col => cell(row[col], col, row)).join("")}</tr>`).join("") : "<tr><td class='empty' colspan='99'>No rows.</td></tr>"}
+      ${rows.length ? rows.map(row => `<tr>${columns.map(col => cell(row[col], col, row)).join("")}</tr>`).join("") : "<tr><td class='empty' colspan='99'>No rows.</td></tr>"}
     </tbody>
   `;
+}
+
+function renderColumnPicker() {
+  const panel = document.getElementById("columns-panel");
+  panel.innerHTML = `<div class="column-picker-actions">
+    <button class="btn" type="button" data-columns="all">All</button>
+    <button class="btn" type="button" data-columns="none">None</button>
+  </div>${DATA.columns.map(column => `<label class="column-option">
+    <input type="checkbox" data-column="${escapeHtml(column)}" ${state.visibleColumns.has(column) ? "checked" : ""}>
+    ${escapeHtml(column)}
+  </label>`).join("")}`;
+}
+
+function csvCell(value) {
+  let output = value;
+  if (value?.__edsl_cell_type === "interview_transcript") {
+    output = (value.turns || []).map(turn => `${turn.role}: ${turn.text || ""}`).join("\n");
+  } else if (typeof value === "object" && value !== null) output = JSON.stringify(value);
+  const string = output === null || output === undefined ? "" : String(output);
+  return `"${string.replaceAll('"', '""')}"`;
+}
+
+function shownCsv() {
+  const columns = DATA.columns.filter(column => state.visibleColumns.has(column));
+  return [columns, ...filteredRows().map(row => columns.map(column => row[column]))]
+    .map(row => row.map(csvCell).join(","))
+    .join("\n");
 }
 
 function sortArrow(col) {
@@ -483,6 +526,30 @@ function bindEvents() {
     renderTable();
   });
   document.getElementById("copy-json").addEventListener("click", copyJson);
+  document.getElementById("columns-button").addEventListener("click", () => {
+    const panel = document.getElementById("columns-panel");
+    panel.hidden = !panel.hidden;
+  });
+  document.getElementById("columns-panel").addEventListener("change", event => {
+    const column = event.target.dataset.column;
+    if (!column) return;
+    if (event.target.checked) state.visibleColumns.add(column);
+    else state.visibleColumns.delete(column);
+    renderTable();
+  });
+  document.getElementById("columns-panel").addEventListener("click", event => {
+    const action = event.target.dataset.columns;
+    if (!action) return;
+    state.visibleColumns = new Set(action === "all" ? DATA.columns : []);
+    renderColumnPicker();
+    renderTable();
+  });
+  document.getElementById("copy-csv").addEventListener("click", () => {
+    navigator.clipboard?.writeText(shownCsv()).then(
+      () => showToast("Shown CSV copied"),
+      () => showToast("Clipboard blocked by browser")
+    );
+  });
   document.getElementById("table-tab").addEventListener("click", () => activateView("table"));
   document.getElementById("transcript-tab").addEventListener("click", () => activateView("transcript"));
   document.getElementById("transcript-toolbar").addEventListener("click", event => {

--- a/edsl/results/results_git.py
+++ b/edsl/results/results_git.py
@@ -233,6 +233,7 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
         or []
     )
     rows = [_result_row(index, result) for index, result in enumerate(results, start=1)]
+    columns = _result_columns(rows)
     transcript_rows = [
         _transcript_row(index, result, question_names)
         for index, result in enumerate(results, start=1)
@@ -247,7 +248,7 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
             (len(getattr(results, "agent_keys", []) or []), "Agent keys"),
             (len(getattr(results, "model_keys", []) or []), "Model keys"),
         ],
-        columns=["#", "agent", "model", "scenario", "answers"],
+        columns=columns,
         rows=rows,
         raw={"manifest": manifest, "results": serialized_results},
         search_placeholder="Search agents, models, scenarios, answers",
@@ -261,13 +262,53 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
 
 def _result_row(index: int, result: object) -> dict:
     data = _result_dict(result)
-    return {
+    row = {
         "#": index,
-        "agent": _compact_json(data.get("agent")),
-        "model": _model_label(data.get("model")),
-        "scenario": _compact_json(data.get("scenario")),
-        "answers": _display_answers(data),
     }
+    row.update(_flatten_context("agent", data.get("agent"), unwrap_traits=True))
+    row["model"] = _model_label(data.get("model"))
+    row.update(_flatten_context("scenario", data.get("scenario")))
+    row.update(
+        {f"answer.{name}": answer for name, answer in _display_answers(data).items()}
+    )
+    return row
+
+
+def _flatten_context(
+    prefix: str, value: object, *, unwrap_traits: bool = False
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {prefix: value}
+    fields = value
+    if unwrap_traits and isinstance(value.get("traits"), dict):
+        fields = {**value["traits"]}
+        if value.get("name") is not None:
+            fields["name"] = value["name"]
+    return {f"{prefix}.{key}": field for key, field in fields.items()}
+
+
+def _result_columns(rows: list[dict]) -> list[str]:
+    groups = ("agent.", "scenario.")
+    columns = ["#"]
+    for prefix in groups:
+        columns.extend(
+            key
+            for row in rows
+            for key in row
+            if key.startswith(prefix) and key not in columns
+        )
+    if any("agent" in row for row in rows):
+        columns.append("agent")
+    columns.append("model")
+    if any("scenario" in row for row in rows):
+        columns.append("scenario")
+    columns.extend(
+        key
+        for row in rows
+        for key in row
+        if key.startswith("answer.") and key not in columns
+    )
+    return columns
 
 
 def _transcript_row(index: int, result: object, question_names: list[str]) -> dict:

--- a/edsl/results/results_git.py
+++ b/edsl/results/results_git.py
@@ -226,7 +226,12 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
     manifest = _load_manifest_at_ref(path, ref)
     raw = results.to_dict(add_edsl_version=False)
     serialized_results = raw.get("data") or raw.get("results") or []
-    question_names = list(getattr(results, "question_names", []) or [])
+    survey = getattr(results, "survey", None)
+    question_names = list(
+        getattr(survey, "question_names", None)
+        or getattr(results, "question_names", [])
+        or []
+    )
     rows = [_result_row(index, result) for index, result in enumerate(results, start=1)]
     transcript_rows = [
         _transcript_row(index, result, question_names)

--- a/edsl/results/results_git.py
+++ b/edsl/results/results_git.py
@@ -262,15 +262,22 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
 
 def _result_row(index: int, result: object) -> dict:
     data = _result_dict(result)
+    answers = data.get("answer") or data.get("answers") or {}
+    attributes = data.get("question_to_attributes") or {}
+    answers = answers if isinstance(answers, dict) else {}
     row = {
         "#": index,
+        "__interview_transcripts": {
+            name: turns
+            for name, answer in answers.items()
+            if (turns := _question_interview_turns(name, answer, attributes))
+            is not None
+        },
     }
     row.update(_flatten_context("agent", data.get("agent"), unwrap_traits=True))
     row["model"] = _model_label(data.get("model"))
     row.update(_flatten_context("scenario", data.get("scenario")))
-    row.update(
-        {f"answer.{name}": answer for name, answer in _display_answers(data).items()}
-    )
+    row.update({f"answer.{name}": answer for name, answer in answers.items()})
     return row
 
 
@@ -330,7 +337,10 @@ def _transcript_row(index: int, result: object, question_names: list[str]) -> di
             {
                 "name": name,
                 "text": (attributes.get(name) or {}).get("question_text") or name,
-                "answer": _display_answer(name, answers.get(name), attributes),
+                "answer": answers.get(name),
+                "interview_turns": _question_interview_turns(
+                    name, answers.get(name), attributes
+                ),
             }
             for name in ordered_names
             if name in answers
@@ -348,29 +358,13 @@ def _result_label(index: int, agent: object) -> str:
     return f"Result {index}"
 
 
-def _display_answers(data: dict) -> dict:
-    """Mark valid QuestionInterview answers for transcript-aware HTML rendering."""
-    answers = data.get("answer") or data.get("answers") or {}
-    attributes = data.get("question_to_attributes") or {}
-    if not isinstance(answers, dict):
-        return answers
-
-    return {
-        question_name: _display_answer(question_name, answer, attributes)
-        for question_name, answer in answers.items()
-    }
-
-
-def _display_answer(question_name: str, answer: object, attributes: dict) -> object:
+def _question_interview_turns(
+    question_name: str, answer: object, attributes: dict
+) -> list[dict[str, str]] | None:
     question_attributes = attributes.get(question_name) or {}
     if question_attributes.get("question_type") == "interview":
-        turns = _interview_turns(answer)
-        if turns is not None:
-            return {
-                "__edsl_cell_type": "interview_transcript",
-                "turns": turns,
-            }
-    return answer
+        return _interview_turns(answer)
+    return None
 
 
 def _interview_turns(answer: object) -> list[dict[str, str]] | None:

--- a/edsl/results/results_git.py
+++ b/edsl/results/results_git.py
@@ -226,22 +226,28 @@ def _render_results_package_html(path: Path, ref: str, results: "Results") -> st
     manifest = _load_manifest_at_ref(path, ref)
     raw = results.to_dict(add_edsl_version=False)
     serialized_results = raw.get("data") or raw.get("results") or []
-    rows = [_result_row(index, result) for index, result in enumerate(results, start=1)]
     question_names = list(getattr(results, "question_names", []) or [])
+    rows = [_result_row(index, result) for index, result in enumerate(results, start=1)]
+    transcript_rows = [
+        _transcript_row(index, result, question_names)
+        for index, result in enumerate(results, start=1)
+    ]
 
     return render_collection_html(
-        title="EDSL Results",
+        title="Results",
         subtitle=f"{path.name} · {ref}",
         facts=[
-            (len(results), "results"),
-            (len(question_names), "questions"),
-            (len(getattr(results, "agent_keys", []) or []), "agent keys"),
-            (len(getattr(results, "model_keys", []) or []), "model keys"),
+            (len(results), "Results"),
+            (len(question_names), "Questions"),
+            (len(getattr(results, "agent_keys", []) or []), "Agent keys"),
+            (len(getattr(results, "model_keys", []) or []), "Model keys"),
         ],
         columns=["#", "agent", "model", "scenario", "answers"],
         rows=rows,
         raw={"manifest": manifest, "results": serialized_results},
         search_placeholder="Search agents, models, scenarios, answers",
+        facts_layout="table",
+        transcript_rows=transcript_rows,
         remote_context=package_remote_context(
             path, ref, manifest=manifest, error_cls=ResultsGitError
         ),
@@ -255,8 +261,93 @@ def _result_row(index: int, result: object) -> dict:
         "agent": _compact_json(data.get("agent")),
         "model": _model_label(data.get("model")),
         "scenario": _compact_json(data.get("scenario")),
-        "answers": data.get("answer") or data.get("answers") or {},
+        "answers": _display_answers(data),
     }
+
+
+def _transcript_row(index: int, result: object, question_names: list[str]) -> dict:
+    data = _result_dict(result)
+    answers = data.get("answer") or data.get("answers") or {}
+    attributes = data.get("question_to_attributes") or {}
+    answers = answers if isinstance(answers, dict) else {}
+    ordered_names = list(question_names)
+    ordered_names.extend(name for name in answers if name not in ordered_names)
+    agent = data.get("agent")
+    return {
+        "index": index,
+        "label": _result_label(index, agent),
+        "agent": _compact_json(agent),
+        "model": _model_label(data.get("model")),
+        "scenario": _compact_json(data.get("scenario")),
+        "iteration": data.get("iteration"),
+        "questions": [
+            {
+                "name": name,
+                "text": (attributes.get(name) or {}).get("question_text") or name,
+                "answer": _display_answer(name, answers.get(name), attributes),
+            }
+            for name in ordered_names
+            if name in answers
+        ],
+    }
+
+
+def _result_label(index: int, agent: object) -> str:
+    if isinstance(agent, dict):
+        name = agent.get("name")
+        traits = agent.get("traits") or {}
+        name = name or (traits.get("agent_name") if isinstance(traits, dict) else None)
+        if name:
+            return str(name)
+    return f"Result {index}"
+
+
+def _display_answers(data: dict) -> dict:
+    """Mark valid QuestionInterview answers for transcript-aware HTML rendering."""
+    answers = data.get("answer") or data.get("answers") or {}
+    attributes = data.get("question_to_attributes") or {}
+    if not isinstance(answers, dict):
+        return answers
+
+    return {
+        question_name: _display_answer(question_name, answer, attributes)
+        for question_name, answer in answers.items()
+    }
+
+
+def _display_answer(question_name: str, answer: object, attributes: dict) -> object:
+    question_attributes = attributes.get(question_name) or {}
+    if question_attributes.get("question_type") == "interview":
+        turns = _interview_turns(answer)
+        if turns is not None:
+            return {
+                "__edsl_cell_type": "interview_transcript",
+                "turns": turns,
+            }
+    return answer
+
+
+def _interview_turns(answer: object) -> list[dict[str, str]] | None:
+    """Normalize the public text blocks in an interview answer, or decline it."""
+    if not isinstance(answer, list):
+        return None
+
+    turns: list[dict[str, str]] = []
+    for turn in answer:
+        if not isinstance(turn, dict) or not isinstance(turn.get("role"), str):
+            return None
+        content = turn.get("content")
+        if not isinstance(content, list):
+            return None
+        text = "\n".join(
+            str(block["text"])
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        )
+        turns.append({"role": turn["role"], "text": text})
+    return turns
 
 
 def _result_dict(result: object) -> dict:

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -250,6 +250,10 @@ def test_results_git_package_html(tmp_path):
     assert 'class="${columnClass(col)}"' in html
     assert 'class="interview-link"' in html
     assert '"answer.how_feeling"' in html
+    assert 'id="columns-button"' in html
+    assert 'id="copy-csv"' in html
+    assert "function shownCsv()" in html
+    assert "dimensionPosition(row, field)" in html
     assert html_path.read_text(encoding="utf-8") == html
 
 

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 
 from edsl.results import Results, ResultsGitError, ResultsGitNestedRepoWarning
+from edsl import Agent, Model, QuestionInterview, Scenario, Survey
+from edsl.results import Result
 from edsl.results.exceptions import ResultsError
 from edsl.base.base_exception import BaseException as EDSLBaseException
 from edsl.tasks import TaskHistory
@@ -215,7 +217,8 @@ def test_results_git_package_html(tmp_path):
 
     html = Results.git.open(package_path).html(filename=html_path)
 
-    assert "<title>EDSL Results</title>" in html
+    assert "<title>Results</title>" in html
+    assert "<title>EDSL Results</title>" not in html
     assert "Expected Parrot" in html
     assert "Expected Parrot Server" in html
     assert "remote-meta" in html
@@ -233,7 +236,85 @@ def test_results_git_package_html(tmp_path):
     assert 'target="_blank"' in html
     assert "collection-table" in html
     assert "<table" in html
+    assert 'class="facts-table"' in html
+    assert '"label": "Results"' in html
+    assert '"label": "Questions"' in html
+    assert 'id="table-tab"' in html
+    assert 'id="transcript-tab"' in html
+    assert 'id="transcript-panel" hidden' in html
+    assert 'id="transcript-prev"' in html
+    assert 'id="transcript-next"' in html
     assert html_path.read_text(encoding="utf-8") == html
+
+
+def test_results_git_package_html_renders_interview_answers_as_turns(tmp_path):
+    question = QuestionInterview(
+        question_name="experience",
+        question_text="Tell me about your experience.",
+        interview_guide="Ask for a concrete example.",
+    )
+    survey = Survey([question])
+    answer = [
+        {
+            "role": "interviewer",
+            "content": [
+                {"type": "text", "text": "What changed?"},
+                {"type": "image", "url": "https://example.com/image.png"},
+                {"type": "text", "text": "Please be specific."},
+            ],
+        },
+        {
+            "role": "respondent",
+            "content": [
+                {"type": "text", "text": "Everything <script>alert(1)</script>."}
+            ],
+        },
+    ]
+    result = Result(
+        agent=Agent(name="participant-1"),
+        scenario=Scenario(),
+        model=Model("test"),
+        iteration=0,
+        answer={"experience": answer},
+        survey=survey,
+    )
+    results = Results(survey=survey, data=[result])
+    package_path = tmp_path / "interview-results.ep"
+    results.git.save(package_path)
+
+    html = Results.git.open(package_path).html()
+
+    assert '"__edsl_cell_type": "interview_transcript"' in html
+    assert 'class="interview-transcript"' in html
+    assert 'class="interview-turn ${role}"' in html
+    assert "What changed?\\nPlease be specific." in html
+    assert "Tell me about your experience." in html
+    assert '"label": "participant-1"' in html
+    assert "participant-1" in html
+
+
+def test_results_git_package_html_preserves_malformed_interview_answer(tmp_path):
+    question = QuestionInterview(
+        question_name="experience",
+        question_text="Tell me about your experience.",
+        interview_guide="Ask for a concrete example.",
+    )
+    survey = Survey([question])
+    result = Result(
+        agent=Agent(name="participant-1"),
+        scenario=Scenario(),
+        model=Model("test"),
+        iteration=0,
+        answer={"experience": {"unexpected": "shape"}},
+        survey=survey,
+    )
+    package_path = tmp_path / "malformed-interview-results.ep"
+    Results(survey=survey, data=[result]).git.save(package_path)
+
+    html = Results.git.open(package_path).html()
+
+    assert '"unexpected": "shape"' in html
+    assert '"__edsl_cell_type": "interview_transcript"' not in html
 
 
 def test_results_git_tag_restore(tmp_path):

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -243,9 +243,13 @@ def test_results_git_package_html(tmp_path):
     assert 'id="table-tab"' in html
     assert 'id="transcript-tab"' in html
     assert 'id="transcript-panel" hidden' in html
-    assert 'id="transcript-prev"' in html
-    assert 'id="transcript-next"' in html
+    assert 'id="transcript-toolbar"' in html
+    assert 'data-dimension="${field}"' in html
     assert 'class="context-fields"' in html
+    assert 'class="scenario-token"' in html
+    assert 'class="${columnClass(col)}"' in html
+    assert 'class="interview-link"' in html
+    assert '"answer.how_feeling"' in html
     assert html_path.read_text(encoding="utf-8") == html
 
 

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import pytest
 
 from edsl.results import Results, ResultsGitError, ResultsGitNestedRepoWarning
-from edsl import Agent, Model, QuestionInterview, Scenario, Survey
+from edsl import Agent, Model, QuestionFreeText, QuestionInterview, Scenario, Survey
 from edsl.results import Result
+from edsl.results.results_git import _transcript_row
 from edsl.results.exceptions import ResultsError
 from edsl.base.base_exception import BaseException as EDSLBaseException
 from edsl.tasks import TaskHistory
@@ -244,16 +245,23 @@ def test_results_git_package_html(tmp_path):
     assert 'id="transcript-panel" hidden' in html
     assert 'id="transcript-prev"' in html
     assert 'id="transcript-next"' in html
+    assert 'class="context-fields"' in html
     assert html_path.read_text(encoding="utf-8") == html
 
 
 def test_results_git_package_html_renders_interview_answers_as_turns(tmp_path):
+    opening = QuestionFreeText(
+        question_name="opening", question_text="What is your initial reaction?"
+    )
     question = QuestionInterview(
         question_name="experience",
         question_text="Tell me about your experience.",
         interview_guide="Ask for a concrete example.",
     )
-    survey = Survey([question])
+    closing = QuestionFreeText(
+        question_name="closing", question_text="What should improve?"
+    )
+    survey = Survey([opening, question, closing])
     answer = [
         {
             "role": "interviewer",
@@ -275,7 +283,11 @@ def test_results_git_package_html_renders_interview_answers_as_turns(tmp_path):
         scenario=Scenario(),
         model=Model("test"),
         iteration=0,
-        answer={"experience": answer},
+        answer={
+            "opening": "Positive",
+            "experience": answer,
+            "closing": "Faster checkout",
+        },
         survey=survey,
     )
     results = Results(survey=survey, data=[result])
@@ -283,7 +295,13 @@ def test_results_git_package_html_renders_interview_answers_as_turns(tmp_path):
     results.git.save(package_path)
 
     html = Results.git.open(package_path).html()
+    transcript = _transcript_row(1, result, survey.question_names)
 
+    assert [item["name"] for item in transcript["questions"]] == [
+        "opening",
+        "experience",
+        "closing",
+    ]
     assert '"__edsl_cell_type": "interview_transcript"' in html
     assert 'class="interview-transcript"' in html
     assert 'class="interview-turn ${role}"' in html

--- a/tests/results/test_results_git.py
+++ b/tests/results/test_results_git.py
@@ -9,7 +9,7 @@ import pytest
 from edsl.results import Results, ResultsGitError, ResultsGitNestedRepoWarning
 from edsl import Agent, Model, QuestionFreeText, QuestionInterview, Scenario, Survey
 from edsl.results import Result
-from edsl.results.results_git import _transcript_row
+from edsl.results.results_git import _result_row, _transcript_row
 from edsl.results.exceptions import ResultsError
 from edsl.base.base_exception import BaseException as EDSLBaseException
 from edsl.tasks import TaskHistory
@@ -310,7 +310,8 @@ def test_results_git_package_html_renders_interview_answers_as_turns(tmp_path):
         "experience",
         "closing",
     ]
-    assert '"__edsl_cell_type": "interview_transcript"' in html
+    assert '"__interview_transcripts"' in html
+    assert '"interview_turns"' in html
     assert 'class="interview-transcript"' in html
     assert 'class="interview-turn ${role}"' in html
     assert "What changed?\\nPlease be specific." in html
@@ -340,7 +341,32 @@ def test_results_git_package_html_preserves_malformed_interview_answer(tmp_path)
     html = Results.git.open(package_path).html()
 
     assert '"unexpected": "shape"' in html
-    assert '"__edsl_cell_type": "interview_transcript"' not in html
+    assert '"interview_turns": null' in html
+
+
+def test_results_html_reserved_marker_cannot_hide_user_answer():
+    question = QuestionFreeText(
+        question_name="structured", question_text="Return structured data."
+    )
+    survey = Survey([question])
+    answer = {
+        "__edsl_cell_type": "interview_transcript",
+        "turns": ["user-authored", "data"],
+        "actual_value": "preserve me",
+    }
+    result = Result(
+        agent=Agent(name="participant-1"),
+        scenario=Scenario(),
+        model=Model("test"),
+        iteration=0,
+        answer={"structured": answer},
+        survey=survey,
+    )
+
+    row = _result_row(1, result)
+
+    assert row["answer.structured"] == answer
+    assert row["__interview_transcripts"] == {}
 
 
 def test_results_git_tag_restore(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1581,7 +1581,7 @@ class TestOpen:
         assert out["data"]["object_type"] == "Results"
         assert opened_urls == [html_path.resolve().as_uri()]
         html = html_path.read_text(encoding="utf-8")
-        assert "<title>EDSL Results</title>" in html
+        assert "<title>Results</title>" in html
         assert "Expected Parrot" in html
         assert "collection-table" in html
         assert "<table" in html


### PR DESCRIPTION
## Summary
- simplify the Results package heading and replace count cards with a compact summary table
- add Table and Transcript views, keeping Table as the default
- show one Result at a time in Transcript view with navigation, metadata, and ordered question/answer pairs
- render QuestionInterview answers as a nested alternating interviewer/respondent transcript
- preserve the existing serialized Results payload and safely fall back to JSON for malformed or structured answers

## Validation
- `pytest -q --noconftest -o cache_dir=/private/tmp/edsl-pytest-cache tests/results/test_results_git.py tests/test_cli.py -k "results_git or open_"` (21 passed)
- `ruff check --no-cache edsl/base/collection_html_renderer.py edsl/results/results_git.py tests/results/test_results_git.py tests/test_cli.py`
- visually inspected a generated standalone HTML file in Chromium

References expectedparrot/ep-agent#207. This improves the HTML view; CLI transcript export can be handled separately.