### PR TITLE
Omit skipped questions from memory context

### DIFF
--- a/edsl/surveys/memory/memory_plan.py
+++ b/edsl/surveys/memory/memory_plan.py
@@ -82,8 +82,9 @@ class MemoryPlan(UserDict):
             return Prompt("")
 
         q_and_a_pairs = [
-            (self.name_to_text[question_name], answers.get(question_name, None))
+            (self.name_to_text[question_name], answers[question_name])
             for question_name in self[focal_question]
+            if question_name in answers
         ]
 
         base_prompt_text = """

--- a/tests/surveys/test_MemoryPlan.py
+++ b/tests/surveys/test_MemoryPlan.py
@@ -77,6 +77,25 @@ class TestMemoryPlan(unittest.TestCase):
         prompt = memory_plan.get_memory_prompt_fragment("q2", self.answers_dict)
         self.assertIn("How are you?", prompt)
 
+    def test_prompt_fragment_omits_unanswered_memory(self):
+        memory_plan = self.example()
+        memory_plan.add_memory_collection("q3", ["q1", "q2"])
+
+        prompt = memory_plan.get_memory_prompt_fragment("q3", {"q1": "Good!"})
+
+        self.assertIn("How are you?", prompt)
+        self.assertNotIn("What is your age?", prompt)
+        self.assertNotIn("Answer: None", prompt)
+
+    def test_prompt_fragment_preserves_explicit_none_answer(self):
+        memory_plan = self.example()
+        memory_plan.add_single_memory("q2", "q1")
+
+        prompt = memory_plan.get_memory_prompt_fragment("q2", {"q1": None})
+
+        self.assertIn("How are you?", prompt)
+        self.assertIn("Answer: None", prompt)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- include prior questions in memory only when an answer record exists
- omit skipped questions instead of rendering them as Answer: None
- preserve explicitly recorded None answers

## Verification
- 10 focused MemoryPlan and runner rendering tests passed

Closes #1224