### PR TITLE
Fix remote inference docs frontmatter

### DIFF
--- a/docs/en/latest/remote_inference.mdx
+++ b/docs/en/latest/remote_inference.mdx
@@ -1,14 +1,4 @@
 ---
-
-## Partial remote results
-
-`ep run` fails closed when a remote job reports `failed` or `partial_failed`; it does not save incomplete Results through the normal success path. If a partially failed job contains useful successful interviews and you intentionally want them, opt in explicitly:
-
-```bash
-ep run --jobs jobs.ep --allow-partial --output partial-results.ep
-```
-
-The command reports authoritative successful and failed interview counts. A partial job with zero successful interviews is always an error. Use the reported `ep jobs errors ...` command to retrieve its exception report.
 title: "Remote Inference"
 description: "Remote inference allows you to run surveys at the Expected Parrot server instead of locally on your own machine, and to use [Remote Caching](/en/latest/remote_caching) to store survey results and logs at your account."
 ---
@@ -22,6 +12,16 @@ description: "Remote inference allows you to run surveys at the Expected Parrot 
 When remote inference is activated, calling the run() method on a survey will send it to the Expected Parrot server. Survey results and job details (history, costs, etc.) are automatically stored at the server and accessible from your workspace or at the [Jobs](https://www.expectedparrot.com/home/remote-inference) page of your account.
 
 By default, a remote cache is used to retrieve responses to any questions that have already been run. You can choose whether to use it or generate fresh responses to questions. See the [Remote Caching](/en/latest/remote_caching) section for more details.
+
+## Partial remote results
+
+`ep run` fails closed when a remote job reports `failed` or `partial_failed`; it does not save incomplete Results through the normal success path. If a partially failed job contains useful successful interviews and you intentionally want them, opt in explicitly:
+
+```bash
+ep run --jobs jobs.ep --allow-partial --output partial-results.ep
+```
+
+The command reports authoritative successful and failed interview counts. A partial job with zero successful interviews is always an error. Use the reported `ep jobs errors ...` command to retrieve its exception report.
 
 ## Activating remote inference
 


### PR DESCRIPTION
## Summary

- restore valid YAML frontmatter in the remote inference guide
- move the partial-results documentation into the MDX body

## Validation

- parsed the repaired frontmatter as YAML
- validated docs/docs.json
- ran git diff --check

This fixes the Mintlify parse failure reported at https://github.com/expectedparrot/edsl/runs/101081223982.