### PR TITLE
Expose reasoning-token uncertainty in job cost estimates

### DIFF
--- a/docs/en/latest/costs.mdx
+++ b/docs/en/latest/costs.mdx
@@ -92,6 +92,28 @@ This will return:
 {'credits_hold': 0.1, 'usd': 0.001}
 ```
 
+### Reasoning-model uncertainty
+
+Reasoning-token usage depends on the workload and may not be included in a server point estimate. For reasoning models, EDSL labels the returned amount as a lower bound instead of presenting it as an exact prediction. Inspect `estimate_kind`, `warnings`, and the `assumptions.reasoning_tokens` object before using an estimate as a budget:
+
+```bash
+ep jobs cost jobs.ep
+```
+
+```json
+{
+  "usd": 0.01,
+  "credits_hold": 1.0,
+  "estimate_kind": "lower_bound",
+  "lower_bound_usd": 0.01,
+  "expected_usd": null,
+  "upper_bound_usd": null,
+  "warnings": ["The server point estimate does not specify a reasoning-token assumption..."]
+}
+```
+
+`null` expected or upper values mean EDSL does not have enough information to produce those bounds; they do not mean zero additional cost. If the server supplies a richer range, EDSL preserves that range and its assumptions.
+
 ## Calculations
 
 The above-mentioned methods use the following calculation for each question in a survey to estimate the total cost of the job:

--- a/edsl/cli_commands/jobs.py
+++ b/edsl/cli_commands/jobs.py
@@ -389,7 +389,12 @@ def register(jobs_group: click.Group) -> None:
                         models=[Model(model)],
                         scenarios=obj.scenarios,
                     )
-            output(jsonable(Coop().remote_inference_cost(obj, iterations=iterations)))
+            cost_data = Coop().remote_inference_cost(obj, iterations=iterations)
+            cost_warnings = [
+                {"code": "COST_ESTIMATE_UNCERTAIN", "message": message}
+                for message in (cost_data.get("warnings") or [])
+            ]
+            output(jsonable(cost_data), warnings=cost_warnings)
         except SystemExit:
             raise
         except Exception as e:

--- a/edsl/coop/coop.py
+++ b/edsl/coop/coop.py
@@ -2855,10 +2855,9 @@ class Coop(CoopFunctionsMixin):
         )
         self._resolve_server_response(response)
         response_json = response.json()
-        return {
-            "credits_hold": response_json.get("cost_in_credits"),
-            "usd": response_json.get("cost_in_usd"),
-        }
+        from ..jobs.cost_estimate_contract import apply_cost_estimate_contract
+
+        return apply_cost_estimate_contract(job, response_json)
 
     ################
     # HUMAN SURVEYS

--- a/edsl/jobs/cost_estimate_contract.py
+++ b/edsl/jobs/cost_estimate_contract.py
@@ -1,0 +1,100 @@
+"""Structured uncertainty metadata for remote job cost estimates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _reasoning_model(model: Any) -> dict[str, Any] | None:
+    service = str(getattr(model, "_inference_service_", "") or "").lower()
+    name = str(getattr(model, "model", "") or "").lower()
+    parameters = dict(getattr(model, "parameters", {}) or {})
+    setting = parameters.get("reasoning_effort", parameters.get("reasoning"))
+    openai_reasoning_name = name.startswith(("gpt-5", "o1", "o3", "o4"))
+    explicit_reasoning = setting is not None
+    if not (explicit_reasoning or (service.startswith("openai") and openai_reasoning_name)):
+        return None
+    return {
+        "inference_service": service,
+        "model": name,
+        "reasoning_setting": setting,
+        "reasoning_setting_source": "explicit" if explicit_reasoning else "model_default",
+    }
+
+
+def apply_cost_estimate_contract(job: Any, response_json: dict) -> dict:
+    """Normalize server cost data and expose known reasoning-token uncertainty."""
+    cost = {
+        "credits_hold": response_json.get("cost_in_credits"),
+        "usd": response_json.get("cost_in_usd"),
+    }
+    # Prefer a richer server contract when available and retain its assumptions.
+    for key in (
+        "estimate_kind",
+        "lower_bound_usd",
+        "expected_usd",
+        "upper_bound_usd",
+        "lower_bound_credits",
+        "expected_credits",
+        "upper_bound_credits",
+        "assumptions",
+        "pricing_revision",
+        "warnings",
+    ):
+        if key in response_json:
+            cost[key] = response_json[key]
+
+    if "estimate_kind" in response_json:
+        return cost
+
+    reasoning_models = [
+        details
+        for model in getattr(job, "models", [])
+        if (details := _reasoning_model(model)) is not None
+    ]
+    cost["is_exact"] = False
+    if reasoning_models:
+        warning = (
+            "The server point estimate does not specify a reasoning-token assumption; "
+            "treat this amount as a lower bound because billed reasoning usage is workload-dependent."
+        )
+        cost.update(
+            {
+                "estimate_kind": "lower_bound",
+                "lower_bound_usd": cost["usd"],
+                "expected_usd": None,
+                "upper_bound_usd": None,
+                "lower_bound_credits": cost["credits_hold"],
+                "expected_credits": None,
+                "upper_bound_credits": None,
+                "assumptions": {
+                    "ordinary_input_tokens": "included in server estimate",
+                    "cached_input_tokens": "server-defined",
+                    "visible_output_tokens": "included in server estimate",
+                    "reasoning_tokens": {
+                        "included_in_point_estimate": False,
+                        "expected_tokens": None,
+                        "upper_bound_tokens": None,
+                        "models": reasoning_models,
+                    },
+                    "pricing_revision": response_json.get("pricing_revision"),
+                },
+                "warnings": [warning],
+            }
+        )
+    else:
+        cost.update(
+            {
+                "estimate_kind": "point_estimate",
+                "assumptions": {
+                    "reasoning_tokens": {
+                        "included_in_point_estimate": True,
+                        "expected_tokens": 0,
+                        "models": [],
+                    },
+                    "pricing_revision": response_json.get("pricing_revision"),
+                },
+                "warnings": [],
+            }
+        )
+    return cost

--- a/edsl/jobs/cost_estimate_contract.py
+++ b/edsl/jobs/cost_estimate_contract.py
@@ -22,6 +22,17 @@ def _reasoning_model(model: Any) -> dict[str, Any] | None:
     }
 
 
+def _effective_models(job: Any) -> list[Any]:
+    """Return job-level models plus models assigned to individual questions."""
+    models = list(getattr(job, "models", []) or [])
+    survey = getattr(job, "survey", None)
+    for question in getattr(survey, "questions", []) or []:
+        question_model = getattr(question, "_model", None)
+        if question_model is not None:
+            models.append(question_model)
+    return models
+
+
 def apply_cost_estimate_contract(job: Any, response_json: dict) -> dict:
     """Normalize server cost data and expose known reasoning-token uncertainty."""
     cost = {
@@ -49,7 +60,7 @@ def apply_cost_estimate_contract(job: Any, response_json: dict) -> dict:
 
     reasoning_models = [
         details
-        for model in getattr(job, "models", [])
+        for model in _effective_models(job)
         if (details := _reasoning_model(model)) is not None
     ]
     cost["is_exact"] = False

--- a/tests/jobs/test_cost_estimate_contract.py
+++ b/tests/jobs/test_cost_estimate_contract.py
@@ -54,6 +54,31 @@ def test_non_reasoning_model_remains_point_estimate():
     assert result["warnings"] == []
 
 
+def test_question_level_reasoning_model_is_labeled_lower_bound():
+    job = _job("gpt-4o")
+    job.survey = SimpleNamespace(
+        questions=[
+            SimpleNamespace(
+                _model=SimpleNamespace(
+                    model="gpt-5-mini",
+                    _inference_service_="openai",
+                    parameters={},
+                )
+            )
+        ]
+    )
+
+    result = apply_cost_estimate_contract(
+        job,
+        {"cost_in_usd": 0.5, "cost_in_credits": 50},
+    )
+
+    assert result["estimate_kind"] == "lower_bound"
+    models = result["assumptions"]["reasoning_tokens"]["models"]
+    assert [model["model"] for model in models] == ["gpt-5-mini"]
+    assert result["warnings"]
+
+
 def test_richer_server_range_is_preserved():
     response = {
         "cost_in_usd": 1.0,

--- a/tests/jobs/test_cost_estimate_contract.py
+++ b/tests/jobs/test_cost_estimate_contract.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from edsl.jobs.cost_estimate_contract import apply_cost_estimate_contract
+
+
+def _job(model, service="openai", **parameters):
+    return SimpleNamespace(
+        models=[
+            SimpleNamespace(
+                model=model,
+                _inference_service_=service,
+                parameters=parameters,
+            )
+        ]
+    )
+
+
+def test_default_reasoning_model_cost_is_labeled_lower_bound():
+    result = apply_cost_estimate_contract(
+        _job("gpt-5-nano"),
+        {"cost_in_usd": 0.0019, "cost_in_credits": 0.19},
+    )
+
+    assert result["usd"] == 0.0019
+    assert result["estimate_kind"] == "lower_bound"
+    assert result["is_exact"] is False
+    assert result["lower_bound_usd"] == 0.0019
+    assert result["expected_usd"] is None
+    reasoning = result["assumptions"]["reasoning_tokens"]
+    assert reasoning["included_in_point_estimate"] is False
+    assert reasoning["models"][0]["reasoning_setting_source"] == "model_default"
+    assert result["warnings"]
+
+
+def test_explicit_reasoning_setting_is_machine_readable():
+    result = apply_cost_estimate_contract(
+        _job("custom-model", service="custom", reasoning_effort="high"),
+        {"cost_in_usd": 1.0, "cost_in_credits": 100},
+    )
+
+    model = result["assumptions"]["reasoning_tokens"]["models"][0]
+    assert result["estimate_kind"] == "lower_bound"
+    assert model["reasoning_setting"] == "high"
+    assert model["reasoning_setting_source"] == "explicit"
+
+
+def test_non_reasoning_model_remains_point_estimate():
+    result = apply_cost_estimate_contract(
+        _job("gpt-4o"),
+        {"cost_in_usd": 0.5, "cost_in_credits": 50},
+    )
+
+    assert result["estimate_kind"] == "point_estimate"
+    assert result["warnings"] == []
+
+
+def test_richer_server_range_is_preserved():
+    response = {
+        "cost_in_usd": 1.0,
+        "cost_in_credits": 100,
+        "estimate_kind": "range",
+        "lower_bound_usd": 1.0,
+        "expected_usd": 1.5,
+        "upper_bound_usd": 2.0,
+        "assumptions": {"reasoning_tokens": {"expected_tokens": 500}},
+        "pricing_revision": "2026-08-01",
+        "warnings": [],
+    }
+
+    assert apply_cost_estimate_contract(_job("gpt-5-nano"), response) == {
+        "credits_hold": 100,
+        "usd": 1.0,
+        **{key: value for key, value in response.items() if not key.startswith("cost_in_")},
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2974,6 +2974,38 @@ class TestJobsCli:
         out = json.loads(result.output)
         assert out["data"]["credits_hold"] == 2.34
 
+    def test_jobs_cost_surfaces_reasoning_uncertainty_warning(
+        self, tmp_path, monkeypatch
+    ):
+        from edsl.jobs import Jobs
+        import edsl.coop
+
+        jobs_path = tmp_path / "jobs.ep"
+        Jobs.example().git.save(jobs_path)
+        warning = "Reasoning tokens are not included; this is a lower bound."
+
+        class FakeCoop:
+            def remote_inference_cost(self, obj, iterations=1):
+                return {
+                    "credits_hold": 0.19,
+                    "usd": 0.0019,
+                    "estimate_kind": "lower_bound",
+                    "warnings": [warning],
+                }
+
+        monkeypatch.setattr(edsl.coop, "Coop", FakeCoop)
+
+        result = CliRunner().invoke(
+            cli_module.app, ["jobs", "cost", str(jobs_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["data"]["estimate_kind"] == "lower_bound"
+        assert out["warnings"] == [
+            {"code": "COST_ESTIMATE_UNCERTAIN", "message": warning}
+        ]
+
     def test_jobs_cost_accepts_model_override(self, tmp_path, monkeypatch):
         from edsl.jobs import Jobs
         import edsl.coop


### PR DESCRIPTION
## Summary
- label cost estimates for implicit/default reasoning models such as openai:gpt-5-nano as lower bounds rather than exact totals
- preserve compatible usd and credits_hold fields while adding machine-readable estimate kind, lower/expected/upper fields, assumptions, model reasoning settings, pricing revision, and warnings
- surface reasoning uncertainty prominently in the ep jobs cost JSON envelope
- preserve richer range metadata when the server provides it

This deliberately does not invent an unsupported reasoning-token multiplier: when usage cannot be predicted, expected and upper values are null and the lower-bound status is explicit.

## Verification
- focused cost and CLI tests: 16 passed
- broader Jobs suite: 323 passed; 2 unrelated fixture-collection errors under --noconftest
- Ruff passes on touched code

Closes #2580