### PR TITLE
Bound and secure scenario network requests

### DIFF
--- a/edsl/scenarios/file_store.py
+++ b/edsl/scenarios/file_store.py
@@ -1035,6 +1035,7 @@ class FileStore(Scenario):
         mime_type: Optional[str] = None,
         field_name: Optional[str] = None,
         testing: bool = False,
+        timeout: float = 30.0,
     ) -> "FileStore":
         """
         :param url: The URL of the file to download.
@@ -1043,25 +1044,29 @@ class FileStore(Scenario):
         """
         import requests
         from urllib.parse import urlparse
+        from .network import validate_request_timeout
 
-        response = requests.get(url, stream=True)
-        response.raise_for_status()  # Raises an HTTPError for bad responses
+        timeout = validate_request_timeout(timeout)
+        response = requests.get(url, stream=True, timeout=timeout)
+        try:
+            response.raise_for_status()  # Raises an HTTPError for bad responses
 
-        # Get the filename from the URL if download_path is not provided
-        if download_path is None:
-            filename = os.path.basename(urlparse(url).path)
-            if not filename:
-                filename = "downloaded_file"
-            # download_path = filename
-            download_path = os.path.join(os.getcwd(), filename)
+            # Get the filename from the URL if download_path is not provided
+            if download_path is None:
+                filename = os.path.basename(urlparse(url).path)
+                if not filename:
+                    filename = "downloaded_file"
+                download_path = os.path.join(os.getcwd(), filename)
 
-        # Ensure the directory exists
-        os.makedirs(os.path.dirname(download_path), exist_ok=True)
+            # Ensure the directory exists
+            os.makedirs(os.path.dirname(download_path), exist_ok=True)
 
-        # Write the file
-        with open(download_path, "wb") as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                file.write(chunk)
+            # Write the file
+            with open(download_path, "wb") as file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    file.write(chunk)
+        finally:
+            response.close()
 
         # Create and return a new File instance
         return cls(download_path, mime_type=mime_type)

--- a/edsl/scenarios/network.py
+++ b/edsl/scenarios/network.py
@@ -1,0 +1,15 @@
+"""Shared safeguards for scenario-related network requests."""
+
+from numbers import Real
+from math import isfinite
+
+
+DEFAULT_REQUEST_TIMEOUT = 30.0
+
+
+def validate_request_timeout(timeout: Real) -> float:
+    """Return a positive finite request timeout as a float."""
+    value = float(timeout)
+    if isinstance(timeout, bool) or value <= 0 or not isfinite(value):
+        raise ValueError("timeout must be a positive finite number")
+    return value

--- a/edsl/scenarios/scenario.py
+++ b/edsl/scenarios/scenario.py
@@ -973,7 +973,11 @@ class Scenario(Base, UserDict):
 
     @classmethod
     def from_url(
-        cls, url: str, field_name: Optional[str] = "text", testing: bool = False
+        cls,
+        url: str,
+        field_name: Optional[str] = "text",
+        testing: bool = False,
+        timeout: float = 30.0,
     ) -> "Scenario":
         """
         Creates a Scenario from the content of a URL.
@@ -1012,7 +1016,7 @@ class Scenario(Base, UserDict):
         """
         from .scenario_factory import ScenarioFactory
 
-        return ScenarioFactory.from_url(url, field_name, testing)
+        return ScenarioFactory.from_url(url, field_name, testing, timeout)
 
     @classmethod
     def from_file(cls, file_path: str, field_name: str) -> "Scenario":

--- a/edsl/scenarios/scenario_factory.py
+++ b/edsl/scenarios/scenario_factory.py
@@ -35,7 +35,11 @@ class ScenarioFactory:
 
     @classmethod
     def from_url(
-        cls, url: str, field_name: Optional[str] = "text", testing: bool = False
+        cls,
+        url: str,
+        field_name: Optional[str] = "text",
+        testing: bool = False,
+        timeout: float = 30.0,
     ) -> "Scenario":
         """
         Creates a Scenario from the content of a URL.
@@ -73,10 +77,13 @@ class ScenarioFactory:
             - When using BeautifulSoup, it extracts text from paragraph and heading tags.
         """
         import requests
+        from .network import validate_request_timeout
+
+        timeout = validate_request_timeout(timeout)
 
         if testing:
             # Use simple requests method for testing
-            response = requests.get(url)
+            response = requests.get(url, timeout=timeout)
             text = response.text
         else:
             try:
@@ -91,7 +98,7 @@ class ScenarioFactory:
                     "Accept-Language": "en-US,en;q=0.5",
                 }
 
-                response = requests.get(url, headers=headers)
+                response = requests.get(url, headers=headers, timeout=timeout)
                 soup = BeautifulSoup(response.content, "html.parser")
 
                 # Get text content while preserving some structure
@@ -109,7 +116,7 @@ class ScenarioFactory:
                 print(
                     "BeautifulSoup/fake_useragent not available. Falling back to basic requests."
                 )
-                response = requests.get(url)
+                response = requests.get(url, timeout=timeout)
                 text = response.text
 
         # Import here to avoid circular imports

--- a/edsl/scenarios/scenario_list.py
+++ b/edsl/scenarios/scenario_list.py
@@ -1133,11 +1133,11 @@ class ScenarioList(MutableSequence, Base, ScenarioListOperationsMixin):
 
     @classmethod
     def from_urls(
-        cls, urls: list[str], field_name: str = "text"
+        cls, urls: list[str], field_name: str = "text", timeout: float = 30.0
     ) -> ScenarioList:
         from .scenario_source import URLSource
 
-        return URLSource(urls, field_name).to_scenario_list()
+        return URLSource(urls, field_name, timeout).to_scenario_list()
 
     @classmethod
     def from_list(

--- a/edsl/scenarios/scenario_source.py
+++ b/edsl/scenarios/scenario_source.py
@@ -20,7 +20,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    TYPE_CHECKING,
 )
 
 # Import all source classes from the sources package
@@ -49,10 +48,6 @@ from .sources import (
 # Local imports
 from .scenario import Scenario
 from .exceptions import UnsupportedSourceTypeError, ScenarioError
-
-if TYPE_CHECKING:
-    from .scenario_list import ScenarioList
-
 
 class ScenarioSource:
     """
@@ -106,15 +101,21 @@ class ScenarioSource:
                 )
 
     @staticmethod
-    def _from_urls(urls: list[str], field_name: Optional[str] = "text"):
+    def _from_urls(
+        urls: list[str], field_name: Optional[str] = "text", timeout: float = 30.0
+    ):
         """Create a ScenarioList from a list of URLs."""
 
         import requests
+        from .network import validate_request_timeout
+        from .scenario_list import ScenarioList
+
+        timeout = validate_request_timeout(timeout)
 
         result = ScenarioList()
         for url in urls:
             try:
-                response = requests.get(url)
+                response = requests.get(url, timeout=timeout)
                 response.raise_for_status()
                 scenario = Scenario({field_name: response.text})
                 result.append(scenario)
@@ -229,14 +230,19 @@ class ScenarioSource:
         return source.to_scenario_list()
 
     @staticmethod
-    def _from_wikipedia(url: str, table_index: int = 0, header: bool = True):
+    def _from_wikipedia(
+        url: str,
+        table_index: int = 0,
+        header: bool = True,
+        timeout: float = 30.0,
+    ):
         """Create a ScenarioList from a table on a Wikipedia page."""
         warnings.warn(
             "_from_wikipedia is deprecated. Use WikipediaSource directly or ScenarioSource.from_source('wikipedia', ...) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        source = WikipediaSource(url, table_index, header)
+        source = WikipediaSource(url, table_index, header, timeout)
         return source.to_scenario_list()
 
     @staticmethod

--- a/edsl/scenarios/sources/url_source.py
+++ b/edsl/scenarios/sources/url_source.py
@@ -16,9 +16,12 @@ class URLSource(Source):
 
     source_type = "urls"
 
-    def __init__(self, urls: list[str], field_name: str):
+    def __init__(self, urls: list[str], field_name: str, timeout: float = 30.0):
+        from ..network import validate_request_timeout
+
         self.urls = urls
         self.field_name = field_name
+        self.timeout = validate_request_timeout(timeout)
 
     @classmethod
     def example(cls) -> "URLSource":
@@ -69,7 +72,7 @@ class URLSource(Source):
         result = ScenarioList()
         for url in self.urls:
             try:
-                response = requests.get(url)
+                response = requests.get(url, timeout=self.timeout)
                 response.raise_for_status()
                 scenario = Scenario({self.field_name: response.text})
                 result.append(scenario)

--- a/edsl/scenarios/sources/wikipedia_source.py
+++ b/edsl/scenarios/sources/wikipedia_source.py
@@ -1,7 +1,9 @@
 """Wikipedia table source for ScenarioList creation."""
 
 from __future__ import annotations
+from io import StringIO
 from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlparse
 
 from .base import Source
 from ..scenario import Scenario
@@ -16,7 +18,16 @@ class WikipediaSource(Source):
 
     source_type = "wikipedia"
 
-    def __init__(self, url: str, table_index: int = 0, header: bool = True):
+    MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+    MAX_REDIRECTS = 5
+
+    def __init__(
+        self,
+        url: str,
+        table_index: int = 0,
+        header: bool = True,
+        timeout: float = 30.0,
+    ):
         """
         Initialize a WikipediaSource with a URL to a Wikipedia page.
 
@@ -25,9 +36,68 @@ class WikipediaSource(Source):
             table_index: The index of the table to extract (default is 0).
             header: Whether the table has a header row (default is True).
         """
+        from ..network import validate_request_timeout
+
+        self._validate_url(url)
         self.url = url
         self.table_index = table_index
         self.header = header
+        self.timeout = validate_request_timeout(timeout)
+
+    @staticmethod
+    def _validate_url(url: str) -> None:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        if (
+            parsed.scheme != "https"
+            or not (hostname == "wikipedia.org" or hostname.endswith(".wikipedia.org"))
+            or parsed.port not in (None, 443)
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ScenarioError(
+                "Wikipedia URLs must use HTTPS on a wikipedia.org host and the default port."
+            )
+
+    def _fetch_html(self, requests) -> str:
+        current_url = self.url
+        visited = set()
+        for _ in range(self.MAX_REDIRECTS + 1):
+            self._validate_url(current_url)
+            if current_url in visited:
+                raise ScenarioError("Wikipedia redirect loop detected.")
+            visited.add(current_url)
+            response = requests.get(
+                current_url,
+                stream=True,
+                allow_redirects=False,
+                timeout=self.timeout,
+            )
+            try:
+                response.raise_for_status()
+                if 300 <= response.status_code < 400:
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise ScenarioError("Wikipedia redirect omitted its Location header.")
+                    current_url = urljoin(current_url, location)
+                    continue
+                content_type = response.headers.get("Content-Type", "")
+                if not content_type.lower().startswith("text/html"):
+                    raise ScenarioError("Wikipedia response is not HTML.")
+                chunks = []
+                size = 0
+                for chunk in response.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    size += len(chunk)
+                    if size > self.MAX_RESPONSE_BYTES:
+                        raise ScenarioError("Wikipedia response exceeds the size limit.")
+                    chunks.append(chunk)
+                encoding = response.encoding or "utf-8"
+                return b"".join(chunks).decode(encoding, errors="replace")
+            finally:
+                response.close()
+        raise ScenarioError("Wikipedia URL exceeded the redirect limit.")
 
     @classmethod
     def example(cls) -> "WikipediaSource":
@@ -87,12 +157,8 @@ class WikipediaSource(Source):
             raise ImportError("pandas is required to read Wikipedia tables")
 
         try:
-            # Check if the URL is reachable
-            response = requests.get(self.url)
-            response.raise_for_status()  # Raises HTTPError for bad responses
-
-            # Extract tables from the Wikipedia page
-            tables = pd.read_html(self.url, header=0 if self.header else None)
+            html = self._fetch_html(requests)
+            tables = pd.read_html(StringIO(html), header=0 if self.header else None)
 
             # Ensure the requested table index is within the range of available tables
             if self.table_index >= len(tables) or self.table_index < 0:
@@ -113,6 +179,8 @@ class WikipediaSource(Source):
 
         except requests.exceptions.RequestException as e:
             raise ScenarioError(f"Error fetching the URL: {str(e)}")
+        except ScenarioError:
+            raise
         except ValueError as e:
             raise ScenarioError(f"Error parsing tables: {str(e)}")
         except Exception as e:

--- a/edsl/scenarios/sources/wikipedia_source.py
+++ b/edsl/scenarios/sources/wikipedia_source.py
@@ -48,10 +48,16 @@ class WikipediaSource(Source):
     def _validate_url(url: str) -> None:
         parsed = urlparse(url)
         hostname = (parsed.hostname or "").lower()
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ScenarioError(
+                "Wikipedia URLs must use HTTPS on a wikipedia.org host and the default port."
+            ) from exc
         if (
             parsed.scheme != "https"
             or not (hostname == "wikipedia.org" or hostname.endswith(".wikipedia.org"))
-            or parsed.port not in (None, 443)
+            or port not in (None, 443)
             or parsed.username is not None
             or parsed.password is not None
         ):

--- a/tests/scenarios/test_Scenario.py
+++ b/tests/scenarios/test_Scenario.py
@@ -46,6 +46,16 @@ class TestScenario(unittest.TestCase):
         # Assert
         self.assertEqual(scenario["url"], url)
         self.assertEqual(scenario["content"], "Mocked response text")
+        mock_get.assert_called_once_with(url, timeout=30.0)
+
+    @patch('requests.get')
+    def test_from_url_custom_timeout(self, mock_get):
+        mock_response = MagicMock(text="content")
+        mock_get.return_value = mock_response
+
+        Scenario.from_url("http://example.com", testing=True, timeout=4)
+
+        mock_get.assert_called_once_with("http://example.com", timeout=4.0)
 
 
 if __name__ == "__main__":

--- a/tests/scenarios/test_network_safety.py
+++ b/tests/scenarios/test_network_safety.py
@@ -87,6 +87,11 @@ def test_wikipedia_rejects_urls_outside_trust_boundary(url):
         WikipediaSource(url)
 
 
+def test_wikipedia_normalizes_malformed_port_error():
+    with pytest.raises(ScenarioError, match="Wikipedia URLs"):
+        WikipediaSource("https://en.wikipedia.org:not-a-port/wiki/Test")
+
+
 @patch("requests.get")
 def test_wikipedia_rejects_off_domain_redirect(mock_get):
     response = _response()

--- a/tests/scenarios/test_network_safety.py
+++ b/tests/scenarios/test_network_safety.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from edsl.scenarios import FileStore, ScenarioList
+from edsl.scenarios.exceptions import ScenarioError
+from edsl.scenarios.scenario_source import ScenarioSource
+from edsl.scenarios.sources.wikipedia_source import WikipediaSource
+
+
+def _response(body=b"<table><tr><th>name</th></tr><tr><td>A</td></tr></table>"):
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"Content-Type": "text/html; charset=utf-8"}
+    response.encoding = "utf-8"
+    response.iter_content.return_value = [body]
+    return response
+
+
+@patch("requests.get")
+def test_scenario_list_url_timeouts(mock_get):
+    mock_get.return_value = MagicMock(text="content")
+
+    ScenarioList.from_urls(["https://example.com"])
+    ScenarioSource._from_urls(["https://example.org"], timeout=7)
+
+    assert mock_get.call_args_list[0].kwargs["timeout"] == 30.0
+    assert mock_get.call_args_list[1].kwargs["timeout"] == 7.0
+
+
+@patch("requests.get")
+def test_filestore_url_timeout_and_validation(mock_get, tmp_path):
+    response = MagicMock()
+    response.iter_content.return_value = [b"hello"]
+    mock_get.return_value = response
+    path = tmp_path / "download.txt"
+
+    result = FileStore.from_url(
+        "https://example.com/download.txt", download_path=str(path), timeout=5
+    )
+
+    mock_get.assert_called_once_with(
+        "https://example.com/download.txt", stream=True, timeout=5.0
+    )
+    assert result.text == "hello"
+    response.close.assert_called_once()
+
+    mock_get.reset_mock()
+    with pytest.raises(ValueError, match="positive finite"):
+        FileStore.from_url("https://example.com/file", timeout=0)
+    mock_get.assert_not_called()
+
+
+@patch("pandas.read_html")
+@patch("requests.get")
+def test_wikipedia_fetch_is_bounded_and_parses_fetched_html(mock_get, read_html):
+    mock_get.return_value = _response()
+    read_html.return_value = [pd.DataFrame([{"name": "A"}])]
+
+    result = WikipediaSource(
+        "https://en.wikipedia.org/wiki/Test", timeout=6
+    ).to_scenario_list()
+
+    mock_get.assert_called_once_with(
+        "https://en.wikipedia.org/wiki/Test",
+        stream=True,
+        allow_redirects=False,
+        timeout=6.0,
+    )
+    assert hasattr(read_html.call_args.args[0], "read")
+    assert result[0]["name"] == "A"
+    mock_get.return_value.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://en.wikipedia.org/wiki/Test",
+        "https://example.com/wiki/Test",
+        "https://en.wikipedia.org:444/wiki/Test",
+        "https://wikipedia.org.evil.test/wiki/Test",
+    ],
+)
+def test_wikipedia_rejects_urls_outside_trust_boundary(url):
+    with pytest.raises(ScenarioError, match="Wikipedia URLs"):
+        WikipediaSource(url)
+
+
+@patch("requests.get")
+def test_wikipedia_rejects_off_domain_redirect(mock_get):
+    response = _response()
+    response.status_code = 302
+    response.headers = {"Location": "https://example.com/large.html"}
+    mock_get.return_value = response
+
+    with pytest.raises(ScenarioError, match="Wikipedia URLs"):
+        WikipediaSource("https://en.wikipedia.org/wiki/Test").to_scenario_list()
+
+    response.close.assert_called_once()
+
+
+@patch("requests.get")
+def test_wikipedia_rejects_oversized_response(mock_get):
+    response = _response()
+    response.iter_content.return_value = [
+        b"x" * (WikipediaSource.MAX_RESPONSE_BYTES + 1)
+    ]
+    mock_get.return_value = response
+
+    with pytest.raises(ScenarioError, match="size limit"):
+        WikipediaSource("https://en.wikipedia.org/wiki/Test").to_scenario_list()
+
+    response.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add a validated 30-second default timeout with caller overrides for Scenario.from_url, ScenarioList.from_urls, legacy ScenarioSource URL imports, and FileStore.from_url
- close streamed FileStore responses after success or failure
- constrain Wikipedia imports to HTTPS wikipedia.org hosts on the default port
- validate every redirect hop, bound redirects and response size, require HTML, and parse the fetched body instead of letting pandas make a second request
- repair the legacy ScenarioSource._from_urls runtime import uncovered by regression coverage

## Verification
- full scenario suite: 93 passed, 1 skipped
- Ruff passes on all touched files

Closes #2505
Closes #2506
Closes #2507