### PR TITLE
Fail closed on unsuccessful remote inference runs

### DIFF
--- a/docs/en/latest/remote_inference.mdx
+++ b/docs/en/latest/remote_inference.mdx
@@ -1,4 +1,14 @@
 ---
+
+## Partial remote results
+
+`ep run` fails closed when a remote job reports `failed` or `partial_failed`; it does not save incomplete Results through the normal success path. If a partially failed job contains useful successful interviews and you intentionally want them, opt in explicitly:
+
+```bash
+ep run --jobs jobs.ep --allow-partial --output partial-results.ep
+```
+
+The command reports authoritative successful and failed interview counts. A partial job with zero successful interviews is always an error. Use the reported `ep jobs errors ...` command to retrieve its exception report.
 title: "Remote Inference"
 description: "Remote inference allows you to run surveys at the Expected Parrot server instead of locally on your own machine, and to use [Remote Caching](/en/latest/remote_caching) to store survey results and logs at your account."
 ---

--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -56,6 +56,7 @@ def register(app: click.Group) -> None:
     @click.option("--fresh", is_flag=True, default=False, help="Ignore cache.")
     @click.option("--n", "-n", "iterations", default=1, type=int, show_default=True, help="Number of iterations per question/scenario/agent/model combination.")
     @click.option("--local", is_flag=True, default=False, help="Disable remote inference and run locally.")
+    @click.option("--allow-partial", is_flag=True, default=False, help="Save and return usable partial remote results.")
     @click.option("--max-concurrency", default=None, type=click.IntRange(min=1), help="Maximum concurrent local interviews.")
     @click.option("--api-timeout", default=None, type=click.FloatRange(min=0.001), help="Local model API timeout in seconds.")
     @click.option("--save", default=None, help="Save Results JSON to file.")
@@ -65,7 +66,7 @@ def register(app: click.Group) -> None:
             model_list, model, service, base_url, api_key_env, qtype, options, name, progress, background,
             wait, poll_interval, timeout, task_timeout, remote_inference_description,
             remote_inference_results_visibility, results_description, fresh,
-            iterations, local, max_concurrency, api_timeout, save, output_path, input_path):
+            iterations, local, allow_partial, max_concurrency, api_timeout, save, output_path, input_path):
         """Run question(s) and get results.
 
         \b
@@ -266,6 +267,40 @@ def register(app: click.Group) -> None:
 
         saved = None
         result_count = 0 if background else _safe_len(results_obj)
+        remote_status = None
+        if not background and not local:
+            remote_status = _remote_status_from_results(results_obj)
+            if remote_status is not None:
+                status = str(remote_status.get("status") or "").lower()
+                counts = _remote_interview_counts(remote_status, result_count)
+                if status in {"failed", "cancelled", "canceled"} or (
+                    status in {"partial_failed", "partially_failed"}
+                    and (counts["completed_interviews"] == 0 or not allow_partial)
+                ):
+                    error(
+                        "REMOTE_JOB_PARTIAL_FAILED"
+                        if status in {"partial_failed", "partially_failed"}
+                        else "REMOTE_JOB_FAILED",
+                        "Remote inference produced no successful interviews."
+                        if counts["completed_interviews"] == 0
+                        else "Remote inference did not complete successfully.",
+                        suggestion=(
+                            "Retrieve the exception report with "
+                            f"ep jobs errors {remote_status.get('job_uuid')} --output error.md."
+                        ),
+                        details=[_remote_failure_details(remote_status, counts)],
+                        exit_code=EXIT_ERROR,
+                    )
+                if status in {"partial_failed", "partially_failed"}:
+                    envelope_warnings.append(
+                        {
+                            "code": "REMOTE_PARTIAL_RESULTS",
+                            "message": (
+                                f"Remote inference completed {counts['completed_interviews']} "
+                                f"of {counts['total_interviews']} interviews."
+                            ),
+                        }
+                    )
 
         # Save if requested
         if (save or output_path) and not background:
@@ -303,10 +338,19 @@ def register(app: click.Group) -> None:
                         return
         if saved is not None:
             meta["saved"] = saved
+        if remote_status is not None:
+            meta["remote_job"] = jsonable(remote_status)
 
         if not background:
             task_history = getattr(results_obj, "task_history", None)
             failed_count = len(getattr(task_history, "unfixed_exceptions", []) or [])
+            if remote_status is not None and str(
+                remote_status.get("status") or ""
+            ).lower() in {"partial_failed", "partially_failed"}:
+                counts = _remote_interview_counts(remote_status, result_count)
+                failed_count = counts["failed_interviews"]
+                result_count = counts["total_interviews"]
+                meta["result_count"] = result_count
             meta["run_status"] = "partial" if failed_count else "complete"
             meta["failed_interview_count"] = failed_count
             meta["completed_interview_count"] = max(result_count - failed_count, 0)
@@ -428,6 +472,44 @@ def register(app: click.Group) -> None:
             return len(obj)
         except Exception:
             return None
+
+
+    def _remote_status_from_results(results_obj) -> Optional[dict]:
+        results_uuid = getattr(results_obj, "results_uuid", None)
+        if not results_uuid:
+            return None
+        from edsl.coop import Coop
+
+        return dict(Coop().remote_inference_get(results_uuid=results_uuid))
+
+
+    def _remote_interview_counts(status_data: dict, fallback_total: int) -> dict:
+        details = status_data.get("latest_job_run_details", {}) or {}
+        interview_details = details.get("interview_details", {}) or {}
+        total = interview_details.get("total_interviews")
+        completed = interview_details.get("completed_interviews")
+        with_exceptions = interview_details.get("interviews_with_exceptions") or 0
+        total = fallback_total if total is None else total
+        completed = 0 if completed is None else completed
+        successful = max(completed - with_exceptions, 0)
+        return {
+            "total_interviews": total,
+            "completed_interviews": successful,
+            "failed_interviews": max(total - successful, 0),
+        }
+
+
+    def _remote_failure_details(status_data: dict, counts: dict) -> dict:
+        latest = status_data.get("latest_job_run_details", {}) or {}
+        return {
+            "job_uuid": status_data.get("job_uuid"),
+            "results_uuid": status_data.get("results_uuid"),
+            **counts,
+            "cost_usd": latest.get("cost_usd"),
+            "error_report_uuid": latest.get("error_report_uuid"),
+            "error_report_url": latest.get("error_report_url"),
+            "remote_status": status_data.get("status"),
+        }
 
 
     def _build_job(input_mode, input_path, jobs_path, survey_path, json_str, stdin_data,

--- a/edsl/cli_commands/run.py
+++ b/edsl/cli_commands/run.py
@@ -269,7 +269,23 @@ def register(app: click.Group) -> None:
         result_count = 0 if background else _safe_len(results_obj)
         remote_status = None
         if not background and not local:
-            remote_status = _remote_status_from_results(results_obj)
+            try:
+                remote_status = _remote_status_from_results(results_obj)
+            except Exception as e:
+                recovery_details = {"status_error": str(e)}
+                if save or output_path:
+                    try:
+                        saved = save_results(results_obj, output_path or save)
+                        recovery_details["saved"] = saved
+                    except Exception as save_error:
+                        recovery_details["save_error"] = str(save_error)
+                error(
+                    "REMOTE_STATUS_UNAVAILABLE",
+                    "Remote inference finished, but its authoritative status could not be verified.",
+                    suggestion="Check the remote job status before using the saved Results.",
+                    details=[recovery_details],
+                    exit_code=EXIT_ERROR,
+                )
             if remote_status is not None:
                 status = str(remote_status.get("status") or "").lower()
                 counts = _remote_interview_counts(remote_status, result_count)
@@ -476,11 +492,15 @@ def register(app: click.Group) -> None:
 
     def _remote_status_from_results(results_obj) -> Optional[dict]:
         results_uuid = getattr(results_obj, "results_uuid", None)
-        if not results_uuid:
+        job_uuid = getattr(results_obj, "job_uuid", None) or getattr(
+            results_obj, "_job_uuid", None
+        )
+        if not (results_uuid or job_uuid):
             return None
         from edsl.coop import Coop
 
-        return dict(Coop().remote_inference_get(results_uuid=results_uuid))
+        lookup = {"results_uuid": results_uuid} if results_uuid else {"job_uuid": job_uuid}
+        return dict(Coop().remote_inference_get(**lookup))
 
 
     def _remote_interview_counts(status_data: dict, fallback_total: int) -> dict:

--- a/tests/inference_services/test_cli_openai_compatible.py
+++ b/tests/inference_services/test_cli_openai_compatible.py
@@ -2,6 +2,7 @@
 
 import json
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from click.testing import CliRunner
 
@@ -179,3 +180,106 @@ def test_run_reports_partial_results(tmp_path, monkeypatch):
     assert out["data"]["meta"]["run_status"] == "partial"
     assert out["data"]["meta"]["failed_interview_count"] == 1
     assert out["warnings"][-1]["code"] == "PARTIAL_RESULTS"
+
+
+def test_run_fails_before_saving_zero_success_remote_results(tmp_path, monkeypatch):
+    from edsl.coop import Coop
+    from edsl.jobs import Jobs
+    from edsl.results import Results
+    import edsl.cli_commands.run as run_command
+
+    fake_results = Results(data=[object(), object()])
+    fake_results.results_uuid = "results-uuid"
+    monkeypatch.setattr(Jobs, "run", lambda self, **kwargs: fake_results)
+    monkeypatch.setattr(
+        Coop,
+        "remote_inference_get",
+        lambda self, **kwargs: {
+            "job_uuid": "job-uuid",
+            "results_uuid": "results-uuid",
+            "status": "partial_failed",
+            "latest_job_run_details": {
+                "interview_details": {
+                    "total_interviews": 2,
+                    "completed_interviews": 0,
+                    "interviews_with_exceptions": 0,
+                },
+                "cost_usd": 0.0,
+                "error_report_uuid": "report-uuid",
+                "error_report_url": "https://example.test/error/report-uuid",
+            },
+        },
+    )
+    save = Mock()
+    monkeypatch.setattr(run_command, "save_results", save)
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["run", "--question", "hi", "--output", str(tmp_path / "results.ep")],
+    )
+
+    assert result.exit_code == 1, result.output
+    out = json.loads(result.output)
+    assert out["error"]["code"] == "REMOTE_JOB_PARTIAL_FAILED"
+    assert out["error"]["details"][0]["completed_interviews"] == 0
+    assert out["error"]["details"][0]["failed_interviews"] == 2
+    assert out["error"]["details"][0]["error_report_uuid"] == "report-uuid"
+    save.assert_not_called()
+
+
+def test_run_allows_and_reports_genuine_partial_remote_results(tmp_path, monkeypatch):
+    from edsl.coop import Coop
+    from edsl.jobs import Jobs
+    from edsl.results import Results
+    import edsl.cli_commands.run as run_command
+
+    fake_results = Results(data=[object(), object()])
+    fake_results.results_uuid = "results-uuid"
+    monkeypatch.setattr(Jobs, "run", lambda self, **kwargs: fake_results)
+    monkeypatch.setattr(
+        Coop,
+        "remote_inference_get",
+        lambda self, **kwargs: {
+            "job_uuid": "job-uuid",
+            "results_uuid": "results-uuid",
+            "status": "partial_failed",
+            "latest_job_run_details": {
+                "interview_details": {
+                    "total_interviews": 3,
+                    "completed_interviews": 2,
+                    "interviews_with_exceptions": 0,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        run_command,
+        "save_results",
+        lambda results, path: {
+            "path": str(path),
+            "format": "ep",
+            "object_type": "Results",
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "run",
+            "--question",
+            "hi",
+            "--allow-partial",
+            "--output",
+            str(tmp_path / "results.ep"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.output)
+    assert out["data"]["meta"]["run_status"] == "partial"
+    assert out["data"]["meta"]["completed_interview_count"] == 2
+    assert out["data"]["meta"]["failed_interview_count"] == 1
+    assert {warning["code"] for warning in out["warnings"]} >= {
+        "REMOTE_PARTIAL_RESULTS",
+        "PARTIAL_RESULTS",
+    }

--- a/tests/inference_services/test_cli_openai_compatible.py
+++ b/tests/inference_services/test_cli_openai_compatible.py
@@ -283,3 +283,77 @@ def test_run_allows_and_reports_genuine_partial_remote_results(tmp_path, monkeyp
         "REMOTE_PARTIAL_RESULTS",
         "PARTIAL_RESULTS",
     }
+
+
+def test_run_checks_streamed_results_by_job_uuid(tmp_path, monkeypatch):
+    from edsl.coop import Coop
+    from edsl.jobs import Jobs
+    from edsl.results import Results
+    import edsl.cli_commands.run as run_command
+
+    fake_results = Results(data=[object()])
+    fake_results.job_uuid = "job-uuid"
+    monkeypatch.setattr(Jobs, "run", lambda self, **kwargs: fake_results)
+
+    def remote_status(self, **kwargs):
+        assert kwargs == {"job_uuid": "job-uuid"}
+        return {
+            "job_uuid": "job-uuid",
+            "status": "partial_failed",
+            "latest_job_run_details": {
+                "interview_details": {
+                    "total_interviews": 1,
+                    "completed_interviews": 0,
+                }
+            },
+        }
+
+    monkeypatch.setattr(Coop, "remote_inference_get", remote_status)
+    save = Mock()
+    monkeypatch.setattr(run_command, "save_results", save)
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["run", "--question", "hi", "--output", str(tmp_path / "results.ep")],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert json.loads(result.output)["error"]["code"] == "REMOTE_JOB_PARTIAL_FAILED"
+    save.assert_not_called()
+
+
+def test_run_preserves_results_when_remote_status_lookup_fails(tmp_path, monkeypatch):
+    from edsl.coop import Coop
+    from edsl.jobs import Jobs
+    from edsl.results import Results
+    import edsl.cli_commands.run as run_command
+
+    fake_results = Results(data=[object()])
+    fake_results.results_uuid = "results-uuid"
+    monkeypatch.setattr(Jobs, "run", lambda self, **kwargs: fake_results)
+    monkeypatch.setattr(
+        Coop,
+        "remote_inference_get",
+        lambda self, **kwargs: (_ for _ in ()).throw(ConnectionError("offline")),
+    )
+    saved_path = tmp_path / "results.ep"
+    save = Mock(
+        return_value={
+            "path": str(saved_path),
+            "format": "ep",
+            "object_type": "Results",
+        }
+    )
+    monkeypatch.setattr(run_command, "save_results", save)
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["run", "--question", "hi", "--output", str(saved_path)],
+    )
+
+    assert result.exit_code == 1, result.output
+    out = json.loads(result.output)
+    assert out["error"]["code"] == "REMOTE_STATUS_UNAVAILABLE"
+    assert out["error"]["details"][0]["status_error"] == "offline"
+    assert out["error"]["details"][0]["saved"]["path"] == str(saved_path)
+    save.assert_called_once_with(fake_results, str(saved_path))


### PR DESCRIPTION
## Summary
- query authoritative Coop status for synchronous remote runs before saving Results
- fail with structured remote job/report metadata for failed jobs and partial jobs by default
- never save zero-success placeholder Results to the requested output path
- add explicit --allow-partial opt-in and report authoritative success/failure counts

## Verification
- 55 inference-service tests passed, 1 skipped
- tests cover partial_failed with zero successes and inconsistent interviews_with_exceptions=0
- tests cover explicit partial-result opt-in and reporting

Closes #2583