### PR TITLE
Allow questions in the same group to have skip rules based on earlier pages

### DIFF
--- a/edsl/surveys/dag/construct_dag.py
+++ b/edsl/surveys/dag/construct_dag.py
@@ -12,8 +12,20 @@ class ConstructDAG:
         self.question_name_to_index = self.survey.question_name_to_index
 
     def dag(self, textify: bool = False) -> DAG:
+        return self._dag(self.survey.rule_collection.dag, textify)
+
+    def rendering_dag(self, textify: bool = False) -> DAG:
+        """The DAG of what each question needs in order to be rendered.
+
+        Differs from :meth:`dag` only in what a skip rule contributes: the questions
+        its expression names, rather than every question before it. See
+        :attr:`RuleCollection.rendering_dag`. Use this to ask whether questions can be
+        shown together; use :meth:`dag` to ask what order they are reached in.
+        """
+        return self._dag(self.survey.rule_collection.rendering_dag, textify)
+
+    def _dag(self, rule_dag: DAG, textify: bool) -> DAG:
         memory_dag = self.survey.memory_plan.dag
-        rule_dag = self.survey.rule_collection.dag
         piping_dag = self.piping_dag
         if textify:
             memory_dag = DAG(self.textify(memory_dag))

--- a/edsl/surveys/rules/rule_collection.py
+++ b/edsl/surveys/rules/rule_collection.py
@@ -415,6 +415,45 @@ class RuleCollection(UserList):
         return question_range
 
     @property
+    def rendering_dag(self) -> dict:
+        """Find the DAG of what a question needs in order to be *rendered*.
+
+        Same shape as :attr:`dag`, and identical for every rule except a skip rule.
+        `dag` says a skippable question depends on every question before it, which is
+        true of the order it is reached in but not of what deciding to skip it reads.
+        Here a skip rule contributes only the questions its expression names.
+
+        The distinction matters wherever questions are served together rather than one
+        at a time. A page can hold a question skipped on an answer given pages ago; it
+        cannot hold one skipped on an answer given on that same page, because the page
+        is rendered before any of it is answered. Under `dag` the two are the same
+        thing, so the first is refused along with the second.
+
+        Rules that jump keep their `dag` dependency: the questions a jump passes over
+        depend on the answer that triggers it, and that is a real constraint on
+        rendering them together.
+
+        >>> rule_collection = RuleCollection(num_questions=4)
+        >>> qn2i = {'q0': 0, 'q1': 1, 'q2': 2, 'q3': 3}
+        >>> _ = rule_collection.add_rule(Rule(current_q=3, expression="{{ q0.answer }} == 'yes'", next_q=4, priority=1, question_name_to_index=qn2i, before_rule=True))
+        >>> rule_collection.dag              # every earlier question
+        {3: {0, 1, 2}}
+        >>> rule_collection.rendering_dag    # only the one the expression reads
+        {3: {0}}
+        """
+        children_to_parents = defaultdict(set)
+        for rule in self.non_default_rules:
+            if not rule.before_rule:
+                current_q, next_q = rule.current_q, rule.next_q
+                for q in self.keys_between(current_q, next_q):
+                    children_to_parents[q].add(current_q)
+            else:
+                for q in rule.named_questions_by_index:
+                    children_to_parents[rule.current_q].add(q)
+
+        return DAG(dict(sorted(children_to_parents.items())))
+
+    @property
     def dag(self) -> dict:
         """
         Find the DAG of the survey, based on the skip logic.

--- a/edsl/surveys/survey.py
+++ b/edsl/surveys/survey.py
@@ -2157,6 +2157,17 @@ class Survey(Base):
     ) -> None:
         """Validate that questions in a group don't have dependencies on each other.
 
+        A group is served as one page, so every question on it is rendered before any
+        of it is answered. A question may therefore not need anything else in the same
+        group: not its text, through piping or memory, and not its presence, through a
+        rule reading an answer given on that page.
+
+        Uses :meth:`rendering_dag` rather than :meth:`dag`. The two differ only for
+        skip rules, where `dag` reports a dependency on every preceding question
+        because that is the order they are reached in. That would refuse a page holding
+        a question skipped on an answer given pages earlier, which renders perfectly
+        well -- the answer is in hand before the page is built.
+
         Args:
             start_index: Starting index of the group
             end_index: Ending index of the group
@@ -2166,8 +2177,7 @@ class Survey(Base):
             SurveyCreationError: If any question in the group depends on another
                 question in the same group.
         """
-        # Get the complete dependency DAG
-        dag = self.dag()
+        dag = self.rendering_dag()
 
         # Get all question indices in the proposed group
         group_indices = set(range(start_index, end_index + 1))
@@ -3185,6 +3195,33 @@ class Survey(Base):
         from .dag import ConstructDAG
 
         return ConstructDAG(self).dag(textify)
+
+    def rendering_dag(self, textify: bool = False) -> "DAG":
+        """Return the DAG of what each question needs in order to be rendered.
+
+        Differs from :meth:`dag` only in what a skip rule contributes. `dag` treats a
+        skippable question as depending on every question before it, which describes
+        the order it is reached in; here it depends only on the questions its skip
+        expression reads. Ask this when questions are served together -- a page of a
+        grouped survey -- and :meth:`dag` when you mean traversal order.
+
+        Args:
+            textify: If True, use question names as nodes instead of indices.
+
+        Examples:
+            >>> from edsl.questions import QuestionMultipleChoice
+            >>> q0 = QuestionMultipleChoice(question_name="q0", question_text="?", question_options=["y", "n"])
+            >>> q1 = QuestionMultipleChoice(question_name="q1", question_text="?", question_options=["y", "n"])
+            >>> q2 = QuestionMultipleChoice(question_name="q2", question_text="?", question_options=["y", "n"])
+            >>> s = Survey([q0, q1, q2]).add_skip_rule("q2", "{{ q0.answer }} == 'y'")
+            >>> s.dag()[2] == {0, 1}
+            True
+            >>> s.rendering_dag()[2] == {0}
+            True
+        """
+        from .dag import ConstructDAG
+
+        return ConstructDAG(self).rendering_dag(textify)
 
     ###################
     # DUNDER METHODS

--- a/edsl/utilities/ast_utilities.py
+++ b/edsl/utilities/ast_utilities.py
@@ -4,7 +4,25 @@ import ast
 
 
 def extract_variable_names(node):
-    """Extract variable names from an abstract syntax tree (AST) node."""
+    """Extract variable names from an abstract syntax tree (AST) node.
+
+    Every node recurses into its children, so a name is found wherever it appears.
+    The one exception is a call's ``func``, deliberately skipped so that the name
+    being called is not reported as a variable.
+
+    Callers rely on this being exhaustive: a name missed here is a dependency the
+    survey does not know it has.
+
+    >>> import ast
+    >>> extract_variable_names(ast.parse("q0 == 'yes'"))
+    ['q0']
+    >>> extract_variable_names(ast.parse("f(q0) == 5"))
+    ['q0']
+    >>> extract_variable_names(ast.parse("f(a=q0, b=10) == 5"))
+    ['q0']
+    >>> extract_variable_names(ast.parse("f(*q0, **q1) == 5"))
+    ['q0', 'q1']
+    """
     if isinstance(node, ast.Name):
         return [node.id]  # Extract variable name
     elif isinstance(node, ast.BinOp):
@@ -14,9 +32,13 @@ def extract_variable_names(node):
     elif isinstance(node, ast.UnaryOp):
         return extract_variable_names(node.operand)
     elif isinstance(node, ast.Call):
+        # node.func is skipped on purpose; everything passed to the call is not.
+        # Keyword arguments carry their value on `.value`, which also covers **kwargs.
         names = []
         for arg in node.args:
             names.extend(extract_variable_names(arg))
+        for keyword in node.keywords:
+            names.extend(extract_variable_names(keyword.value))
         return names
     else:
         names = []

--- a/tests/surveys/test_group_navigation.py
+++ b/tests/surveys/test_group_navigation.py
@@ -1112,5 +1112,103 @@ class TestNextGroup(unittest.TestCase):
         self.assertTrue(result["is_end"])
 
 
+
+class TestGroupDependencyValidation(unittest.TestCase):
+    """What a group may hold, given that its questions are rendered together.
+
+    A group is one page, built before any of it is answered. So a question may not
+    need anything else on that page -- not its text, and not the decision to show it.
+    It may freely need answers from earlier pages, which is the distinction these
+    tests pin down: a skip rule is judged by what its expression reads, not by where
+    the question sits.
+    """
+
+    @staticmethod
+    def _choice(name):
+        return QuestionMultipleChoice(
+            question_name=name, question_text="?", question_options=["yes", "no"]
+        )
+
+    def test_skip_rule_reading_an_earlier_page_may_share_a_group(self):
+        gate = self._choice("gate")
+        filler = self._choice("filler")
+        branched = self._choice("branched")
+        survey = Survey([gate, filler, branched]).add_skip_rule(
+            "branched", "{{ gate.answer }} == 'yes'"
+        )
+
+        # gate is answered on an earlier page, so the page can be built knowing
+        # whether to include branched -- even though filler precedes it.
+        survey.add_question_group("filler", "branched", "page")
+
+        self.assertEqual(survey.question_groups["page"], (1, 2))
+
+    def test_skip_rule_reading_the_same_group_is_rejected(self):
+        gate = self._choice("gate")
+        branched = self._choice("branched")
+        survey = Survey([gate, branched]).add_skip_rule(
+            "branched", "{{ gate.answer }} == 'yes'"
+        )
+
+        # gate is on the page, so whether to show branched is not knowable when the
+        # page is rendered.
+        with self.assertRaises(SurveyCreationError):
+            survey.add_question_group("gate", "branched", "page")
+
+    def test_two_branched_questions_may_share_a_group(self):
+        """The either/or pattern: one question per answer, both on one page."""
+        gate = self._choice("gate")
+        if_yes = self._choice("if_yes")
+        if_no = self._choice("if_no")
+        survey = Survey([gate, if_yes, if_no])
+        survey = survey.add_skip_rule("if_yes", "{{ gate.answer }} != 'yes'")
+        survey = survey.add_skip_rule("if_no", "{{ gate.answer }} == 'yes'")
+
+        survey.add_question_group("if_yes", "if_no", "page")
+
+        yes_page = survey.next_group(answers={"gate.answer": "yes"})
+        no_page = survey.next_group(answers={"gate.answer": "no"})
+        self.assertEqual(yes_page["question_names"], ["if_yes"])
+        self.assertEqual(no_page["question_names"], ["if_no"])
+
+    def test_piping_within_a_group_is_still_rejected(self):
+        source = self._choice("source")
+        piped = QuestionMultipleChoice(
+            question_name="piped",
+            question_text="You said {{ source.answer }}?",
+            question_options=["yes", "no"],
+        )
+        survey = Survey([source, piped])
+
+        with self.assertRaises(SurveyCreationError):
+            survey.add_question_group("source", "piped", "page")
+
+    def test_rendering_dag_narrows_only_skip_rules(self):
+        gate = self._choice("gate")
+        filler = self._choice("filler")
+        branched = self._choice("branched")
+        survey = Survey([gate, filler, branched]).add_skip_rule(
+            "branched", "{{ gate.answer }} == 'yes'"
+        )
+
+        # dag() reports the order questions are reached in: everything before.
+        self.assertEqual(survey.dag()[2], {0, 1})
+        # rendering_dag() reports what the decision to show it reads.
+        self.assertEqual(survey.rendering_dag()[2], {0})
+
+    def test_rendering_dag_keeps_jump_rule_dependencies(self):
+        """A jump is a real constraint: the questions it passes over depend on it."""
+        gate = self._choice("gate")
+        skipped = self._choice("skipped")
+        target = self._choice("target")
+        survey = Survey([gate, skipped, target]).add_rule(
+            "gate", "{{ gate.answer }} == 'yes'", "target"
+        )
+
+        self.assertEqual(survey.rendering_dag()[1], {0})
+        with self.assertRaises(SurveyCreationError):
+            survey.add_question_group("gate", "target", "page")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/surveys/test_group_navigation.py
+++ b/tests/surveys/test_group_navigation.py
@@ -1155,6 +1155,23 @@ class TestGroupDependencyValidation(unittest.TestCase):
         with self.assertRaises(SurveyCreationError):
             survey.add_question_group("gate", "branched", "page")
 
+    def test_skip_rule_reading_the_same_group_via_keyword_argument(self):
+        """A name in a keyword argument is a dependency like any other.
+
+        The group check is only as complete as the list of questions a skip
+        expression is known to read, so a name the extractor misses is a page that
+        validates and then cannot be rendered.
+        """
+        gate = self._choice("gate")
+        branched = self._choice("branched")
+        survey = Survey([gate, branched]).add_skip_rule(
+            "branched", "min(a={{ gate.answer }}, b=10) == 5"
+        )
+
+        self.assertEqual(survey.rendering_dag()[1], {0})
+        with self.assertRaises(SurveyCreationError):
+            survey.add_question_group("gate", "branched", "page")
+
     def test_two_branched_questions_may_share_a_group(self):
         """The either/or pattern: one question per answer, both on one page."""
         gate = self._choice("gate")


### PR DESCRIPTION
This fixes an issue where multiple questions on the same page could not be skipped based on answers from earlier pages. For example, the following configuration would not build:

Page 1:
Q1

Page 2:
Q2 - skip if Q1 == "yes"
Q3 - skip if Q1 == "no"
Q4 - no skip rules
Q5 - no skip rules