### PR TITLE
Honor pinned option orders throughout Runner execution

### DIFF
--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -159,7 +159,7 @@ class DirectAnswerRegistry:
         }
 
     def _question_for_interview(self, entry: DirectAnswerEntry):
-        """Return an isolated question with this interview's resolved row order."""
+        """Return an isolated question with this interview's option and row orders."""
         if not self._job_service or not entry.job_id or not entry.interview_id:
             return entry.question
         question = entry.question.duplicate()
@@ -167,6 +167,18 @@ class DirectAnswerRegistry:
             entry.job_id, entry.interview_id
         )
         question_data = question.to_dict(add_edsl_version=False)
+        interview_def = self._job_service._interviews.get_definition(
+            entry.job_id, entry.interview_id
+        )
+        if interview_def and hasattr(question, "question_options"):
+            options = interview_def.question_option_permutations.get(
+                question.question_name, question_data.get("question_options")
+            )
+            options = self._job_service._resolve_question_options(
+                options, current_answers, entry.scenario
+            )
+            if isinstance(options, list):
+                question.question_options = list(options)
         items = self._job_service._resolve_question_items(
             question_data,
             current_answers,

--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -601,6 +601,20 @@ class ExecutionWorker:
         Handles question_options, min_value, max_value, and any other
         string fields that reference prior answers or scenario variables.
         """
+        # Validate and translate codes against the same order shown in the prompt,
+        # including static options that need no template resolution.
+        interview_def = self._job_service._interviews.get_definition(
+            job_id, interview_id
+        )
+        if interview_def:
+            permutations = interview_def.question_option_permutations
+            question_name = question_data.get("question_name")
+            if question_name in permutations:
+                question_data = {
+                    **question_data,
+                    "question_options": permutations[question_name],
+                }
+
         # Check if any values need resolution
         has_templates = False
         for key, value in question_data.items():
@@ -625,9 +639,6 @@ class ExecutionWorker:
 
         answer_dict = self._get_interview_answers(job_id, interview_id)
         scenario = None
-        interview_def = self._job_service._interviews.get_definition(
-            job_id, interview_id
-        )
         if interview_def:
             scenario = self._job_service._jobs.get_scenario(
                 job_id, interview_def.scenario_id

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -325,7 +325,9 @@ class JobService:
 
                 # Generate randomized question options for this interview
                 question_option_permutations = self._generate_question_permutations(
-                    questions, questions_to_randomize
+                    questions,
+                    questions_to_randomize,
+                    getattr(survey, "options_to_pin", None),
                 )
                 question_item_randomization_seeds = {
                     self._get_question_name(question): random.getrandbits(64)
@@ -2639,7 +2641,10 @@ class JobService:
         return {"_repr": repr(obj), "_type": type(obj).__name__}
 
     def _generate_question_permutations(
-        self, questions: list, questions_to_randomize: list[str]
+        self,
+        questions: list,
+        questions_to_randomize: list[str],
+        options_to_pin: dict[str, list] | None = None,
     ) -> dict[str, list]:
         """
         Generate randomized question option permutations.
@@ -2651,6 +2656,8 @@ class JobService:
             questions: List of question objects from the survey
             questions_to_randomize: List of question names that should have
                                     their options randomized
+            options_to_pin: Option values to retain at their original positions,
+                            keyed by question name.
 
         Returns:
             Dict mapping question_name -> permuted options list
@@ -2675,7 +2682,9 @@ class JobService:
 
             if options and isinstance(options, list) and len(options) > 1:
                 # Generate a random permutation
-                permutations[q_name] = random.sample(options, len(options))
+                permutations[q_name] = self._shuffle_pinned(
+                    options, (options_to_pin or {}).get(q_name, []), random
+                )
 
         return permutations
 

--- a/tests/runner/test_option_randomization.py
+++ b/tests/runner/test_option_randomization.py
@@ -1,0 +1,96 @@
+import random
+
+import pytest
+
+from edsl import Agent, Model, QuestionMultipleChoice, Survey
+
+
+@pytest.mark.parametrize(
+    "pins, expected",
+    [
+        (["Other"], ["Beta", "Fixed", "Alpha", "Other"]),
+        (["Fixed", "Other"], ["Beta", "Fixed", "Alpha", "Other"]),
+        (["Alpha", "Fixed", "Beta", "Other"], ["Alpha", "Fixed", "Beta", "Other"]),
+        ([], ["Other", "Beta", "Fixed", "Alpha"]),
+    ],
+)
+def test_runner_pins_match_prompts_and_translated_answers(monkeypatch, pins, expected):
+    # Force a non-identity permutation without relying on random draws differing.
+    monkeypatch.setattr(
+        random, "sample", lambda population, k: list(reversed(population))
+    )
+    prompts = []
+
+    def first_option(user_prompt, system_prompt, files_list):
+        prompts.append(user_prompt)
+        return "0"
+
+    original = ["Alpha", "Fixed", "Beta", "Other"]
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options=original,
+        use_code=True,
+    )
+    survey = Survey(
+        [question],
+        questions_to_randomize=["pick"],
+        options_to_pin={"pick": pins},
+    )
+    results = survey.by(Model("test", func=first_option)).run(
+        n=2,
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+        stop_on_exception=True,
+    )
+
+    assert results.select("question_options.pick").to_list() == [expected, expected]
+    assert results.select("answer.pick").to_list() == [expected[0], expected[0]]
+    assert len(prompts) == 2
+    for prompt in prompts:
+        positions = [prompt.index(option) for option in expected]
+        assert positions == sorted(positions)
+    assert question.question_options == original
+
+
+def test_direct_answer_receives_the_recorded_permutation(monkeypatch):
+    monkeypatch.setattr(
+        random, "sample", lambda population, k: list(reversed(population))
+    )
+    seen = []
+
+    def answer_question_directly(self, question, scenario):
+        seen.append(list(question.question_options))
+        answer = question.question_options[0]
+        question.question_options.reverse()  # Must not mutate another interview.
+        return answer
+
+    agent = Agent()
+    agent.add_direct_question_answering_method(answer_question_directly)
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options=["Alpha", "Beta", "Other"],
+    )
+    survey = Survey(
+        [question],
+        questions_to_randomize=["pick"],
+        options_to_pin={"pick": ["Other"]},
+    )
+    results = (
+        survey.by(agent)
+        .by(Model("test"))
+        .run(
+            n=2,
+            disable_remote_inference=True,
+            disable_remote_cache=True,
+            cache=False,
+            stop_on_exception=True,
+        )
+    )
+
+    assert seen == [["Beta", "Alpha", "Other"]] * 2
+    assert results.select("question_options.pick").to_list() == seen
+    assert results.select("answer.pick").to_list() == ["Beta", "Beta"]
+    assert question.question_options == ["Alpha", "Beta", "Other"]


### PR DESCRIPTION
The current Runner ignores `Survey.options_to_pin`, allowing anchored choices such as “Other” to move. Pass those settings to the existing pinned-shuffle helper when generating each interview's option order.

Use the stored order for response validation/code translation and direct-answer agents as well. Previously, a model choosing code `0` could receive one first option in its prompt but have its answer translated against the original list; direct-answer agents likewise received the original order. The prompt, recorded options, and interpreted answer now agree.

Regression tests force a deterministic permutation and cover final/multiple/all/no pins, coded LLM answers, direct answers, and isolation from mutations across interviews. All five new cases failed before the fix.

Validation: `pytest -q --noconftest tests/runner tests/surveys/test_Survey.py::TestPinnedOptions tests/questions/test_QuestionMultipleChoice.py tests/questions/test_QuestionMatrix.py` — **66 passed** (one existing unknown-mark warning). `git diff --check` passed. Model execution tests use the local test service; deployed Humanize/remote workers were not tested.

Addresses the Runner anchor defect in #2633 and the behavior requested by #2311. JSONL persistence is separate in #2634; whole-list dynamic option randomization follows separately.