### PR TITLE
Preserve pinned survey options in JSONL round trips

### DIFF
--- a/edsl/surveys/survey_serializer.py
+++ b/edsl/surveys/survey_serializer.py
@@ -16,7 +16,7 @@ class SurveySerializer:
     JSONL format:
       - Line 1: metadata header with ``__header__: true``, class name, count,
         plus ``memory_plan``, ``rule_collection``, ``question_groups``, and
-        optional ``name`` / ``questions_to_randomize``.
+        optional ``name`` / ``questions_to_randomize`` / ``options_to_pin``.
       - Lines 2+: one question/instruction per line
         (``to_dict(add_edsl_version=False)``).
     """
@@ -42,6 +42,8 @@ class SurveySerializer:
             meta["name"] = s.name
         if s.questions_to_randomize:
             meta["questions_to_randomize"] = s.questions_to_randomize
+        if s.options_to_pin:
+            meta["options_to_pin"] = s.options_to_pin
         if add_edsl_version:
             from edsl import __version__
 
@@ -153,6 +155,7 @@ class SurveySerializer:
             rule_collection=rule_collection,
             question_groups=meta.get("question_groups", {}),
             questions_to_randomize=meta.get("questions_to_randomize"),
+            options_to_pin=meta.get("options_to_pin"),
             name=meta.get("name"),
         )
 

--- a/tests/surveys/test_survey_jsonl.py
+++ b/tests/surveys/test_survey_jsonl.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+
+from edsl import QuestionMultipleChoice, Survey
+
+
+@pytest.mark.parametrize("source_kind", ["text", "file", "rows"])
+def test_jsonl_preserves_pinned_options_and_draw_behavior(source_kind, tmp_path):
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options=["A", "Fixed", "B", "Other"],
+    )
+    survey = Survey(
+        [question],
+        questions_to_randomize=["pick"],
+        options_to_pin={"pick": ["Fixed", "Other"]},
+    )
+    if source_kind == "file":
+        source = tmp_path / "survey.jsonl"
+        survey.to_jsonl(source)
+    elif source_kind == "rows":
+        source = survey.to_jsonl_rows()
+    else:
+        source = survey.to_jsonl()
+
+    restored = Survey.from_jsonl(source)
+
+    assert restored.options_to_pin == survey.options_to_pin
+    assert restored.questions_to_randomize == ["pick"]
+    for _ in range(5):
+        options = restored.draw().questions[0].question_options
+        assert options[1] == "Fixed"
+        assert options[3] == "Other"
+        assert {options[0], options[2]} == {"A", "B"}
+    assert survey.questions[0].question_options == ["A", "Fixed", "B", "Other"]
+
+
+def test_jsonl_without_pins_retains_legacy_defaults():
+    question = QuestionMultipleChoice.example()
+    survey = Survey([question], questions_to_randomize=[question.question_name])
+    text = survey.to_jsonl()
+
+    assert "options_to_pin" not in json.loads(text.splitlines()[0])
+    restored = Survey.from_jsonl(text)
+    assert restored.options_to_pin == {}
+    assert restored.questions_to_randomize == survey.questions_to_randomize


### PR DESCRIPTION
Survey JSONL export/import retained `questions_to_randomize` but silently discarded `options_to_pin`, so loading a survey could turn anchored option shuffling into an unrestricted shuffle. Preserve the pin mapping in the metadata header and restore it on import; older JSONL without pins retains the empty default.

Regression tests cover string, file, and row-iterator round trips, pinned positions when drawing the restored survey, and legacy defaults.

Validation: `pytest -q --noconftest tests/surveys/test_survey_jsonl.py tests/surveys/test_survey_git.py tests/surveys/test_Survey.py::TestPinnedOptions` — **27 passed** (one existing unknown-mark warning). `git diff --check` passed.

Addresses the JSONL persistence defect in #2633. The other randomization repairs are separate PRs.