### PR TITLE
Allow humanize scenario methods with Jobs packages

### DIFF
--- a/edsl/cli_commands/humanize.py
+++ b/edsl/cli_commands/humanize.py
@@ -1564,6 +1564,12 @@ def register(humanize: click.Group) -> None:
                         "Jobs with scenarios require --scenario_method.",
                         exit_code=EXIT_USAGE,
                     )
+                if scenario_list is None and scenario_method is not None:
+                    error(
+                        "USAGE_ERROR",
+                        "--scenario_method requires scenarios in the Jobs object.",
+                        exit_code=EXIT_USAGE,
+                    )
             else:
                 survey = _load_survey_object(survey_path)
                 agent_list = _load_agent_list_object(agent_list_path) if agent_list_path else None

--- a/edsl/cli_commands/humanize.py
+++ b/edsl/cli_commands/humanize.py
@@ -1521,10 +1521,16 @@ def register(humanize: click.Group) -> None:
                 "Provide exactly one of --survey or --jobs.",
                 exit_code=EXIT_USAGE,
             )
-        if bool(scenario_list_path) != bool(scenario_method):
+        if scenario_list_path and not scenario_method:
             error(
                 "USAGE_ERROR",
                 "--scenario_list and --scenario_method must be supplied together.",
+                exit_code=EXIT_USAGE,
+            )
+        if scenario_method and not (scenario_list_path or jobs_path):
+            error(
+                "USAGE_ERROR",
+                "--scenario_method requires --scenario_list or --jobs.",
                 exit_code=EXIT_USAGE,
             )
         if jobs_path and (scenario_list_path or agent_list_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3429,6 +3429,54 @@ class TestHumanizeCli:
         out = json.loads(result.output)
         assert out["error"]["code"] == "USAGE_ERROR"
 
+    def test_humanize_create_uses_scenarios_from_jobs(self, tmp_path, monkeypatch):
+        from edsl.jobs import Jobs
+        from edsl.questions import QuestionFreeText
+        from edsl.scenarios import ScenarioList
+        from edsl.surveys import Survey
+        import edsl.coop
+
+        jobs_path = tmp_path / "jobs.ep"
+        scenarios = ScenarioList.from_list("city", ["Boston"])
+        Jobs(
+            survey=Survey(
+                [
+                    QuestionFreeText(
+                        question_name="visit",
+                        question_text="What would you visit in {{ city }}?",
+                    )
+                ]
+            ),
+            models=[],
+            scenarios=scenarios,
+        ).git.save(jobs_path)
+
+        class FakeCoop:
+            def create_human_survey(
+                self, survey, scenario_list=None, scenario_list_method=None, **kwargs
+            ):
+                assert type(survey).__name__ == "Survey"
+                assert scenario_list == scenarios
+                assert scenario_list_method == "ordered"
+                return {"uuid": "human-survey-uuid"}
+
+        monkeypatch.setattr(edsl.coop, "Coop", FakeCoop)
+
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "humanize",
+                "create",
+                "--jobs",
+                str(jobs_path),
+                "--scenario_method",
+                "ordered",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["data"]["uuid"] == "human-survey-uuid"
+
     def test_humanize_responses_fetches_and_saves_results(self, tmp_path, monkeypatch):
         from edsl.results import Results
         import edsl.coop

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3477,6 +3477,29 @@ class TestHumanizeCli:
         assert result.exit_code == 0, result.output
         assert json.loads(result.output)["data"]["uuid"] == "human-survey-uuid"
 
+    def test_humanize_create_rejects_scenario_method_for_empty_jobs(self, tmp_path):
+        from edsl.jobs import Jobs
+
+        jobs_path = tmp_path / "jobs.ep"
+        Jobs(survey=Jobs.example().survey, models=[], scenarios=[]).git.save(jobs_path)
+
+        result = CliRunner().invoke(
+            cli_module.app,
+            [
+                "humanize",
+                "create",
+                "--jobs",
+                str(jobs_path),
+                "--scenario_method",
+                "ordered",
+            ],
+        )
+
+        assert result.exit_code == cli_module.EXIT_USAGE
+        out = json.loads(result.output)
+        assert out["error"]["code"] == "USAGE_ERROR"
+        assert "requires scenarios" in out["error"]["message"]
+
     def test_humanize_responses_fetches_and_saves_results(self, tmp_path, monkeypatch):
         from edsl.results import Results
         import edsl.coop


### PR DESCRIPTION
## Summary
- permit --scenario_method when scenarios come from --jobs
- continue requiring a method for explicit --scenario_list input
- reject a method when neither scenario source is provided
- pass Jobs scenarios and the selected method to Coop.create_human_survey

## Verification
- uv run pytest --noconftest -q -p no:cacheprovider tests/test_cli.py -k humanize_create
- 4 passed

Closes #2544