### PR TITLE
Support Instruction destinations in survey rules

### DIFF
--- a/edsl/surveys/rules/rule.py
+++ b/edsl/surveys/rules/rule.py
@@ -47,9 +47,13 @@ class QuestionIndex:
         return getattr(obj, self.name)
 
     def __set__(self, obj, value):
-        if not isinstance(value, (int, EndOfSurvey.__class__)):
-            raise SurveyError(f"{self.name} must be an integer or EndOfSurvey")
-        if self.name == "_next_q" and isinstance(value, int):
+        allowed_index_types = (int, float) if self.name == "_next_q" else (int,)
+        if not isinstance(value, (*allowed_index_types, EndOfSurvey.__class__)):
+            raise SurveyError(
+                f"{self.name} must be a question index, instruction pseudo-index, "
+                "or EndOfSurvey"
+            )
+        if self.name == "_next_q" and isinstance(value, (int, float)):
             current_q = getattr(obj, "_current_q")
             if value <= current_q:
                 raise SurveyError("next_q must be greater than current_q")
@@ -66,7 +70,7 @@ class Rule:
         self,
         current_q: int,
         expression: str,
-        next_q: Union[int, EndOfSurvey.__class__],
+        next_q: Union[int, float, EndOfSurvey.__class__],
         question_name_to_index: dict[str, int],
         priority: int,
         before_rule: bool = False,

--- a/edsl/surveys/rules/rule_collection.py
+++ b/edsl/surveys/rules/rule_collection.py
@@ -410,7 +410,14 @@ class RuleCollection(UserList):
                 )
             end_q = self.num_questions - 1
 
-        question_range = list(range(start_q + 1, end_q + int(right_inclusive)))
+        if isinstance(end_q, float):
+            # An instruction pseudo-index is positioned between questions. Only
+            # real questions before that instruction participate in the DAG.
+            import math
+
+            question_range = list(range(start_q + 1, math.ceil(end_q)))
+        else:
+            question_range = list(range(start_q + 1, end_q + int(right_inclusive)))
 
         return question_range
 

--- a/edsl/surveys/rules/rule_manager.py
+++ b/edsl/surveys/rules/rule_manager.py
@@ -1,6 +1,7 @@
 from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ...instructions import Instruction
     from ...questions import QuestionBase
     from ..survey import Survey
 
@@ -23,8 +24,8 @@ class RuleManager:
         self.survey = survey
 
     def _get_question_index(
-        self, q: Union["QuestionBase", str, "EndOfSurvey"]
-    ) -> Union[int, "EndOfSurvey"]:
+        self, q: Union["QuestionBase", "Instruction", str, float, "EndOfSurvey"]
+    ) -> Union[int, float, "EndOfSurvey"]:
         """Return the index of the question or EndOfSurvey object.
 
         :param q: The question or question name to get the index of.
@@ -48,12 +49,20 @@ class RuleManager:
         if q == EndOfSurvey:
             return EndOfSurvey
         else:
-            question_name = q if isinstance(q, str) else q.question_name
-            if question_name not in self.survey.question_name_to_index:
-                raise SurveyError(
-                    f"""Question name {question_name} not found in survey. The current question names are {self.survey.question_name_to_index}."""
-                )
-            return self.survey.question_name_to_index[question_name]
+            if isinstance(q, float):
+                return q
+            item_name = (
+                q
+                if isinstance(q, str)
+                else getattr(q, "question_name", None) or getattr(q, "name", None)
+            )
+            if item_name in self.survey.question_name_to_index:
+                return self.survey.question_name_to_index[item_name]
+            if item_name in self.survey._instruction_names_to_instructions:
+                return self.survey._pseudo_indices[item_name]
+            raise SurveyError(
+                f"""Question or instruction name {item_name} not found in survey. The current question names are {self.survey.question_name_to_index}."""
+            )
 
     def _get_new_rule_priority(
         self, question_index: int, before_rule: bool = False
@@ -90,7 +99,7 @@ class RuleManager:
         self,
         question: Union["QuestionBase", str],
         expression: str,
-        next_question: Union["QuestionBase", str, int],
+        next_question: Union["QuestionBase", "Instruction", str, int, float],
         before_rule: bool = False,
     ) -> "Survey":
         """
@@ -108,7 +117,7 @@ class RuleManager:
         question_index = self.survey._get_question_index(question)  # Fix
 
         # Might not have the name of the next question yet
-        if isinstance(next_question, int):
+        if isinstance(next_question, (int, float)):
             next_question_index = next_question
         else:
             next_question_index = self._get_question_index(next_question)

--- a/edsl/surveys/survey.py
+++ b/edsl/surveys/survey.py
@@ -728,7 +728,7 @@ class Survey(Base):
 
     def _get_question_index(
         self, q: Union["QuestionBase", str, EndOfSurveyParent]
-    ) -> Union[int, EndOfSurveyParent]:
+    ) -> Union[int, float, EndOfSurveyParent]:
         """Return the index of the question or EndOfSurvey object.
 
         :param q: The question or question name to get the index of.
@@ -751,12 +751,16 @@ class Survey(Base):
             elif isinstance(q, EndOfSurveyParent):
                 return EndOfSurvey
             else:
-                question_name = q.question_name
-            if question_name not in self.question_name_to_index:
-                raise SurveyError(
-                    f"""Question name {question_name} not found in survey. The current question names are {self.question_name_to_index}."""
+                question_name = getattr(q, "question_name", None) or getattr(
+                    q, "name", None
                 )
-            return self.question_name_to_index[question_name]
+            if question_name in self.question_name_to_index:
+                return self.question_name_to_index[question_name]
+            if question_name in self._instruction_names_to_instructions:
+                return self._pseudo_indices[question_name]
+            raise SurveyError(
+                f"""Question or instruction name {question_name} not found in survey. The current question names are {self.question_name_to_index}."""
+            )
 
     def _get_question_by_name(self, question_name: str) -> QuestionBase:
         """Return the question object given the question name.
@@ -2480,7 +2484,9 @@ class Survey(Base):
         self,
         question: Union["QuestionBase", str],
         expression: str,
-        next_question: Union["QuestionBase", str, int, EndOfSurveyParent],
+        next_question: Union[
+            "QuestionBase", "Instruction", str, int, float, EndOfSurveyParent
+        ],
         before_rule: bool = False,
     ) -> Survey:
         """Add a conditional rule for navigating between questions in the survey.
@@ -2498,9 +2504,9 @@ class Survey(Base):
             expression: A string expression that will be evaluated to determine if the
                 rule should trigger. Can reference previous questions' answers using
                 the template syntax, e.g., "{{ q0.answer }} == 'yes'".
-            next_question: The destination question to jump to if the expression is True.
-                Can be specified as a QuestionBase object, a question_name string, an index,
-                or the EndOfSurvey class to end the survey.
+            next_question: The destination question or instruction to jump to if the
+                expression is True. Can be specified as an object, a name, an index or
+                instruction pseudo-index, or the EndOfSurvey class to end the survey.
             before_rule: If True, the rule is evaluated before the question is presented.
                 If False (default), the rule is evaluated after the question is answered.
 

--- a/edsl/surveys/survey_navigator.py
+++ b/edsl/surveys/survey_navigator.py
@@ -56,7 +56,7 @@ class SurveyNavigator:
         self,
         current_question: Optional[Union[str, "QuestionBase"]] = None,
         answers: Optional[Dict[str, Any]] = None,
-    ) -> Union["QuestionBase", EndOfSurveyParent]:
+    ) -> Union["QuestionBase", "Instruction", EndOfSurveyParent]:
         """
         Return the next question in a survey.
 
@@ -96,6 +96,14 @@ class SurveyNavigator:
         if next_question_object.next_q == EndOfSurvey:
             return EndOfSurvey
         else:
+            if isinstance(next_question_object.next_q, float):
+                for name, index in self.survey._pseudo_indices.items():
+                    if index == next_question_object.next_q:
+                        return self.survey._instruction_names_to_instructions[name]
+                raise SurveyError(
+                    f"Instruction pseudo-index {next_question_object.next_q} "
+                    "not found in survey."
+                )
             if next_question_object.next_q >= len(self.survey.questions):
                 return EndOfSurvey
             else:
@@ -115,6 +123,16 @@ class SurveyNavigator:
                             )
                             if skip_result.next_q == EndOfSurvey:
                                 return EndOfSurvey
+                            elif isinstance(skip_result.next_q, float):
+                                for name, index in self.survey._pseudo_indices.items():
+                                    if index == skip_result.next_q:
+                                        return self.survey._instruction_names_to_instructions[
+                                            name
+                                        ]
+                                raise SurveyError(
+                                    f"Instruction pseudo-index {skip_result.next_q} "
+                                    "not found in survey."
+                                )
                             elif skip_result.next_q >= len(self.survey.questions):
                                 return EndOfSurvey
                             else:
@@ -534,6 +552,18 @@ class SurveyNavigator:
         except ValueError:
             raise SurveyError("Current item not found in survey sequence.")
 
+        def instruction_at(pseudo_index: float):
+            for name, index in self.survey._pseudo_indices.items():
+                if index == pseudo_index:
+                    return self.survey._instruction_names_to_instructions.get(name)
+            return None
+
+        def next_remaining_instruction():
+            for item in combined_items[current_position + 1 :]:
+                if self._is_instruction(item):
+                    return item
+            return EndOfSurvey
+
         # If this is an instruction, determine what comes next
         if self._is_instruction(current_item):
             # This is an instruction
@@ -564,6 +594,17 @@ class SurveyNavigator:
                         next_question_object.num_rules_found > 0
                         and next_question_object.next_q != EndOfSurvey
                     ):
+                        if isinstance(next_question_object.next_q, float):
+                            target_instruction = instruction_at(
+                                next_question_object.next_q
+                            )
+                            if target_instruction is not None:
+                                target_position = combined_items.index(
+                                    target_instruction
+                                )
+                                if target_position > current_position:
+                                    return target_instruction
+                                return combined_items[current_position + 1]
                         # There's a rule that determined the next question
                         target_question = self.survey.questions[
                             next_question_object.next_q
@@ -605,22 +646,19 @@ class SurveyNavigator:
 
         # Handle end of survey case
         if next_question_object.next_q == EndOfSurvey:
-            # Check if there are any instructions after the current question before ending
-            next_position = current_position + 1
-            if next_position < len(combined_items):
-                next_item = combined_items[next_position]
-                if self._is_instruction(next_item):
-                    return next_item
-            return EndOfSurvey
+            return next_remaining_instruction()
+
+        if isinstance(next_question_object.next_q, float):
+            target_instruction = instruction_at(next_question_object.next_q)
+            if target_instruction is None:
+                raise SurveyError(
+                    f"Instruction pseudo-index {next_question_object.next_q} "
+                    "not found in survey."
+                )
+            return target_instruction
 
         if next_question_object.next_q >= len(self.survey.questions):
-            # Check if there are any instructions after the current question before ending
-            next_position = current_position + 1
-            if next_position < len(combined_items):
-                next_item = combined_items[next_position]
-                if self._is_instruction(next_item):
-                    return next_item
-            return EndOfSurvey
+            return next_remaining_instruction()
 
         # Check if the next question has any "before rules" (skip rules)
         candidate_next_q = next_question_object.next_q
@@ -637,21 +675,17 @@ class SurveyNavigator:
                         candidate_next_q, answer_dict
                     )
                     if skip_result.next_q == EndOfSurvey:
-                        # Check if there are any instructions after the current question before ending
-                        next_position = current_position + 1
-                        if next_position < len(combined_items):
-                            next_item = combined_items[next_position]
-                            if self._is_instruction(next_item):
-                                return next_item
-                        return EndOfSurvey
+                        return next_remaining_instruction()
+                    elif isinstance(skip_result.next_q, float):
+                        target_instruction = instruction_at(skip_result.next_q)
+                        if target_instruction is None:
+                            raise SurveyError(
+                                f"Instruction pseudo-index {skip_result.next_q} "
+                                "not found in survey."
+                            )
+                        return target_instruction
                     elif skip_result.next_q >= len(self.survey.questions):
-                        # Check if there are any instructions after the current question before ending
-                        next_position = current_position + 1
-                        if next_position < len(combined_items):
-                            next_item = combined_items[next_position]
-                            if self._is_instruction(next_item):
-                                return next_item
-                        return EndOfSurvey
+                        return next_remaining_instruction()
                     else:
                         candidate_next_q = skip_result.next_q
                 except Exception:
@@ -662,13 +696,7 @@ class SurveyNavigator:
                 break
 
         if candidate_next_q >= len(self.survey.questions):
-            # Check if there are any instructions after the current question before ending
-            next_position = current_position + 1
-            if next_position < len(combined_items):
-                next_item = combined_items[next_position]
-                if self._is_instruction(next_item):
-                    return next_item
-            return EndOfSurvey
+            return next_remaining_instruction()
 
         # Find the target question in the combined list
         target_question = self.survey.questions[candidate_next_q]

--- a/tests/surveys/test_survey_flow.py
+++ b/tests/surveys/test_survey_flow.py
@@ -369,6 +369,66 @@ class TestSurveyFlow(unittest.TestCase):
         )
         self.assertEqual(next_item_no.question_name, "q1")
 
+    def test_rule_can_target_instruction_by_name_or_object(self):
+        end_message = Instruction(text="Early completion", name="end_message")
+        survey = Survey([self.q0, self.q1, end_message])
+        survey.add_rule("q0", "{{ q0.answer }} == 'stop'", "end_message")
+
+        next_item = survey.next_question_with_instructions(
+            "q0", {"q0.answer": "stop"}
+        )
+        self.assertIs(next_item, end_message)
+        self.assertIs(survey.next_question("q0", {"q0.answer": "stop"}), end_message)
+        self.assertIs(
+            survey.next_question_with_instructions(
+                end_message, {"q0.answer": "stop"}
+            ),
+            EndOfSurvey,
+        )
+
+        object_target = Instruction(text="Object target", name="object_target")
+        survey = Survey([self.q0, self.q1, object_target])
+        survey.add_rule("q0", "{{ q0.answer }} == 'stop'", object_target)
+        self.assertIs(
+            survey.next_question_with_instructions(
+                "q0", {"q0.answer": "stop"}
+            ),
+            object_target,
+        )
+
+        pseudo_index = survey._pseudo_indices["object_target"]
+        survey = Survey([self.q0, self.q1, object_target])
+        survey.add_rule("q0", "{{ q0.answer }} == 'stop'", pseudo_index)
+        self.assertIs(
+            survey.next_question_with_instructions(
+                "q0", {"q0.answer": "stop"}
+            ),
+            object_target,
+        )
+
+    def test_skip_rule_preserves_trailing_instruction_on_overshoot(self):
+        end_message = Instruction(text="Thanks!", name="end_message")
+        survey = Survey([self.q0, self.q1, end_message])
+        survey.add_skip_rule("q1", "{{ q0.answer }} == 'skip'")
+
+        next_item = survey.next_question_with_instructions(
+            "q0", {"q0.answer": "skip"}
+        )
+
+        self.assertIs(next_item, end_message)
+
+    def test_instruction_rule_destination_round_trips(self):
+        end_message = Instruction(text="Early completion", name="end_message")
+        survey = Survey([self.q0, self.q1, end_message])
+        survey.add_rule("q0", "{{ q0.answer }} == 'stop'", "end_message")
+
+        restored = Survey.from_dict(survey.to_dict())
+
+        next_item = restored.next_question_with_instructions(
+            "q0", {"q0.answer": "stop"}
+        )
+        self.assertEqual(next_item.name, "end_message")
+
     def test_empty_survey(self):
         """Test behavior with an empty survey."""
         survey = Survey([])


### PR DESCRIPTION
## Summary

- allow survey rules to target an `Instruction` by name, object, or serialized pseudo-index
- resolve instruction destinations in both question-only and instruction-aware navigation
- preserve trailing instructions when skip/end navigation overshoots the last question
- make rule DAG construction and survey serialization support instruction pseudo-indices

## Verification

- focused rule/navigation suite: 27 passed
- broader surveys suite: 165 passed, 9 skipped; one unrelated piping test failed because the sandbox could not write the existing runner database
- Ruff passed on all changed files (ignoring the pre-existing `Dataset` F821 in `survey.py`)
- `git diff --check`

Closes #2551