### PR TITLE
Allow WithOther answers in mixed piped option lists

### DIFF
--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -607,6 +607,11 @@ class ExecutionWorker:
             if isinstance(value, str) and "{{" in value:
                 has_templates = True
                 break
+            if isinstance(value, list) and any(
+                isinstance(item, str) and "{{" in item for item in value
+            ):
+                has_templates = True
+                break
             if (
                 isinstance(value, dict)
                 and key == "question_options"

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -2089,7 +2089,9 @@ class JobService:
                     )
                     # Apply per-interview randomized permutation if present
                     if option_permutations and q_name in option_permutations:
-                        q_options = option_permutations[q_name]
+                        q_options = self._resolve_question_options(
+                            option_permutations[q_name], answer_dict, scenario
+                        )
                     question_to_attributes[q_name] = {
                         "question_text": q_data.get("question_text", ""),
                         "question_type": q_data.get("question_type", ""),

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -2496,8 +2496,9 @@ class JobService:
 
         Handles:
         - String templates: "{{ q1.answer }}"
+        - Lists containing templates: ["Fixed", "{{ q1.answer }}"]
         - Dict format: {"from": "{{ q1.answer }}", "add": ["Other"]}
-        - Non-template values (lists, None): returned as-is
+        - Non-template values: returned as-is
         """
 
         # Dict format: {"from": "{{ q1.answer }}", "add": ["Option X"]}
@@ -2516,7 +2517,16 @@ class JobService:
         if isinstance(options, str) and "{{" in options:
             return JobService._resolve_template_string(options, answer_dict, scenario)
 
-        # Non-template (list, None, etc.) — return as-is
+        # Mixed static/dynamic list: render each templated option independently.
+        if isinstance(options, list):
+            return [
+                JobService._resolve_template_string(option, answer_dict, scenario)
+                if isinstance(option, str) and "{{" in option
+                else option
+                for option in options
+            ]
+
+        # Non-template (None, scalar, etc.) — return as-is
         return options
 
     @staticmethod

--- a/tests/runner/test_dynamic_option_resolution.py
+++ b/tests/runner/test_dynamic_option_resolution.py
@@ -13,3 +13,15 @@ def test_resolves_prior_answer_inside_mixed_option_list():
     )
 
     assert resolved == ["cherry", "blackberry", "Other: mango"]
+
+
+def test_resolves_prior_answer_inside_randomized_option_permutation():
+    permutation = ["{{ favorite.answer }}", "blackberry", "cherry"]
+
+    resolved = JobService._resolve_question_options(
+        permutation,
+        {"favorite": "Other: mango"},
+        scenario=None,
+    )
+
+    assert resolved == ["Other: mango", "blackberry", "cherry"]

--- a/tests/runner/test_dynamic_option_resolution.py
+++ b/tests/runner/test_dynamic_option_resolution.py
@@ -1,0 +1,15 @@
+"""Regression tests for dynamic question options in the current runner."""
+
+from edsl.runner.service import JobService
+
+
+def test_resolves_prior_answer_inside_mixed_option_list():
+    options = ["cherry", "blackberry", "{{ favorite.answer }}"]
+
+    resolved = JobService._resolve_question_options(
+        options,
+        {"favorite": "Other: mango"},
+        scenario=None,
+    )
+
+    assert resolved == ["cherry", "blackberry", "Other: mango"]

--- a/tests/surveys/test_piping.py
+++ b/tests/surveys/test_piping.py
@@ -1,5 +1,9 @@
 import pytest
-from edsl.questions import QuestionList, QuestionMultipleChoice
+from edsl.questions import (
+    QuestionList,
+    QuestionMultipleChoice,
+    QuestionMultipleChoiceWithOther,
+)
 from edsl.surveys import Survey
 from edsl.agents import Agent, AgentList
 from edsl.language_models import LanguageModel
@@ -105,6 +109,32 @@ def test_comment_piping():
         results.select("prompt.why_bird_user_prompt").first().text
         == "Why do you like Parrots - you also said I think they are cool?"
     )
+
+
+def test_multiple_choice_with_other_answer_pipes_as_custom_option():
+    from edsl import Model
+
+    favorite = QuestionMultipleChoiceWithOther(
+        question_name="favorite",
+        question_text="Which fruit do you like best?",
+        question_options=["apple", "blueberry", "cranberry"],
+    )
+    least_favorite = QuestionMultipleChoice(
+        question_name="least_favorite",
+        question_text="Which fruit do you like least?",
+        question_options=["cherry", "blackberry", "{{ favorite.answer }}"],
+    )
+
+    results = (
+        Survey([favorite, least_favorite])
+        .by(Model("test", canned_response="Other: mango"))
+        .run(disable_remote_inference=True, cache=False)
+    )
+
+    assert results.select(
+        "question_options.least_favorite_question_options"
+    ).first() == ["cherry", "blackberry", "Other: mango"]
+    assert results.select("answer.least_favorite").first() == "Other: mango"
 
 
 def test_option_piping_across_agents():


### PR DESCRIPTION
## Summary
- resolve Jinja expressions inside mixed static/dynamic question-option lists in the current runner
- apply the same resolution before answer validation and when assembling Results metadata
- preserve the complete recorded WithOther answer (for example, `Other: mango`) as the downstream option
- add unit and end-to-end coverage for the reported survey shape

## Verification
- `pytest --noconftest -q -p no:cacheprovider tests/surveys/test_piping.py tests/surveys/test_piping_with_additional_options.py tests/runner/test_dynamic_option_resolution.py tests/runner/test_stored_answer_routing.py tests/runner/test_with_other_repair_contract.py` (24 passed)
- Ruff checks pass for changed files (with existing E402/F841 exclusions)
- `git diff --check`

Closes #2554