### PR TITLE
Randomize resolved option lists with persisted interview draws

### DIFF
--- a/edsl/runner/direct_answer.py
+++ b/edsl/runner/direct_answer.py
@@ -91,6 +91,7 @@ class DirectAnswerRegistry:
         contract = getattr(entry.question, "probabilistic_response", None)
         if contract is None:
             return result
+        question = self._question_for_interview(entry)
 
         iteration = 0
         if self._job_service and entry.job_id and entry.interview_id:
@@ -100,13 +101,13 @@ class DirectAnswerRegistry:
             if definition is not None:
                 iteration = definition.iteration
 
-        entry.question._probabilistic_seed_context = contract.seed_context(
+        question._probabilistic_seed_context = contract.seed_context(
             agent=entry.agent,
             scenario=entry.scenario,
             question_name=entry.question.question_name,
             iteration=iteration,
         )
-        validated = entry.question._validate_answer(
+        validated = question._validate_answer(
             {
                 "answer": result["answer"],
                 "comment": result.get("comment"),
@@ -171,11 +172,8 @@ class DirectAnswerRegistry:
             entry.job_id, entry.interview_id
         )
         if interview_def and hasattr(question, "question_options"):
-            options = interview_def.question_option_permutations.get(
-                question.question_name, question_data.get("question_options")
-            )
-            options = self._job_service._resolve_question_options(
-                options, current_answers, entry.scenario
+            options = self._job_service._resolve_interview_options(
+                question_data, interview_def, current_answers, entry.scenario
             )
             if isinstance(options, list):
                 question.question_options = list(options)

--- a/edsl/runner/executor.py
+++ b/edsl/runner/executor.py
@@ -647,8 +647,8 @@ class ExecutionWorker:
         resolved_data = question_data.copy()
         for key, value in question_data.items():
             if key == "question_options":
-                resolved = JobService._resolve_question_options(
-                    value, answer_dict, scenario
+                resolved = JobService._resolve_interview_options(
+                    question_data, interview_def, answer_dict, scenario
                 )
                 if resolved != value:
                     resolved_data[key] = resolved

--- a/edsl/runner/models.py
+++ b/edsl/runner/models.py
@@ -11,7 +11,7 @@ Defines the core domain objects:
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TypedDict
 import uuid
 
 
@@ -250,6 +250,13 @@ class JobStatus:
 # =============================================================================
 
 
+class OptionRandomization(TypedDict):
+    """Persisted draw parameters for an option list resolved at interview time."""
+
+    seed: int
+    pin_options: list
+
+
 @dataclass
 class InterviewDefinition:
     """
@@ -272,6 +279,9 @@ class InterviewDefinition:
     # Only populated for questions in survey.questions_to_randomize
     question_option_permutations: dict[str, list] = field(default_factory=dict)
     question_item_randomization_seeds: dict[str, int] = field(default_factory=dict)
+    question_option_randomizations: dict[str, OptionRandomization] = field(
+        default_factory=dict
+    )
 
     def storage_key(self) -> str:
         return f"job:{self.job_id}:interview:{self.interview_id}"
@@ -286,6 +296,7 @@ class InterviewDefinition:
             "iteration": self.iteration,
             "question_option_permutations": self.question_option_permutations,
             "question_item_randomization_seeds": self.question_item_randomization_seeds,
+            "question_option_randomizations": self.question_option_randomizations,
         }
 
     @classmethod
@@ -304,6 +315,9 @@ class InterviewDefinition:
             question_option_permutations=data.get("question_option_permutations", {}),
             question_item_randomization_seeds=data.get(
                 "question_item_randomization_seeds", {}
+            ),
+            question_option_randomizations=data.get(
+                "question_option_randomizations", {}
             ),
         )
 

--- a/edsl/runner/render.py
+++ b/edsl/runner/render.py
@@ -14,6 +14,7 @@ import base64
 from .storage import StorageProtocol
 from .stores import JobStore, InterviewStore, TaskStore, AnswerStore
 from .models import TaskDefinition, TaskStatus, InterviewDefinition
+from .service import JobService
 
 # EDSL imports - relative since this module lives inside edsl package
 from ..scenarios import Scenario
@@ -217,6 +218,13 @@ class RenderService:
         )
         # Get current answers for memory/piping
         current_answers = self._get_current_answers(job_id, interview_id, task_def)
+        if task_def.question_name in interview_def.question_option_randomizations:
+            question_data = {
+                **question_data,
+                "question_options": JobService._resolve_interview_options(
+                    question_data, interview_def, current_answers, scenario_data
+                ),
+            }
         item_randomization_seed = interview_def.question_item_randomization_seeds.get(
             task_def.question_name
         )
@@ -1049,6 +1057,18 @@ class RenderWorker:
                 if interview_def
                 else None
             )
+            current_answers = answers_cache.get(interview_id, {})
+            if (
+                interview_def
+                and task_def.question_name
+                in interview_def.question_option_randomizations
+            ):
+                option_perms = JobService._resolve_interview_options(
+                    questions[task_def.question_id],
+                    interview_def,
+                    current_answers,
+                    scenario,
+                )
             item_seed = (
                 interview_def.question_item_randomization_seeds.get(
                     task_def.question_name
@@ -1056,7 +1076,7 @@ class RenderWorker:
                 if interview_def
                 else None
             )
-            if option_perms or item_seed is not None:
+            if option_perms is not None or item_seed is not None:
                 _perm_key = (
                     task_def.question_id,
                     tuple(str(o) for o in option_perms or []),
@@ -1064,11 +1084,8 @@ class RenderWorker:
                 )
                 if _perm_key not in _permuted_questions:
                     q_data = questions.get(task_def.question_id)
-                    q_data = self._render_service._apply_option_permutation(
-                        q_data,
-                        task_def.question_name,
-                        interview_def.question_option_permutations,
-                    )
+                    if option_perms is not None:
+                        q_data = {**q_data, "question_options": option_perms}
                     _permuted_questions[_perm_key] = QuestionBase.from_dict(q_data)
                 question = _permuted_questions[_perm_key]
 
@@ -1078,9 +1095,6 @@ class RenderWorker:
                         task_def.question_name
                     )
                 )
-
-            # Get current answers from cache
-            current_answers = answers_cache.get(interview_id, {})
 
             # Get or build Survey + MemoryPlan (cached by question + answer keys)
             _t_survey = _time.time()

--- a/edsl/runner/service.py
+++ b/edsl/runner/service.py
@@ -334,6 +334,17 @@ class JobService:
                     for question in questions
                     if self._to_dict(question).get("randomize_items")
                 }
+                # Whole-list templates cannot be permuted until their inputs exist.
+                # Persist the draw now so rendering/retries/validation use one order.
+                question_option_randomizations = {
+                    q_name: {
+                        "seed": random.getrandbits(64),
+                        "pin_options": list(survey.options_to_pin.get(q_name, [])),
+                    }
+                    for q_data in questions_batch.values()
+                    if (q_name := q_data.get("question_name")) in questions_to_randomize
+                    and isinstance(q_data.get("question_options"), (str, dict))
+                }
 
                 # Create tasks for this interview
                 # Pass agent and scenario objects for direct answer detection
@@ -387,6 +398,7 @@ class JobService:
                     iteration=iteration,
                     question_option_permutations=question_option_permutations,
                     question_item_randomization_seeds=question_item_randomization_seeds,
+                    question_option_randomizations=question_option_randomizations,
                 )
                 interview_definitions.append(interview_def)
 
@@ -2068,11 +2080,6 @@ class JobService:
         # Build question_to_attributes from already-fetched questions_data
         # Get per-interview option permutations (for questions_to_randomize)
         _t_qattr = _time.time()
-        option_permutations = (
-            interview_def.question_option_permutations
-            if interview_def and hasattr(interview_def, "question_option_permutations")
-            else {}
-        )
         item_randomization_seeds = (
             interview_def.question_item_randomization_seeds
             if interview_def
@@ -2084,16 +2091,9 @@ class JobService:
                 q_data = questions_data.get(q_id)
                 if q_data:
                     q_name = q_data.get("question_name", q_id)
-                    q_options = q_data.get("question_options")
-                    # Resolve template variables in question_options using prior answers
-                    q_options = self._resolve_question_options(
-                        q_options, answer_dict, scenario
+                    q_options = self._resolve_interview_options(
+                        q_data, interview_def, answer_dict, scenario, strict=False
                     )
-                    # Apply per-interview randomized permutation if present
-                    if option_permutations and q_name in option_permutations:
-                        q_options = self._resolve_question_options(
-                            option_permutations[q_name], answer_dict, scenario
-                        )
                     question_to_attributes[q_name] = {
                         "question_text": q_data.get("question_text", ""),
                         "question_type": q_data.get("question_type", ""),
@@ -2687,6 +2687,47 @@ class JobService:
                 )
 
         return permutations
+
+    @staticmethod
+    def _resolve_interview_options(
+        question_data: dict,
+        interview_def: InterviewDefinition | None,
+        answer_dict: dict,
+        scenario: Any,
+        *,
+        strict: bool = True,
+    ) -> Any:
+        """Resolve options and reproduce the interview's static or deferred draw.
+
+        Results may include skipped/failed questions whose inputs never existed;
+        strict=False preserves their unresolved metadata without attempting a draw.
+        """
+        name = question_data.get("question_name")
+        permutations = (
+            interview_def.question_option_permutations if interview_def else {}
+        )
+        options = JobService._resolve_question_options(
+            permutations.get(name, question_data.get("question_options")),
+            answer_dict,
+            scenario,
+        )
+        draw = (
+            interview_def.question_option_randomizations.get(name)
+            if interview_def
+            else None
+        )
+        if draw is None:
+            return options
+        if not isinstance(options, list):
+            if strict:
+                raise ValueError(
+                    f"Randomized options for question {name!r} must resolve to a list; "
+                    f"got {type(options).__name__}."
+                )
+            return options
+        return JobService._shuffle_pinned(
+            options, draw["pin_options"], random.Random(draw["seed"])
+        )
 
     @staticmethod
     def _resolve_question_items(

--- a/tests/runner/test_dynamic_option_randomization.py
+++ b/tests/runner/test_dynamic_option_randomization.py
@@ -1,0 +1,248 @@
+import json
+import random
+
+import pytest
+
+from edsl import (
+    Agent,
+    Model,
+    QuestionList,
+    QuestionMultipleChoice,
+    Scenario,
+    ScenarioList,
+    Survey,
+)
+from edsl.runner import Runner
+from edsl.runner.models import InterviewDefinition
+from edsl.runner.render import RenderService
+from edsl.runner.service import JobService
+from edsl.questions.probabilistic_response import ProbabilisticResponse
+
+
+@pytest.mark.parametrize("source", ["scenario", "prior_answer", "prior_with_other"])
+def test_dynamic_options_match_prompts_codes_and_results(monkeypatch, source):
+    monkeypatch.setattr(random, "getrandbits", lambda bits: 0)
+    options = ["Alpha", "Beta", "Gamma", "Other"]
+    questions = []
+    if source == "scenario":
+        option_spec = "{{ scenario.options }}"
+    else:
+        questions.append(
+            QuestionList(question_name="pool", question_text="List the options.")
+        )
+        option_spec = "{{ pool.answer }}"
+        if source == "prior_with_other":
+            option_spec = {"from": "{{ pool.answer }}", "add": ["Other"]}
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options=option_spec,
+        use_code=True,
+    )
+    questions.append(question)
+    survey = Survey(
+        questions,
+        questions_to_randomize=["pick"],
+        options_to_pin={"pick": ["Other"]},
+    )
+    prompts = []
+
+    def response(user_prompt, system_prompt, files_list):
+        if "List the options." in user_prompt:
+            return json.dumps(options[:-1] if source == "prior_with_other" else options)
+        prompts.append(user_prompt)
+        return "0"
+
+    job = survey.by(Model("test", func=response))
+    if source == "scenario":
+        job = job.by(ScenarioList.from_list("options", [options]))
+    results = job.run(
+        n=2,
+        disable_remote_inference=True,
+        disable_remote_cache=True,
+        cache=False,
+        stop_on_exception=True,
+    )
+
+    expected = ["Beta", "Gamma", "Alpha", "Other"]
+    assert results.select("question_options.pick").to_list() == [expected] * 2
+    assert results.select("answer.pick").to_list() == ["Beta"] * 2
+    assert len(prompts) == 2
+    for prompt in prompts:
+        positions = [prompt.index(option) for option in expected]
+        assert positions == sorted(positions)
+    assert question.question_options == option_spec
+
+
+@pytest.mark.parametrize("probabilistic", [False, True])
+def test_dynamic_direct_answers_are_isolated_and_recorded(monkeypatch, probabilistic):
+    monkeypatch.setattr(random, "getrandbits", lambda bits: 0)
+    seen = []
+
+    def answer_question_directly(self, question, scenario):
+        seen.append((scenario["respondent"], list(question.question_options)))
+        answer = question.question_options[0]
+        question.question_options.reverse()
+        return {"probabilities": [1, 0, 0, 0]} if probabilistic else answer
+
+    agent = Agent()
+    agent.add_direct_question_answering_method(answer_question_directly)
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options="{{ scenario.options }}",
+        probabilistic_response=(
+            ProbabilisticResponse(resolution="mode") if probabilistic else None
+        ),
+    )
+    scenarios = ScenarioList(
+        [
+            Scenario(
+                {"respondent": "first", "options": ["Alpha", "Beta", "Gamma", "Other"]}
+            ),
+            Scenario(
+                {"respondent": "second", "options": ["One", "Two", "Three", "Other"]}
+            ),
+        ]
+    )
+    results = (
+        Survey(
+            [question],
+            questions_to_randomize=["pick"],
+            options_to_pin={"pick": ["Other"]},
+        )
+        .by(scenarios)
+        .by(agent)
+        .by(Model("test"))
+        .run(
+            disable_remote_inference=True,
+            disable_remote_cache=True,
+            cache=False,
+            stop_on_exception=True,
+        )
+    )
+
+    recorded = dict(
+        results.select("scenario.respondent", "question_options.pick").to_list()
+    )
+    assert (
+        dict(seen)
+        == recorded
+        == {
+            "first": ["Beta", "Gamma", "Alpha", "Other"],
+            "second": ["Two", "Three", "One", "Other"],
+        }
+    )
+    assert scenarios[0]["options"] == ["Alpha", "Beta", "Gamma", "Other"]
+    assert question.question_options == "{{ scenario.options }}"
+    assert dict(results.select("scenario.respondent", "answer.pick").to_list()) == {
+        "first": "Beta",
+        "second": "Two",
+    }
+
+
+def test_stored_draws_survive_reload_and_repeated_rendering(monkeypatch):
+    seeds = iter([0, 1])
+    monkeypatch.setattr(random, "getrandbits", lambda bits: next(seeds))
+    question = QuestionMultipleChoice(
+        question_name="pick",
+        question_text="Pick one.",
+        question_options="{{ scenario.options }}",
+        use_code=True,
+    )
+    survey = Survey(
+        [question],
+        questions_to_randomize=["pick"],
+        options_to_pin={"pick": ["Other"]},
+    )
+    runner = Runner()
+    handle = runner.submit(
+        survey.by(
+            ScenarioList.from_list("options", [["Alpha", "Beta", "Gamma", "Other"]])
+        ).by(Model("test", canned_response="0")),
+        n=2,
+        cache=False,
+    )
+    definitions = runner.service._jobs.get_definition(handle.job_id)
+    renderer = RenderService(runner._storage)
+    expected = [
+        ["Beta", "Gamma", "Alpha", "Other"],
+        ["Alpha", "Gamma", "Beta", "Other"],
+    ]
+    for index, interview_id in enumerate(definitions.interview_ids):
+        original = runner.service._interviews.get_definition(
+            handle.job_id, interview_id
+        )
+        stored = json.loads(json.dumps(original.to_dict()))
+        restored = InterviewDefinition.from_dict(interview_id, handle.job_id, stored)
+        assert restored.question_option_randomizations == {
+            "pick": {"seed": index, "pin_options": ["Other"]}
+        }
+        runner.service._interviews.create(restored)
+        first = renderer.render_task(handle.job_id, interview_id, restored.task_ids[0])
+        random.random()  # Unrelated global RNG usage cannot change the stored draw.
+        second = renderer.render_task(handle.job_id, interview_id, restored.task_ids[0])
+        assert first.user_prompt == second.user_prompt
+        assert first.cache_key == second.cache_key
+        positions = [first.user_prompt.index(option) for option in expected[index]]
+        assert positions == sorted(positions)
+
+    # Batch rendering/execution must agree with the single-task rendering path.
+    results = handle.results(stop_on_exception=True)
+    assert results.select("question_options.pick").to_list() == expected
+    assert results.select("answer.pick").to_list() == ["Beta", "Alpha"]
+
+
+def test_old_interview_definitions_have_no_deferred_draw():
+    definition = InterviewDefinition.from_dict(
+        "interview",
+        "job",
+        {
+            "scenario_id": "scenario",
+            "agent_id": "agent",
+            "model_id": "model",
+            "total_tasks": 0,
+            "task_ids": [],
+        },
+    )
+    assert definition.question_option_randomizations == {}
+    options = ["Alpha", "Beta"]
+    assert (
+        JobService._resolve_interview_options(
+            {"question_name": "pick", "question_options": "{{ scenario.options }}"},
+            definition,
+            {},
+            {"options": options},
+        )
+        == options
+    )
+
+
+def test_unresolved_options_are_not_shuffled_or_replaced_with_placeholders():
+    definition = InterviewDefinition(
+        interview_id="interview",
+        job_id="job",
+        scenario_id="scenario",
+        agent_id="agent",
+        model_id="model",
+        total_tasks=0,
+        task_ids=[],
+        question_option_randomizations={"pick": {"seed": 0, "pin_options": []}},
+    )
+    question_data = {
+        "question_name": "pick",
+        "question_options": "{{ missing.answer }}",
+    }
+    with pytest.raises(ValueError, match="must resolve to a list"):
+        JobService._resolve_interview_options(question_data, definition, {}, {})
+    # A failed/skipped question must not prevent collection of other results.
+    assert (
+        JobService._resolve_interview_options(
+            question_data,
+            definition,
+            {},
+            {},
+            strict=False,
+        )
+        == "{{ missing.answer }}"
+    )


### PR DESCRIPTION
When a randomized question gets its entire option list from a scenario or prior answer, Runner submission sees a template rather than a list and silently skips the shuffle. Persist a per-interview seed and anchors for these deferred lists, then resolve and shuffle them when their inputs are available.

Both rendering paths, response validation/code translation, direct answers, and result assembly now use the same deterministic option resolver. Re-rendering and loading stored interview definitions reproduce the same order without consuming global RNG state. Direct probability responses also resolve against the actual option order. Explicit option lists keep their existing stored permutations.

Unresolved/non-list randomized options produce an actionable error when used for execution. Result assembly still permits unresolved metadata for skipped or failed questions so those inputs do not prevent collecting the other results. Old interview definitions load with no deferred draws. This adds internal execution metadata; it does not introduce a new survey-randomization API or assignment design.

Regression coverage:
- Whole lists from scenarios, prior answers, and prior-answer lists with appended Other.
- Pinned positions, coded model answers, and agreement between prompts and recorded options.
- Direct and probabilistic answers, with separate scenario lists and mutation isolation.
- Distinct persisted seeds (including zero), JSON reload, repeated single-task rendering, stable cache keys, and agreement with batch rendering/execution.
- Legacy interview definitions and unresolved-option errors.

Validation: `pytest -q --noconftest tests/runner tests/surveys/test_Survey.py::TestPinnedOptions tests/questions/test_QuestionMultipleChoice.py tests/questions/test_QuestionMatrix.py tests/questions/test_probabilistic_response.py tests/questions/test_probabilistic_checkbox.py` — **120 passed** (one existing unknown-mark warning). `git diff --check` passed. Tests use local model/direct execution; deployed Humanize/remote workers were not exercised.

**Stacked on #2635** so its Runner anchor and answer-order fixes are reviewed separately. Merge #2635 first, then retarget this PR to `main`. JSONL persistence is independent in #2634. Addresses the dynamic-option defect in #2633; the umbrella issue remains open for the broader design work.