### PR TITLE
Fail closed when completed runner tasks have no answer

### DIFF
--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -2302,6 +2302,38 @@ class JobService:
         if _timing is not None:
             _timing["get_answers_batch"] = (_time.time() - _t) * 1000
 
+        # A completed task must have a stored Answer, even when the answer value
+        # itself is legitimately None.  Treat a missing record as runner data
+        # loss instead of silently turning it into a successful null response.
+        task_interview_map = {
+            task_id: interview_id
+            for interview_id in completed_interview_ids
+            for task_id in (
+                interview_defs[interview_id].task_ids
+                if interview_defs.get(interview_id)
+                else []
+            )
+        }
+        task_statuses = self._tasks.get_statuses_batch(list(task_interview_map))
+        task_definitions = self._tasks.get_definitions_flat_batch(
+            job_id, task_interview_map
+        )
+        missing_completed_answers: list[dict[str, str]] = []
+        for task_id, interview_id in task_interview_map.items():
+            if task_statuses.get(task_id) != TaskStatus.COMPLETED:
+                continue
+            task_definition = task_definitions.get(task_id)
+            if task_definition is None:
+                continue
+            if task_definition.question_name not in all_answers.get(interview_id, {}):
+                missing_completed_answers.append(
+                    {
+                        "interview_id": interview_id,
+                        "question_name": task_definition.question_name,
+                        "task_id": task_id,
+                    }
+                )
+
         # =====================================================================
         # BUILD RESULTS: Use pre-fetched data (no more DB calls in loop)
         # =====================================================================
@@ -2359,6 +2391,25 @@ class JobService:
         from ..tasks import TaskHistory
 
         errors_by_interview: dict[str, dict[str, list[dict]]] = {}
+        for missing in missing_completed_answers:
+            question_name = missing["question_name"]
+            task_id = missing["task_id"]
+            exception_entry = {
+                "exception": {
+                    "type": "MissingCompletedTaskAnswerError",
+                    "module": "edsl.runner",
+                    "message": (
+                        f"Task {task_id} was marked completed but no stored answer "
+                        f"was found for question {question_name}."
+                    ),
+                    "traceback": "",
+                },
+                "invigilator": None,
+                "additional_data": {"task_id": task_id},
+            }
+            errors_by_interview.setdefault(missing["interview_id"], {}).setdefault(
+                question_name, []
+            ).append(exception_entry)
         for error in self.get_error_details(job_id):
             question_name = error.get("question_name") or "unknown"
             exception_entry = {

--- a/tests/runner/test_failure_propagation.py
+++ b/tests/runner/test_failure_propagation.py
@@ -110,6 +110,48 @@ def test_validation_failure_preserves_response_and_task_history(tmp_path):
     assert package_round_tripped[0]["validated_dict"]["budget_validated"] is False
 
 
+def test_completed_task_without_stored_answer_is_reported_as_failure():
+    question = QuestionFreeText(question_name="response", question_text="Respond?")
+    job = question.by(Model("test"))
+    storage = InMemoryStorage()
+    service = JobService(storage)
+    job_id, _, _ = service.submit_job(job, job_id="job")
+    interview_id = service.jobs.get_definition(job_id).interview_ids[0]
+    interview = service.interviews.get_definition(job_id, interview_id)
+    task_id = interview.task_ids[0]
+
+    service.on_task_completed(job_id, interview_id, task_id, "present")
+    answer_key = f"job:{job_id}:interview:{interview_id}:answer:response"
+    storage.delete_volatile(answer_key)
+    storage.delete_persistent(answer_key)
+
+    results = service.build_edsl_results(job_id)
+
+    assert results[0].answer["response"] is None
+    assert results.has_unfixed_exceptions
+    exception = results.task_history.to_dict()["interviews"][0]["exceptions"][
+        "response"
+    ][0]["exception"]
+    assert exception["type"] == "MissingCompletedTaskAnswerError"
+    assert task_id in exception["message"]
+
+
+def test_skipped_task_without_stored_answer_is_not_reported_as_failure():
+    question = QuestionFreeText(question_name="response", question_text="Respond?")
+    job = question.by(Model("test"))
+    storage = InMemoryStorage()
+    service = JobService(storage)
+    job_id, _, _ = service.submit_job(job, job_id="job")
+    interview_id = service.jobs.get_definition(job_id).interview_ids[0]
+    interview = service.interviews.get_definition(job_id, interview_id)
+
+    service.on_task_skipped(job_id, interview_id, interview.task_ids[0])
+    results = service.build_edsl_results(job_id)
+
+    assert results[0].answer["response"] is None
+    assert not results.has_unfixed_exceptions
+
+
 def test_failure_propagation_blocks_converging_dag_nodes_once():
     root = QuestionFreeText(question_name="root", question_text="Root?")
     left = QuestionCompute(question_name="left", question_text="{{ root.answer }}")


### PR DESCRIPTION
## Summary
- detect completed runner tasks whose stored Answer record is missing
- surface a MissingCompletedTaskAnswerError in TaskHistory so local CLI runs report partial instead of complete
- preserve legitimate skipped questions and explicit null answers

## Verification
- 40 runner tests pass
- added regressions for missing completed answers and skipped tasks without answers

Closes #2601