### PR TITLE
Fix GPT-6 reasoning effort forwarding in both OpenAI adapters

### DIFF
--- a/docs/en/latest/language_models.mdx
+++ b/docs/en/latest/language_models.mdx
@@ -46,6 +46,45 @@ Output:
 We recently added support for OpenAI reasoning models. See an example notebook for usage [here](https://www.expectedparrot.com/content/RobinHorton/reasoning-model-example). Use service_name = “openai_v2” when using these models. The Results that are generated with reasoning models include additional fields for reasoning summaries.
 </Note>
 
+## OpenAI reasoning settings
+
+Both `openai` (Chat Completions) and `openai_v2` (Responses) accept
+`reasoning_effort`, including for the GPT-6 family:
+
+```python
+model = Model(
+    "gpt-6-astra",
+    service_name="openai_v2",
+    reasoning_effort="xhigh",
+    max_tokens=64000,
+)
+```
+
+EDSL sends this as `reasoning_effort` for Chat Completions and as
+`reasoning.effort` for Responses. With `openai_v2`, you can also supply a
+`reasoning` dictionary, such as `{"effort": "high", "summary": "auto"}`.
+A non-`None` `reasoning_effort` overrides the dictionary's `effort`; other
+dictionary fields are preserved.
+
+Explicit effort values are forwarded unchanged for provider validation, even
+when EDSL does not recognize the model. Unsupported values produce a provider
+error rather than being silently removed or reduced. Supported effort values
+depend on the model; see [OpenAI's model guidance](https://developers.openai.com/api/docs/guides/latest-model).
+`reasoning` must be a dictionary or `None`.
+
+When effort is omitted or `None`, Chat Completions uses `medium` for recognized
+reasoning models. Responses requests an automatic reasoning summary and leaves
+effort to the provider unless the dictionary specifies it. Ordinary models get
+no reasoning parameters unless explicitly requested.
+
+Explicit `max_tokens` values are preserved, including small limits. The current
+reasoning-model defaults are 5,000 for Chat Completions and 16,000 for Responses;
+ordinary-model defaults are 1,000 and 2,000, respectively.
+
+Remote workers must run the corrected adapter implementation too: serializing a
+model or Jobs object only saves configuration. When verifying an adapter change,
+use a fresh call with cache bypass and inspect the effective provider request.
+
 ## Local and self-hosted models
 
 Use the `openai_compatible` service to connect EDSL to a local or self-hosted server that implements the OpenAI chat-completions API, including llama.cpp, Ollama, LM Studio, vLLM, and SGLang. Connection details can be saved in a portable `ModelList` without storing an API-key value.

--- a/edsl/inference_services/services/open_ai_service.py
+++ b/edsl/inference_services/services/open_ai_service.py
@@ -35,21 +35,17 @@ class OpenAIParameterBuilder:
     def build_params(model: str, messages: list, **model_params) -> dict:
         """Build API parameters, adjusting for specific model types."""
 
-        default_max_tokens = model_params.get("max_tokens", 1000)
         default_temperature = model_params.get("temperature", 0.5)
-        default_reasoning_effort = model_params.get("reasoning_effort", "medium")
         # Substring match so suffixed variants (e.g. gpt-5.6-terra) are still
         # recognized as reasoning models, consistent with the other services.
         is_reasoning_model = any(tag in model for tag in OPENAI_REASONING_MODELS)
-        if is_reasoning_model:
-            # For reasoning models, use much higher completion tokens to allow for reasoning + response
-            max_tokens = max(default_max_tokens, 5000)
-            # If no reasoning effort is provided, use "medium" as the default
-            # Some models (e.g. gpt-5) do not support null values for reasoning_effort
-            reasoning_effort = default_reasoning_effort or "medium"
-        else:
-            max_tokens = default_max_tokens
-            reasoning_effort = None
+        # Defaults must not overwrite explicit limits, including small ones.
+        max_tokens = model_params.get(
+            "max_tokens", 5000 if is_reasoning_model else 1000
+        )
+        reasoning_effort = model_params.get("reasoning_effort")
+        if reasoning_effort is None and is_reasoning_model:
+            reasoning_effort = "medium"
 
         # GPT-5+ and o-series models reject any temperature other than 1, even
         # when the exact model id isn't in OPENAI_REASONING_MODELS (e.g. dated
@@ -76,7 +72,9 @@ class OpenAIParameterBuilder:
             ),
         }
 
-        if is_reasoning_model:
+        # Forward explicit values even for unrecognized models so the provider
+        # can validate support instead of silently discarding the user's choice.
+        if reasoning_effort is not None:
             params["reasoning_effort"] = reasoning_effort
 
         return params
@@ -212,7 +210,11 @@ class OpenAIService(InferenceServiceABC):
 
             _parameters_ = {
                 "temperature": 0.5,
-                "max_tokens": 1000,
+                "max_tokens": (
+                    5000
+                    if any(tag in model_name for tag in OPENAI_REASONING_MODELS)
+                    else 1000
+                ),
                 "top_p": 1,
                 "frequency_penalty": 0,
                 "presence_penalty": 0,

--- a/edsl/inference_services/services/open_ai_service_v2.py
+++ b/edsl/inference_services/services/open_ai_service_v2.py
@@ -321,18 +321,24 @@ class OpenAIServiceV2(InferenceServiceABC):
                     "store": False,
                 }
 
-                # Check if this is a reasoning model (o-series models)
+                # Recognition controls defaults, not whether explicit settings survive.
                 is_reasoning_model = any(
                     tag in self.model for tag in OPENAI_REASONING_MODELS
                 )
 
-                # Only add reasoning parameter for reasoning models
-                if is_reasoning_model:
-                    reasoning_params = {"summary": "auto"}
-                    if isinstance(self.reasoning, dict):
+                if self.reasoning is not None and not isinstance(self.reasoning, dict):
+                    raise ValueError("reasoning must be a dictionary or None")
+                effort = getattr(self, "reasoning_effort", None)
+                if (
+                    is_reasoning_model
+                    or self.reasoning is not None
+                    or effort is not None
+                ):
+                    reasoning_params = {"summary": "auto"} if is_reasoning_model else {}
+                    if self.reasoning is not None:
                         reasoning_params.update(self.reasoning)
-                    # Support reasoning_effort shorthand (e.g. "none", "low", "medium", "high")
-                    effort = getattr(self, "reasoning_effort", None)
+                    # A non-None shorthand overrides reasoning["effort"]. Keep
+                    # explicit values unchanged for provider-side validation.
                     if effort is not None:
                         reasoning_params["effort"] = effort
                     params["reasoning"] = reasoning_params

--- a/edsl/inference_services/services/service_enums.py
+++ b/edsl/inference_services/services/service_enums.py
@@ -13,6 +13,7 @@ OPENAI_REASONING_MODELS = [
     "gpt-5.1",
     "gpt-5.5",
     "gpt-5.6",
+    "gpt-6",
 ]
 
 

--- a/tests/inference_services/test_openai_reasoning.py
+++ b/tests/inference_services/test_openai_reasoning.py
@@ -1,0 +1,207 @@
+"""Verify reasoning settings at the SDK boundary without credentials or network."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from edsl import Jobs, QuestionFreeText
+from edsl.inference_services.services.open_ai_service import (
+    OpenAIParameterBuilder,
+    OpenAIService,
+)
+from edsl.inference_services.services.open_ai_service_v2 import OpenAIServiceV2
+from edsl.language_models import LanguageModel
+
+
+@pytest.fixture(autouse=True)
+def offline(monkeypatch):
+    monkeypatch.setattr(LanguageModel, "_set_key_lookup", lambda *a, **kw: {})
+    monkeypatch.setattr("edsl.coop.Coop.report_error", AsyncMock())
+
+    def unexpected_network(*args, **kwargs):
+        pytest.fail("These adapter tests must not access the network")
+
+    monkeypatch.setattr("socket.socket.connect", unexpected_network)
+
+
+@pytest.fixture(params=[OpenAIService, OpenAIServiceV2], ids=["chat", "responses"])
+def service(request):
+    return request.param
+
+
+def mock_create(monkeypatch, model):
+    create = AsyncMock(return_value=SimpleNamespace(model_dump=lambda: {}))
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+        responses=SimpleNamespace(create=create),
+    )
+    monkeypatch.setattr(type(model), "async_client", lambda self: client)
+    monkeypatch.setattr(type(model), "sync_client", lambda self: client)
+    return create
+
+
+def request_effort(service, params):
+    if service is OpenAIService:
+        assert "reasoning" not in params
+        return params.get("reasoning_effort")
+    assert "reasoning_effort" not in params
+    return params.get("reasoning", {}).get("effort")
+
+
+@pytest.mark.parametrize(
+    "name,effort",
+    [
+        ("gpt-6", "xhigh"),
+        ("gpt-6-astra", "xhigh"),
+        ("gpt-6-astra-2026-09-01", "xhigh"),
+        ("gpt-5", "high"),
+        ("gpt-5.6-terra", "high"),
+        ("o1", "medium"),
+        ("o3-mini-2025-01-31", "high"),
+        ("o4-mini", "low"),
+    ],
+)
+def test_explicit_effort_and_token_limit(monkeypatch, service, name, effort):
+    model = service.create_model(name)(reasoning_effort=effort, max_tokens=64000)
+    create = mock_create(monkeypatch, model)
+    asyncio.run(model.async_execute_model_call("Return ok."))
+    params = create.call_args.kwargs
+    assert request_effort(service, params) == effort
+    token_field = (
+        "max_completion_tokens" if service is OpenAIService else "max_output_tokens"
+    )
+    assert params[token_field] == 64000
+    assert "max_tokens" not in params
+
+
+@pytest.mark.parametrize("round_trip", ["model", "jobs"])
+@pytest.mark.parametrize("limit", [64, 64000])
+def test_serialized_spec_preserves_outgoing_settings(
+    monkeypatch, service, round_trip, limit
+):
+    model = service.create_model("gpt-6-astra")(
+        reasoning_effort="xhigh", max_tokens=limit
+    )
+    if round_trip == "model":
+        restored = LanguageModel.from_dict(json.loads(json.dumps(model.to_dict())))
+    else:
+        jobs = QuestionFreeText(question_name="q", question_text="Return ok.").by(model)
+        restored = Jobs.from_dict(json.loads(json.dumps(jobs.to_dict()))).models[0]
+    assert restored._inference_service_ == service._inference_service_
+    create = mock_create(monkeypatch, restored)
+    asyncio.run(restored.async_execute_model_call("Return ok."))
+    params = create.call_args.kwargs
+    assert request_effort(service, params) == "xhigh"
+    token_field = (
+        "max_completion_tokens" if service is OpenAIService else "max_output_tokens"
+    )
+    assert params[token_field] == limit
+
+
+@pytest.mark.parametrize(
+    "name", ["gpt-6", "gpt-6-astra", "gpt-5", "o3", "gpt-4o", "gpt-7"]
+)
+@pytest.mark.parametrize("options", [{}, {"reasoning_effort": None}])
+def test_unspecified_effort_and_defaults(monkeypatch, service, name, options):
+    model = service.create_model(name)(**options)
+    create = mock_create(monkeypatch, model)
+    asyncio.run(model.async_execute_model_call("Return ok."))
+    params = create.call_args.kwargs
+    known_reasoning = name not in {"gpt-4o", "gpt-7"}
+    if service is OpenAIService:
+        assert request_effort(service, params) == (
+            "medium" if known_reasoning else None
+        )
+        assert params["max_completion_tokens"] == (5000 if known_reasoning else 1000)
+    else:
+        assert request_effort(service, params) is None
+        assert params.get("reasoning") == (
+            {"summary": "auto"} if known_reasoning else None
+        )
+        assert params["max_output_tokens"] == (16000 if known_reasoning else 2000)
+    if not known_reasoning:
+        assert "reasoning_effort" not in params
+        assert "reasoning" not in params
+
+
+@pytest.mark.parametrize("name", ["gpt-6-astra", "gpt-4o"])
+@pytest.mark.parametrize(
+    "options,expected",
+    [
+        (
+            {"reasoning": {"effort": "xhigh", "summary": "detailed"}},
+            {"effort": "xhigh", "summary": "detailed"},
+        ),
+        (
+            {
+                "reasoning": {"effort": "low", "summary": None},
+                "reasoning_effort": "xhigh",
+            },
+            {"effort": "xhigh", "summary": None},
+        ),
+        (
+            {"reasoning": {"effort": "high"}, "reasoning_effort": None},
+            {"effort": "high"},
+        ),
+        ({"reasoning": {}}, {}),
+    ],
+)
+def test_responses_dictionary_precedence_after_serialization(
+    monkeypatch, name, options, expected
+):
+    original_options = json.loads(json.dumps(options))
+    model = OpenAIServiceV2.create_model(name)(**options)
+    restored = LanguageModel.from_dict(json.loads(json.dumps(model.to_dict())))
+    create = mock_create(monkeypatch, restored)
+    asyncio.run(restored.async_execute_model_call("Return ok."))
+    defaults = {"summary": "auto"} if name == "gpt-6-astra" else {}
+    assert create.call_args.kwargs["reasoning"] == {**defaults, **expected}
+    assert model.reasoning == original_options["reasoning"]
+    assert options == original_options
+
+
+@pytest.mark.parametrize(
+    "name,effort", [("gpt-4o", "xhigh"), ("gpt-6-astra", "none"), ("gpt-6-astra", "")]
+)
+def test_unsupported_effort_reaches_provider_and_error_propagates(
+    monkeypatch, service, name, effort
+):
+    import httpx
+    from openai import BadRequestError
+
+    model = service.create_model(name)(reasoning_effort=effort)
+    create = mock_create(monkeypatch, model)
+    error = BadRequestError(
+        "Unsupported reasoning effort for this model",
+        response=httpx.Response(
+            400, request=httpx.Request("POST", "https://example.test")
+        ),
+        body=None,
+    )
+    create.side_effect = error
+    with pytest.raises(BadRequestError) as caught:
+        asyncio.run(model.async_execute_model_call("Return ok."))
+    assert caught.value is error
+    create.assert_awaited_once()
+    assert request_effort(service, create.call_args.kwargs) == effort
+
+
+@pytest.mark.parametrize("reasoning", ["xhigh", [], False])
+def test_invalid_reasoning_dictionary_fails_visibly(monkeypatch, reasoning):
+    model = OpenAIServiceV2.create_model("gpt-6-astra")(reasoning=reasoning)
+    create = mock_create(monkeypatch, model)
+    with pytest.raises(ValueError, match="reasoning must be a dictionary or None"):
+        asyncio.run(model.async_execute_model_call("Return ok."))
+    create.assert_not_awaited()
+
+
+def test_builder_defaults_do_not_raise_explicit_token_limits():
+    assert (
+        OpenAIParameterBuilder.build_params("gpt-6-astra", [])["max_completion_tokens"]
+        == 5000
+    )
+    params = OpenAIParameterBuilder.build_params("gpt-6-astra", [], max_tokens=64)
+    assert params["max_completion_tokens"] == 64


### PR DESCRIPTION
Explicit `reasoning_effort="xhigh"` on `gpt-6-astra` survived serialization but disappeared from both OpenAI adapters' provider requests. This change recognizes GPT-6 in the shared reasoning-model list and forwards explicit effort settings unchanged as `reasoning_effort` for Chat Completions or `reasoning.effort` for Responses.

Explicit settings are also forwarded for unrecognized models so the provider can reject unsupported values instead of EDSL silently discarding or reducing them. Responses preserves the reasoning dictionary, gives a non-None shorthand precedence over its `effort`, and rejects malformed dictionaries. The documentation explains precedence, defaults, and remote verification.

Explicit token limits, including values below 5,000, now remain unchanged. Chat Completions retains its existing effective 5,000-token reasoning default as a model default instead of enforcing a minimum on every request. Responses retains its 16,000-token reasoning default, now including GPT-6. Broader token policy work remains tracked in #2628.

Validation: `python -m pytest -q tests/inference_services` — **123 passed, 1 skipped**, verified against the committed files in a clean temporary checkout. The 66 new offline regression cases cover both SDK entry points, base/suffixed GPT-6 IDs, GPT-5 and o-series behavior, ordinary models, defaults, dictionary precedence, provider errors, and model/Jobs serialization before inspecting outgoing arguments. The skipped test requires a configured live endpoint.

No live provider call or remote-worker deployment was performed. Remote workers must receive the corrected implementation, with a fresh cache-bypassing request and effective-request diagnostics used for deployment verification.

Fixes #2642.
